### PR TITLE
Fire intro.oak_speech.finished only once (#308)

### DIFF
--- a/src/ui/OakSpeech.lua
+++ b/src/ui/OakSpeech.lua
@@ -542,6 +542,10 @@ function OakSpeech:update(dt)
   elseif s.frame >= 79 and s.frame <= 102 then
     self.fadeLevel = math.floor((s.frame - 79) / 8) + 1
   elseif s.frame > 102 then
+    -- clear before finish(): a finished-listener that pushes a state gets
+    -- ITS state popped in the speech's place, and a live shrink would call
+    -- finish() again next frame, re-firing the event every frame (#308)
+    self.shrink = nil
     self:finish()
   end
 end

--- a/tests/mod_ui_tests.lua
+++ b/tests/mod_ui_tests.lua
@@ -711,6 +711,27 @@ check(type("intro.oak_speech.started") == "string"
   "intro.oak_speech lifecycle event names are stable")
 events:removeOwner("fixture")
 
+-- issue #308: finish runs once even when a finished-listener pushes a
+-- screen (the pop in finish() then removes that screen instead of the
+-- speech, and a live shrink re-fires the event every frame)
+do
+  local fgame = { data = {}, stack = newStack(), input = newInput(),
+                  save = { player = {} } }
+  local fspeech = OakSpeech.new(fgame, nil)
+  fspeech.shrink = { frame = 103 } -- past the shrink timeline's end
+  fgame.stack:push(fspeech)
+  fspeech.picReveal = nil -- skip the intro fade so update reaches shrink
+  local finishes = 0
+  events:on("intro.oak_speech.finished", function()
+    finishes = finishes + 1
+    fgame.stack:push({ pushedByListener = true }) -- the #308 trap
+  end, 0, "t308")
+  for _ = 1, 3 do fspeech:update(1 / 60) end
+  events:removeOwner("t308")
+  check(finishes == 1,
+    "finished fires once when a listener pushes a screen")
+end
+
 -- ModUI step helpers
 local tiny = { { id = "a" }, { id = "c" } }
 ModUI.insertStepAfter(tiny, "a", { id = "b" })


### PR DESCRIPTION
Fixes #308.

## What was wrong

Once Oak's shrink animation passes its last frame, the speech calls finish() on every following frame. finish() emits intro.oak_speech.finished and then pops the stack. If a listener pushes a screen during the event (a warp transition, a menu), that pop removes the listener's screen instead of the speech. The speech stays alive and keeps calling finish(), so the event and the listener's side effects repeat every frame. A mod play test hit this and granted the player over a thousand starters in twenty seconds.

## The fix

Clear the shrink state just before finish() runs, so the timeline can never call it twice. One line plus a comment.

## Tests

New regression test: a finished listener that pushes a screen, driven through three update frames. It fires exactly once with the fix and three times without it. The full mod UI suite passes 249/249, and the ROM-free tiers are green.