### PR TITLE
Add a dev-mode debug menu (F3): teleport, heal, give item/pokemon, no…

### DIFF
--- a/docs/modding.md
+++ b/docs/modding.md
@@ -152,3 +152,23 @@ The console understands these verbs (anything else is evaluated as Lua):
 
 Developer mode also arms the mod loader's dev tripwire, which flags mods
 that reach outside their permission set.
+
+## Debug menu
+
+With developer mode active, `F3` opens a menu-driven front end for the
+same cheats the console offers, docked to the left of the screen (press
+`F3` again to close it):
+
+- `NO CLIP` — toggle walking through walls, sprites and ledges (stays
+  on the same tile grid; still bounded by the map's edges). Selecting it
+  does not close the menu, so the label flips between ON/OFF in place.
+- `TELEPORT` — pick any map from a full list and warp there.
+- `HEAL` — fully heal the current party.
+- `ITEM` — pick an item and a quantity to add to the bag.
+- `POKéMON` — pick a species and a level to add to the party (or the PC
+  if the party is full).
+- `OPTIONS` — a nested menu (B backs out to the debug menu, not the
+  overworld) for lower-level toggles:
+  - `NO WILDS` — suppress wild encounters entirely.
+  - `FAST WALK` — halve the player's step time (stacks with the
+    bicycle).

--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -15,8 +15,9 @@ local Screens = require("src.ui.Screens")
 
 local Game = {}
 
--- dev-mode gate for the F5/backtick hotkeys; false keeps every src/dev
--- module unloaded, so a player boot never touches a byte of dev code
+-- dev-mode gate for the F5/backtick/F3 hotkeys; false keeps every src/dev
+-- module (and the debug menu) unloaded, so a player boot never touches a
+-- byte of dev code
 local devMode = os.getenv("POKEPORT_DEV") == "1" or _G.POKEPORT_DEV_MODE == true
 
 -- the boot screen ids (field.boot.screens); a plain function so the
@@ -278,6 +279,19 @@ function Game:keypressed(key)
   end
   if devMode and key == "`" then
     self.stack:push(require("src.dev.Console").new(self))
+    return
+  end
+  if devMode and key == "f3" and self.save then
+    -- toggle, like the F10 manager below: a second press closes it
+    -- instead of stacking another
+    local top = self.stack:top()
+    if top and top.screenId == "DebugMenu" then
+      self.stack:pop()
+    else
+      local menu = require("src.ui.DebugMenu").new(self)
+      menu.screenId = "DebugMenu"
+      self.stack:push(menu)
+    end
     return
   end
   if key == "f10" then

--- a/src/ui/DebugMenu.lua
+++ b/src/ui/DebugMenu.lua
@@ -1,0 +1,213 @@
+-- Dev-mode debug menu: a menu-driven front end for the same cheats the
+-- backtick console offers (src/dev/Console.lua) -- teleport, heal party,
+-- give item, give Pokémon -- for anyone who'd rather not type Lua.
+-- Opened with F3 (see the devMode gate in src/core/Game.lua); styled like
+-- the START menu (src/ui/StartMenu.lua) but docked left instead of right,
+-- so the two never visually collide if a future hotkey opens both.
+-- Never required on a player boot.
+
+local ListMenu = require("src.ui.ListMenu")
+local Menu = require("src.ui.Menu")
+local QuantityBox = require("src.ui.QuantityBox")
+local TextBox = require("src.render.TextBox")
+
+local DebugMenu = {}
+
+local function report(game, text)
+  game.stack:push(TextBox.new(game, text))
+end
+
+-- ------- teleport
+
+local function sortedMapIds(data)
+  local ids = {}
+  for id in pairs(data.maps or {}) do table.insert(ids, id) end
+  table.sort(ids)
+  return ids
+end
+
+local function openTeleport(game)
+  local items = {}
+  for _, mapId in ipairs(sortedMapIds(game.data)) do
+    table.insert(items, { value = mapId, label = mapId:gsub("_", " ") })
+  end
+  game.stack:push(ListMenu.new(game, "TELEPORT TO?", items, {
+    onChoose = function(item)
+      -- same rebuild the console's `warp` verb uses (src/dev/Console.lua):
+      -- pop everything (this list and menu included) and enter fresh
+      while game.stack:top() do game.stack:pop() end
+      game.stack:push(require("src.world.OverworldController"),
+                       item.value, 5, 5, "down")
+    end,
+  }))
+end
+
+-- ------- heal party
+
+local function healParty(game)
+  local Pokemon = require("src.pokemon.Pokemon")
+  local party = game.save.party or {}
+  for _, mon in ipairs(party) do
+    Pokemon.heal(mon)
+  end
+  require("src.core.Sound").play(game.data, "Healing_Machine")
+  report(game, (#party > 0) and "Party healed!" or "(no party)")
+end
+
+-- ------- give item
+
+local function sortedItemIds(data)
+  local ids = {}
+  for id in pairs(data.items or {}) do table.insert(ids, id) end
+  table.sort(ids, function(a, b)
+    local da, db = data.items[a], data.items[b]
+    return (da and da.name or a) < (db and db.name or b)
+  end)
+  return ids
+end
+
+local function openGiveItem(game)
+  local items = {}
+  for _, id in ipairs(sortedItemIds(game.data)) do
+    local def = game.data.items[id]
+    table.insert(items, { value = id, label = def and def.name or id })
+  end
+  game.stack:push(ListMenu.new(game, "GIVE ITEM", items, {
+    onChoose = function(item, list)
+      local id = item.value
+      local def = game.data.items[id]
+      local name = def and def.name or id
+      list:close()
+      game.stack:push(QuantityBox.new(game, {
+        max = 99, start = 1,
+        onDone = function(qty)
+          if not qty then return end
+          local Bag = require("src.inventory.Bag")
+          if Bag.add(game.save, id, qty) then
+            report(game, ("%s x%d added"):format(name, qty))
+          else
+            report(game, "Bag is full!")
+          end
+        end,
+      }))
+    end,
+  }))
+end
+
+-- ------- give pokemon
+
+local function dexOrderedSpecies(data)
+  local byDex = {}
+  for species, def in pairs(data.pokemon or {}) do
+    if def.dex then byDex[def.dex] = species end
+  end
+  local ids = {}
+  local size = (data.constants and data.constants.dexSize) or 151
+  for n = 1, size do
+    if byDex[n] then table.insert(ids, byDex[n]) end
+  end
+  return ids
+end
+
+local function openGivePokemon(game)
+  local items = {}
+  for _, id in ipairs(dexOrderedSpecies(game.data)) do
+    local def = game.data.pokemon[id]
+    table.insert(items, { value = id, label = def.name or id })
+  end
+  game.stack:push(ListMenu.new(game, "GIVE POKéMON", items, {
+    onChoose = function(item, list)
+      local id = item.value
+      local def = game.data.pokemon[id]
+      local name = def and def.name or id
+      list:close()
+      game.stack:push(QuantityBox.new(game, {
+        max = 100, start = 5,
+        onDone = function(level)
+          if not level then return end
+          local Pokemon = require("src.pokemon.Pokemon")
+          local mon = Pokemon.new(game.data, id, level)
+          if require("src.pokemon.Party").add(game.save.party, mon) then
+            report(game, ("%s L%d joined the party"):format(name, level))
+          elseif require("src.pokemon.Boxes").deposit(game.save, mon) then
+            report(game, ("%s L%d sent to the PC"):format(name, level))
+          else
+            report(game, "Party and PC are full!")
+          end
+        end,
+      }))
+    end,
+  }))
+end
+
+-- ------- no clip
+
+-- Game.noclip (checked in src/world/Player.lua's tryMove) is a plain
+-- field on the Game singleton, not save data -- it resets every process
+-- launch and, unlike a flag on the Player instance (which TELEPORT above
+-- recreates from scratch), survives a teleport.
+local function noclipLabel(game)
+  return "NO CLIP " .. (game.noclip and "ON" or "OFF")
+end
+
+-- ------- options (nested: lower-level toggles, tucked away so the
+-- top-level menu stays short)
+
+local function openOptions(game)
+  local wildsItem = { keepOpen = true }
+  local function wildsLabel() return "NO WILDS " .. (game.noWilds and "ON" or "OFF") end
+  wildsItem.onSelect = function()
+    -- consumed in OverworldController's onStepComplete
+    game.noWilds = not game.noWilds
+    wildsItem.label = wildsLabel()
+  end
+  wildsItem.label = wildsLabel()
+
+  local fastItem = { keepOpen = true }
+  local function fastLabel() return "FAST WALK " .. (game.fastWalk and "ON" or "OFF") end
+  fastItem.onSelect = function()
+    -- consumed in Player:tryMove
+    game.fastWalk = not game.fastWalk
+    fastItem.label = fastLabel()
+  end
+  fastItem.label = fastLabel()
+
+  game.stack:push(Menu.new(game, { wildsItem, fastItem }, {
+    tx = 0, ty = 0, tw = 16, -- fits "FAST WALK OFF" (13 chars)
+    onCancel = function()
+      -- B backs out to the parent menu, not the overworld -- this really
+      -- is a nested menu, not a dead-end screen
+      local menu = DebugMenu.new(game)
+      menu.screenId = "DebugMenu"
+      game.stack:push(menu)
+    end,
+  }))
+end
+
+-- ------- top-level menu
+
+function DebugMenu.new(game)
+  local noclipItem = { keepOpen = true }
+  noclipItem.onSelect = function()
+    game.noclip = not game.noclip
+    noclipItem.label = noclipLabel(game)
+  end
+  noclipItem.label = noclipLabel(game)
+  -- the rest are kept to 8 chars or fewer so they fit the same tw=11 box
+  -- StartMenu uses (POKéMON here mirrors StartMenu's own entry of
+  -- that name); NO CLIP needs the wider box below instead
+  local items = {
+    noclipItem,
+    { label = "TELEPORT", onSelect = function() openTeleport(game) end },
+    { label = "HEAL", onSelect = function() healParty(game) end },
+    { label = "ITEM", onSelect = function() openGiveItem(game) end },
+    { label = "POKéMON", onSelect = function() openGivePokemon(game) end },
+    { label = "OPTIONS", onSelect = function() openOptions(game) end },
+  }
+  -- StartMenu docks tx=9..19 (right, tw=11); this mirrors it at
+  -- tx=0..13 (left, widened to tw=14 so "NO CLIP OFF" fits) so the two
+  -- boxes can never visually overlap.
+  return Menu.new(game, items, { tx = 0, ty = 0, tw = 14 })
+end
+
+return DebugMenu

--- a/src/world/OverworldController.lua
+++ b/src/world/OverworldController.lua
@@ -2775,14 +2775,18 @@ function OverworldState:onStepComplete()
   -- (wild_encounters.asm: caves, towers, the Mansion, Power Plant)
   local encDef = Game.data.encounters[self.map.id]
   local enc
-  local indoor = Game.data.field.indoorEncounters
-  if p.surfing and encDef and encDef.water and self.map:isWaterCell(p.cellX, p.cellY) then
-    enc = self:rollEncounter({ grass = encDef.water }, "water")
-  elseif self.map:isGrassCell(p.cellX, p.cellY) then
-    enc = self:rollEncounter(encDef, "grass")
-  elseif indoor and self.map.def.index >= indoor.firstIndoorMap
-         and self.map.def.tileset ~= indoor.excludedTileset then
-    enc = self:rollEncounter(encDef, "indoor")
+  -- Game.noWilds: the debug menu's OPTIONS > NO WILDS toggle
+  -- (src/ui/DebugMenu.lua)
+  if not Game.noWilds then
+    local indoor = Game.data.field.indoorEncounters
+    if p.surfing and encDef and encDef.water and self.map:isWaterCell(p.cellX, p.cellY) then
+      enc = self:rollEncounter({ grass = encDef.water }, "water")
+    elseif self.map:isGrassCell(p.cellX, p.cellY) then
+      enc = self:rollEncounter(encDef, "grass")
+    elseif indoor and self.map.def.index >= indoor.firstIndoorMap
+           and self.map.def.tileset ~= indoor.excludedTileset then
+      enc = self:rollEncounter(encDef, "indoor")
+    end
   end
   if enc then
     -- REPEL blocks wild mons weaker than the lead

--- a/src/world/Player.lua
+++ b/src/world/Player.lua
@@ -64,18 +64,32 @@ function Player:tryMove(dir, map, entities)
     return "turned"
   end
   if self.turnTimer > 0 then return nil end
-  local ok, why = Collision.canMove(map, entities, self, dir)
+  local Game = require("src.core.Game")
+  local tx, ty = Collision.target(self.cellX, self.cellY, dir)
+  local ok, why
+  if Game.noclip then
+    -- debug menu toggle (src/ui/DebugMenu.lua): walk through tiles,
+    -- sprites and ledges, still bounded by the map's own tile grid
+    ok = map:inBounds(tx, ty)
+    why = ok and nil or "bounds"
+  else
+    ok, why = Collision.canMove(map, entities, self, dir)
+  end
   if not ok then
     return "blocked", why
   end
-  local tx, ty = Collision.target(self.cellX, self.cellY, dir)
   self.targetX, self.targetY = tx, ty
   self.moving = true
   self.progress = 0
   -- the bicycle doubles walking speed (8 frames per step)
-  local save = require("src.core.Game").save
-  self.stepFramesCur = (save and save.onBike) and self.bikeStepFrames
-                       or self.stepFrames or STEP_FRAMES
+  local stepFrames = (Game.save and Game.save.onBike) and self.bikeStepFrames
+                     or self.stepFrames or STEP_FRAMES
+  -- debug menu's OPTIONS > FAST WALK toggle (src/ui/DebugMenu.lua): halves
+  -- it again on top of biking, same doubling the bike itself applies
+  if Game.fastWalk then
+    stepFrames = math.max(1, math.floor(stepFrames / 2))
+  end
+  self.stepFramesCur = stepFrames
   return "moved"
 end
 

--- a/tests/drivers/debug_menu_test.lua
+++ b/tests/drivers/debug_menu_test.lua
@@ -1,0 +1,172 @@
+-- Driver: the F3 debug menu (src/ui/DebugMenu.lua) -- opens via the real
+-- devMode hotkey (Game:keypressed), then exercises NO CLIP, OPTIONS
+-- (NO WILDS / FAST WALK), HEAL, ITEM, GIVE POKEMON and TELEPORT end to
+-- end. Run with POKEPORT_DEV=1 set alongside POKEPORT_DRIVER (devMode
+-- gates the hotkey, same as the console).
+return function(game)
+  local U = dofile("tests/drivers/util.lua")
+  local DIR = os.getenv("SHOT_DIR") or "/tmp/shots"
+  local Pokemon = require("src.pokemon.Pokemon")
+  local ListMenu = require("src.ui.ListMenu")
+  local Menu = require("src.ui.Menu")
+
+  U.teleport(game, "PALLET_TOWN", 5, 5, "down")
+
+  local mon = Pokemon.new(game.data, "CHARMANDER", 12)
+  mon.hp = 1
+  table.insert(game.save.party, mon)
+
+  local function topIs(cls) return getmetatable(game.stack:top()) == cls end
+
+  local function openMenu()
+    game:keypressed("f3")
+    U.wait(2)
+  end
+
+  -- jump a ListMenu's cursor straight to a known value instead of mashing
+  -- "down" through a 100+ row list (fossil_menu_test.lua sets NPC state
+  -- directly the same way -- these drivers own the live objects, not just
+  -- simulated input)
+  local function selectValue(list, value)
+    for i, item in ipairs(list.items) do
+      if item.value == value then
+        list.index = i
+        return true
+      end
+    end
+    return false
+  end
+
+  -- item order: NO CLIP, TELEPORT, HEAL, ITEM, POKEMON, OPTIONS
+  U.log("f3 opens the menu:", (function()
+    openMenu()
+    return topIs(Menu)
+  end)())
+  U.shot(game, DIR .. "/debug_00_menu.png")
+
+  U.log("f3 closes it again:", (function()
+    game:keypressed("f3")
+    U.wait(2)
+    return game.stack:top() == game.overworld
+  end)())
+
+  -- -------- NO CLIP --------
+  openMenu()
+  U.log("noclip starts off:", not game.noclip)
+  U.tap(game, "a") -- toggle on; keepOpen leaves the menu up
+  U.wait(2)
+  U.log("noclip on, menu still open:", game.noclip == true, topIs(Menu))
+  U.shot(game, DIR .. "/debug_01_noclip_on.png")
+  U.tap(game, "a") -- toggle back off
+  U.wait(2)
+  U.log("noclip off again:", game.noclip == false)
+  U.shot(game, DIR .. "/debug_02_noclip_off.png")
+  U.tap(game, "b") -- keepOpen never auto-closes; B backs out like any menu
+  U.wait(3)
+  U.log("back to overworld after b:", game.stack:top() == game.overworld)
+
+  -- -------- OPTIONS (nested submenu) --------
+  openMenu()
+  for _ = 1, 5 do U.tap(game, "down") end -- NO CLIP -> ... -> OPTIONS
+  U.tap(game, "a")
+  U.wait(3)
+  U.log("options submenu opened:", topIs(Menu))
+  U.log("noWilds/fastWalk start off:", not game.noWilds, not game.fastWalk)
+  U.shot(game, DIR .. "/debug_03_options.png")
+  U.tap(game, "a") -- toggle NO WILDS on
+  U.wait(2)
+  U.log("noWilds on:", game.noWilds == true)
+  U.shot(game, DIR .. "/debug_04_options_wilds_on.png")
+  U.tap(game, "down")
+  U.tap(game, "a") -- toggle FAST WALK on
+  U.wait(2)
+  U.log("fastWalk on:", game.fastWalk == true)
+  U.shot(game, DIR .. "/debug_05_options_fastwalk_on.png")
+  U.tap(game, "b") -- nested: backs out to the parent debug menu, not the overworld
+  U.wait(3)
+  U.log("back to the parent debug menu (not overworld):",
+        topIs(Menu) and game.stack:top() ~= game.overworld)
+  U.shot(game, DIR .. "/debug_06_options_back.png")
+  U.tap(game, "b") -- close the debug menu entirely
+  U.wait(3)
+  U.log("closed to overworld:", game.stack:top() == game.overworld)
+  -- leave the toggles as found so they don't affect the rest of this run
+  game.noWilds = false
+  game.fastWalk = false
+
+  -- -------- HEAL --------
+  openMenu()
+  U.tap(game, "down")
+  U.tap(game, "down") -- NO CLIP -> TELEPORT -> HEAL
+  U.tap(game, "a")
+  U.wait(3)
+  U.log("mon hp before heal was 1, after:", mon.hp, "max:", mon.stats.hp)
+  U.shot(game, DIR .. "/debug_07_healed.png")
+  U.tap(game, "a") -- dismiss "Party healed!" TextBox
+  U.wait(3)
+
+  -- -------- ITEM --------
+  openMenu()
+  U.tap(game, "down")
+  U.tap(game, "down")
+  U.tap(game, "down") -- NO CLIP -> TELEPORT -> HEAL -> ITEM
+  U.tap(game, "a")
+  U.wait(3)
+  local itemList = game.stack:top()
+  local itemId = itemList.items[1] and itemList.items[1].value
+  U.log("give-item list opened:", topIs(ListMenu), "first item:", tostring(itemId))
+  U.shot(game, DIR .. "/debug_08_item_list.png")
+  U.tap(game, "a") -- choose it
+  U.wait(3)
+  U.shot(game, DIR .. "/debug_09_item_qty.png")
+  U.tap(game, "a") -- confirm default quantity (1)
+  U.wait(3)
+  U.log("inventory after give:", itemId, "=", tostring(game.save.inventory[itemId]))
+  U.shot(game, DIR .. "/debug_10_item_given.png")
+  U.tap(game, "a") -- dismiss confirmation
+
+  -- -------- GIVE POKEMON --------
+  U.wait(3)
+  local beforeCount = #game.save.party
+  openMenu()
+  U.tap(game, "down")
+  U.tap(game, "down")
+  U.tap(game, "down")
+  U.tap(game, "down") -- NO CLIP -> TELEPORT -> HEAL -> ITEM -> POKEMON
+  U.tap(game, "a")
+  U.wait(3)
+  local monList = game.stack:top()
+  local speciesId = monList.items[1] and monList.items[1].value
+  U.log("give-pokemon list opened:", topIs(ListMenu), "first species:", tostring(speciesId))
+  U.shot(game, DIR .. "/debug_11_pokemon_list.png")
+  U.tap(game, "a") -- choose it
+  U.wait(3)
+  U.shot(game, DIR .. "/debug_12_pokemon_level.png")
+  U.tap(game, "a") -- confirm default level (5)
+  U.wait(3)
+  U.log("party count before/after give:", beforeCount, #game.save.party,
+        "last species:", tostring(game.save.party[#game.save.party]
+          and game.save.party[#game.save.party].species))
+  U.shot(game, DIR .. "/debug_13_pokemon_given.png")
+  U.tap(game, "a") -- dismiss confirmation
+  U.wait(3)
+
+  -- -------- TELEPORT --------
+  openMenu()
+  U.tap(game, "down") -- NO CLIP -> TELEPORT
+  U.tap(game, "a")
+  U.wait(3)
+  local mapList = game.stack:top()
+  U.log("teleport list opened:", topIs(ListMenu))
+  local found = selectValue(mapList, "VIRIDIAN_CITY")
+  U.log("VIRIDIAN_CITY in map list:", found)
+  U.shot(game, DIR .. "/debug_14_map_list.png")
+  U.tap(game, "a") -- warp
+  U.wait(10)
+  U.log("landed on:", game.overworld.map.id, "stack top is overworld:",
+        game.stack:top() == game.overworld)
+  U.shot(game, DIR .. "/debug_15_teleported.png")
+
+  U.log("DONE")
+  love.event.quit()
+end


### PR DESCRIPTION
… clip, no wilds, fast walk

Menu-driven front end for the same debug actions the backtick console already offers, for anyone who'd rather not type Lua. Or for anyone who will inevitably get softlocked / want to reproduce a bug. Locked behind F3 hotkey and docked left (mirroring the START menu's right dock), gated behind the same devMode flag as the console and F5 hot-reload.

- TELEPORT / HEAL / ITEM / POKeMON: reuse the console's existing warp, Pokemon.heal, Bag.add and Pokemon.new/Party.add/Boxes.deposit paths.
- NO CLIP: Player:tryMove bypasses tile/entity collision (still bounded by the map's own tile grid) when Game.noclip is set.
- OPTIONS submenu: NO WILDS (Game.noWilds short-circuits the wild encounter roll in OverworldController) and FAST WALK (halves step time in Player:tryMove, stacking with the bicycle) 

Includes a tests/drivers/debug_menu_test.lua driver covering the whole menu end to end via the real F3 hotkey.