### PR TITLE
Keep the used-move text up during battle animations (#296)

### DIFF
--- a/src/battle/BattleState.lua
+++ b/src/battle/BattleState.lua
@@ -4309,7 +4309,10 @@ end
 function BattleState:drawTextArea()
   Font.drawBox(0, 12, 20, 6)
   love.graphics.setColor(0, 0, 0, 1)
-  if self.phase == "messages" and self.current then
+  if self.phase == "messages" and (self.current or self.animPlaying) then
+    -- during the move animation self.current is nil but shown still holds
+    -- the "used X!" lines; keep drawing them like pokered, whose move
+    -- animations only touch sprites and never the textbox tilemap (#296)
     -- rolling 2-line window: shown[1] at row y=112, shown[2] at y=128 (battle
     -- text uses every other tile row, hlcoord *,14 / *,16).  scrollPx animates
     -- the lines up one row (ScrollTextUpOneLine) so a 3rd line scrolls into

--- a/tests/run_tests.lua
+++ b/tests/run_tests.lua
@@ -2826,6 +2826,32 @@ do
   eq(ys[1], 112, "battle text line 1 at row 14 (y=112)")
   eq(ys[2], 128, "battle text line 2 at row 16 (y=128)")
 end
+
+-- issue #296: the used-move text stays up during the move animation.
+-- current is nil once the message is dismissed, but shown still holds the
+-- lines; pokered's animations never touch the textbox tilemap.
+do
+  local Font = require("src.render.Font")
+  local drawn, origCode, origBox = 0, Font.drawCode, Font.drawBox
+  Font.drawBox = function() end
+  Font.drawCode = function() drawn = drawn + 1 end
+  local battle = setmetatable({
+    phase = "messages",
+    current = nil,
+    animPlaying = true,
+    shown = { { 0x80 }, { 0x81 } },
+  }, BattleState)
+  battle:drawTextArea()
+  eq(drawn, 2, "text keeps drawing while the move animation plays")
+
+  -- without an animation the dismissed message is still hidden, so states
+  -- that clear the box (e.g. pushed UI rows) are unchanged
+  drawn = 0
+  battle.animPlaying = nil
+  battle:drawTextArea()
+  Font.drawCode, Font.drawBox = origCode, origBox
+  eq(drawn, 0, "no current message and no animation draws no text")
+end
 end
 
 -- ================= BUGS.md batch: ledge-shadow =================


### PR DESCRIPTION
Fixes #296.

## What was wrong

In battle, the textbox text is redrawn every frame, but only while a message is active. Once you dismiss "Enemy X used GUST!" and the move animation starts, nothing draws the text, so the box sits empty for the whole animation. Long animations like Gust made this obvious; quick ones like Tackle hid it.

## The fix

Keep drawing the dismissed message's lines while the move animation plays. The original game works this way: its animations only move sprites and never touch the textbox.

## Tests

Added a regression test: the text draws while an animation is playing, and the box still clears normally everywhere else. The full test run is clean apart from the known local-only audio failures (stale ROM import on this machine, skipped in CI).