### PR TITLE
Add a fieldmove.eligibility hook to partyKnows

### DIFF
--- a/src/world/OverworldController.lua
+++ b/src/world/OverworldController.lua
@@ -1240,7 +1240,7 @@ end
 -- (constants.hmBadges; distinct from constants.hmMoves, the forget gate).
 -- Gen 1 allows field use from fainted party members (party menu + name
 -- lookup for Cut/Surf messages); do not require mon.hp > 0 here.
-function OverworldState:partyKnows(moveId)
+local function partyKnowsVanilla(moveId)
   local gate = (FieldDefaults.constant(Game.data, "hmBadges") or {})[moveId]
   local badge = gate and gate.badge
   if badge and not Game.save.inventory[badge] then
@@ -1252,6 +1252,17 @@ function OverworldState:partyKnows(moveId)
     end
   end
   return nil
+end
+
+function OverworldState:partyKnows(moveId)
+  -- a mod may unlock a field move another way (an HM in the bag, a rental
+  -- mon); next_ is the whole vanilla check, so calling it first keeps
+  -- vanilla answers winning
+  if Runtime.wantsHook("fieldmove.eligibility") then
+    return Runtime.call("fieldmove.eligibility", partyKnowsVanilla, moveId,
+      { save = Game.save, data = Game.data })
+  end
+  return partyKnowsVanilla(moveId)
 end
 
 -- The rejection loop shared by the Good and Super Rods

--- a/tests/mod_world_tests.lua
+++ b/tests/mod_world_tests.lua
@@ -575,6 +575,39 @@ do
 end
 
 do
+  -- fieldmove.eligibility: next_ is the whole vanilla partyKnows check,
+  -- so a wrapper can widen field-move rules without forking the engine
+  local save = {
+    inventory = { SOULBADGE = 1, THUNDERBADGE = 1, CASCADEBADGE = 1 },
+    party = { { species = "SQUIRTLE", moves = {} },
+              { species = "PIDGEY", moves = { { id = "FLY" } } } },
+  }
+  local game = { save = save, data = Data }
+  check(bindGame(OW.partyKnows, game), "partyKnows binds a test Game")
+  check(OW:partyKnows("SURF") == nil, "no hook, no surf without a knower")
+  check(OW:partyKnows("FLY") == save.party[2], "the knower wins unwrapped")
+  withBuses(function(_, hooks)
+    local seen
+    hooks:wrap("fieldmove.eligibility", function(next_, moveId, ctx)
+      seen = { moveId = moveId, ctx = ctx }
+      local mon = next_(moveId, ctx)
+      if mon then return mon end -- vanilla first
+      if moveId == "SURF" then return ctx.save.party[1] end
+      return nil
+    end, 0, "rental")
+    check(OW:partyKnows("SURF") == save.party[1],
+      "the hook can offer a field move vanilla denies")
+    check(OW:partyKnows("FLY") == save.party[2],
+      "a vanilla knower still beats the hook")
+    check(OW:partyKnows("CUT") == nil,
+      "next_ still yields nil when the hook declines")
+    check(seen.moveId == "CUT" and seen.ctx.save == save
+      and seen.ctx.data == Data,
+      "the hook ctx carries moveId, save, and data")
+  end)
+end
+
+do
   -- warp.destination reroutes one door without owning the warp table
   local warpDef = Data.maps.PALLET_TOWN.warps[1]
   local m1 = Warp.destination(Data, warpDef)


### PR DESCRIPTION
## Why

Every field-move path (the party menu, surfing, cutting) funnels through `OverworldState:partyKnows`. A mod that wants to widen those rules, for example "use an HM in the field without teaching it", currently has no seam and must monkey-patch that one function. We hit this building exactly that mod.

## What

`partyKnows` now routes through a `fieldmove.eligibility` hook when one is registered. The wrapper's `next_` is the entire vanilla check (badge gate plus knows-move scan), so a mod that calls `next_` first keeps all vanilla answers and only fills the cases vanilla denies. With no hook registered the code path and behavior are unchanged, and the guard keeps it allocation-free.

## Tests

New block in `tests/mod_world_tests.lua`: vanilla behavior unwrapped, the hook offering SURF where vanilla denies it, a vanilla knower beating the hook, and the ctx contract (moveId, save, data). The block fails without the engine change. Full ROM-free tiers green.