### PR TITLE
Fix ROM picker + Auto Updater in the Linux Appimage release

### DIFF
--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -391,9 +391,7 @@ end
 -- LÖVE process ensures scripts, registries, and assets are all rebuilt from
 -- the newly selected mod state.
 function Game:restartWithMods()
-  if love.event and love.event.quit then
-    love.event.quit("restart")
-  end
+  require("src.core.HostShell").restart()
 end
 
 function Game:keyreleased(key)

--- a/src/core/HostShell.lua
+++ b/src/core/HostShell.lua
@@ -20,4 +20,32 @@ function HostShell.popen(command, mode)
   return pipe
 end
 
+-- Restart the whole app. The obvious love.event.quit("restart") re-runs LÖVE's
+-- boot in-process, which calls love.filesystem.init a second time -- and inside
+-- an AppImage physfs is already initialized, so that second init throws
+-- ("Failed to initialize filesystem: already initialized") and the relaunch
+-- crashes. So on an AppImage we relaunch the executable; the fresh process's
+-- Boot step mounts any downloaded update exactly as a manual relaunch would.
+-- On every other platform the in-process restart works, so keep it.
+function HostShell.restart()
+  if not (love and love.event and love.event.quit) then return end
+  local appimage = os.getenv("APPIMAGE")
+  if not appimage then
+    love.event.quit("restart")
+    return
+  end
+
+  -- We have to restart the process with this cursed execv call to prevent the
+  -- PID from changing, which might cause SteamOS and other Linux launchers to
+  -- think the app has crashed.
+  local ffi = require("ffi")
+  pcall(ffi.cdef, [[
+    int execv(const char *path, char *const argv[]);
+    int unsetenv(const char *name);
+  ]])
+  ffi.C.unsetenv("LD_LIBRARY_PATH")
+  local argv = ffi.new("const char *[2]", appimage, nil)
+  ffi.C.execv(appimage, ffi.cast("char *const *", argv))
+end
+
 return HostShell

--- a/src/core/HostShell.lua
+++ b/src/core/HostShell.lua
@@ -1,0 +1,23 @@
+-- Helpers for calling host tools (curl, zenity/kdialog, ...).
+
+local HostShell = {}
+
+-- Our AppRun exports LD_LIBRARY_PATH="$APPDIR/lib:..." so every subprocess we
+-- spawn tries to link against the libraries we're shipping instead of the
+-- system ones. We want to unset the var so that any system tools can find
+-- their proper libraries. Only needed when running in an AppImage.
+function HostShell.envPrefix()
+  if os.getenv("APPIMAGE") then
+    return "env -u LD_LIBRARY_PATH "
+  end
+  return ""
+end
+
+-- Wraps io.popen with the AppImage env fix applied and lua errors swallowed
+function HostShell.popen(command, mode)
+  local ok, pipe = pcall(io.popen, HostShell.envPrefix() .. command, mode or "r")
+  if not ok or not pipe then return nil end
+  return pipe
+end
+
+return HostShell

--- a/src/import/RomImporter.lua
+++ b/src/import/RomImporter.lua
@@ -1,5 +1,6 @@
 local GameVersion = require("src.core.GameVersion")
 local Strings = require("src.core.Strings")
+local HostShell = require("src.core.HostShell")
 
 local RomImporter = {}
 RomImporter.__index = RomImporter
@@ -285,7 +286,7 @@ end
 
 local function commandOutput(command)
   releasePointerGrab()
-  local pipe = io.popen(command, "r")
+  local pipe = HostShell.popen(command)
   if not pipe then return nil end
   local result = pipe:read("*a")
   pipe:close()

--- a/src/import/RomImporter.lua
+++ b/src/import/RomImporter.lua
@@ -1860,7 +1860,7 @@ function RomImporter:mousepressed(x, y, button)
     if action == "download" and self.Check then
       pcall(self.Check.download)
     elseif action == "restart" then
-      love.event.quit("restart")
+      HostShell.restart()
     elseif action == "openurl" and self.Check then
       love.system.openURL(self.Check.releaseUrl())
     end

--- a/src/update/check_worker.lua
+++ b/src/update/check_worker.lua
@@ -35,6 +35,7 @@ local Json    = loadModule("src/link/Json.lua")
 local Check   = loadModule("src/update/Check.lua")
 local Version = loadModule("src/core/Version.lua")
 local Semver  = loadModule("src/update/Semver.lua")
+local HostShell = loadModule("src/core/HostShell.lua")
 -- Boot's top-level require("src.update.Semver") cannot resolve in this thread
 -- (no src.* searcher), which would leave Boot nil and the minShell gate
 -- permanently permissive.  Seed the loaded table first so it resolves.
@@ -76,8 +77,8 @@ local function curlCapture(url)
     .. "-H " .. shq("User-Agent: gen1recomp-updater") .. " "
     .. "-H " .. shq("Accept: application/vnd.github+json") .. " "
     .. shq(url)
-  local ok, pipe = pcall(io.popen, cmd)
-  if not ok or not pipe then return nil end
+  local pipe = HostShell.popen(cmd)
+  if not pipe then return nil end
   local out = pipe:read("*a")
   pipe:close()
   if not out or out == "" then return nil end
@@ -85,8 +86,8 @@ local function curlCapture(url)
 end
 
 local function haveCurl()
-  local ok, pipe = pcall(io.popen, "curl --version")
-  if not ok or not pipe then return false end
+  local pipe = HostShell.popen("curl --version")
+  if not pipe then return false end
   local out = pipe:read("*a")
   pipe:close()
   return out ~= nil and out:find("curl", 1, true) ~= nil
@@ -239,7 +240,7 @@ local function launchDownload(url, partAbs, doneAbs)
     os.execute('start "" /b ' .. shq(saveDir .. "/" .. batRel))
   else
     -- ( ... ) & backgrounds the whole group so os.execute returns at once
-    os.execute("( curl -fsSL --connect-timeout 15 --max-time 900 -o "
+    os.execute("( " .. HostShell.envPrefix() .. "curl -fsSL --connect-timeout 15 --max-time 900 -o "
       .. shq(partAbs) .. " " .. shq(url)
       .. " ; touch " .. shq(doneAbs) .. " ) >/dev/null 2>&1 &")
   end


### PR DESCRIPTION
So, our current AppImage release has two problems:

1. Any system tools we call (like curl/zenity) inherit the love process env vars, which overwrites `LD_LIBRARY_PATH` to include $APPDIR/lib. That causes those system tools to try to link against libraries included in our directory instead of using system libraries, which almost certainly will cause a crash.
2. There is some funky business (aka no clue why it happens) going on in the filesystem handling of the regular `love.event.quit("restart")` call when running from the AppImage release. It's trying to re-initialize physfs and that causes a crash.

This PR proposes a fix by introducing a new `src/core/HostShell.lua` file offering wrappers to a few operations that have to interact with the platform: mostly `popen` and `restart`, but I had to expose an `envPrefix` function so it could work with `os.execute` without too much pain. The wrappers only do anything at all if we're running in the AppImage.

The `popen` wrapper unsets `LD_LIBRARY_PATH` to force the process to use the system's "vanilla" resolver. Should work in pretty much all cases, but if the user has a custom `LD_LIBRARY_PATH` set somewhere, we won't use their custom value. I don't think there's an easy way for us to use it, and I think it should be very rare for people to rely on something like this to run `curl`, so I think this should be more than fine.

The `restart` wrapper tries to dodge the love/physfs thing by completely replacing the running process with an `execv` syscall via the ffi interface. This approach is very cursed and I hate it, but I think SteamOS and other game launchers might think the app closed if we just launched a new process and killed the old one. I couldn't test this, so I can't tell you how necessary this cursed solution actually is, but I tested and restarting is working, so... idk, let me know if you want any of this changed.
There is one `restart` call in `ManagerState.lua` I didn't change for the wrapper because it seems to be a test-only thing (I think?), so it can't run in the AppImage release (I think?).

I manually tested the ROM picker and the auto-updater (built the app with an older version tag to trigger it), everything worked fine.