### PR TITLE
Fix launcher crash on non-ASCII picked filenames (#325)

### DIFF
--- a/src/import/RomImporter.lua
+++ b/src/import/RomImporter.lua
@@ -338,7 +338,10 @@ local function chooseRom(promptName)
       "$d=New-Object System.Windows.Forms.OpenFileDialog;",
       "$d.Title='" .. prompt .. "';",
       "$d.Filter='Game Boy ROM (*.gb)|*.gb|All files (*.*)|*.*';",
-      "if($d.ShowDialog() -eq 'OK'){[Console]::Write($d.FileName)}",
+      -- write the pick as UTF-8: the console's OEM codepage would mangle
+      -- non-ASCII names (Pokémon -> Pok\x82mon) and crash any text draw
+      -- that shows them (#325)
+      "if($d.ShowDialog() -eq 'OK'){[Console]::OutputEncoding=[Text.Encoding]::UTF8; [Console]::Write($d.FileName)}",
     })
     return commandOutput(
       'powershell -NoProfile -STA -Command "' .. script .. '"')
@@ -369,7 +372,16 @@ local function chooseZip()
       "$d=New-Object System.Windows.Forms.OpenFileDialog;",
       "$d.Title='" .. prompt .. "';",
       "$d.Filter='Mod archive (*.zip)|*.zip|All files (*.*)|*.*';",
-      "if($d.ShowDialog() -eq 'OK'){[Console]::Write($d.FileName)}",
+      -- copy the pick to a plain-ASCII temp name and answer with that:
+      -- the console's OEM codepage would mangle a non-ASCII path
+      -- (Pokémon -> Pok\x82mon) and io.open on Windows needs ANSI bytes,
+      -- so returning the original name both crashed the notice draw and
+      -- could never have opened the file (#325)
+      "if($d.ShowDialog() -eq 'OK'){",
+      "$t=Join-Path $env:TEMP 'pokeport_mod_pick.zip';",
+      "Copy-Item -LiteralPath $d.FileName -Destination $t -Force;",
+      "[Console]::OutputEncoding=[Text.Encoding]::UTF8;",
+      "[Console]::Write($t)}",
     })
     return commandOutput(
       'powershell -NoProfile -STA -Command "' .. script .. '"')
@@ -400,7 +412,8 @@ local function chooseSav()
       "$d=New-Object System.Windows.Forms.OpenFileDialog;",
       "$d.Title='" .. prompt .. "';",
       "$d.Filter='Game Boy save (*.sav)|*.sav|All files (*.*)|*.*';",
-      "if($d.ShowDialog() -eq 'OK'){[Console]::Write($d.FileName)}",
+      -- UTF-8, like the ROM and mod pickers (#325)
+      "if($d.ShowDialog() -eq 'OK'){[Console]::OutputEncoding=[Text.Encoding]::UTF8; [Console]::Write($d.FileName)}",
     })
     return commandOutput(
       'powershell -NoProfile -STA -Command "' .. script .. '"')

--- a/tests/engine/launcher_mods_tests.lua
+++ b/tests/engine/launcher_mods_tests.lua
@@ -208,4 +208,26 @@ do
   check(err ~= nil, "missing-mod uninstall carries a reason")
 end
 
+-- ------- issue #325: the Windows pickers must not hand back mangled paths
+
+do
+  -- PowerShell writes the pick in the console's OEM codepage by default
+  -- (Pokémon -> Pok\x82mon), which broke the open AND crashed the mods
+  -- panel's UTF-8-validating text draw.  Every Windows picker script must
+  -- force UTF-8 output, and the mod picker must return an ASCII temp copy
+  -- since io.open on Windows needs ANSI bytes to open the file at all.
+  local f = assert(io.open("src/import/RomImporter.lua", "rb"))
+  local src = f:read("*a")
+  f:close()
+  local utf8, copies = 0, 0
+  for _ in src:gmatch("OutputEncoding=%[Text%.Encoding%]::UTF8") do
+    utf8 = utf8 + 1
+  end
+  check(utf8 >= 3, "all three Windows pickers force UTF-8 output")
+  check(src:find("pokeport_mod_pick.zip", 1, true) ~= nil,
+    "the mod picker copies the pick to an ASCII temp name")
+  check(src:find("Copy%-Item %-LiteralPath") ~= nil,
+    "the copy uses the literal picked path")
+end
+
 T.finish("launcher_mods")


### PR DESCRIPTION
Fixes #325.

## What was wrong

On Windows, the mod/ROM/save pickers shell out to PowerShell, which writes the chosen path in the console's OEM codepage (CP437 on en-US systems), not UTF-8. Picking a file like "Pokémon Green Sprites 1.0.1.zip" returned the path as Pok\x82mon. Two failures followed:

1. The mangled path doesn't name a real file, so the import failed.
2. The error notice carrying those bytes was printed by the mods panel, and LÖVE's text rendering hard-crashes on invalid UTF-8. That crash is what the reporter saw.

## The fix

- All three Windows picker scripts now set [Console]::OutputEncoding to UTF-8 before writing the pick, so returned paths and any notice built from them are valid.
- The mod picker additionally copies the chosen file to a plain-ASCII temp name (pokeport_mod_pick.zip) and returns that, so a non-ASCII filename actually imports. io.open on Windows needs ANSI bytes, so returning even a correctly-encoded UTF-8 path would still not have opened the file.

Verified the mechanism on the reporter's actual zip: the é-named file copies to the ASCII temp and installs. ROM and save pickers get the crash fix; making those open non-ASCII paths too would be the same Copy-Item step if you want it later.

## Tests

New gate in tests/engine/launcher_mods_tests.lua: every Windows picker script forces UTF-8 output, and the mod picker copies via the literal picked path to the ASCII temp. Suite passes 43/43; the only engine-tier failure is the strings gate already fixed by PR #324.