### PR TITLE
Respect the device rotation lock on Android

### DIFF
--- a/conf.lua
+++ b/conf.lua
@@ -54,7 +54,10 @@ function love.conf(t)
     -- the game follow the device.  The renderer letterboxes the 160x144
     -- viewport into whatever size results, and the on-screen touch controls
     -- re-lay themselves out from the new window size, so both orientations
-    -- just work.  iOS follows the Info.plist orientations
+    -- just work.  FULL_SENSOR ignores the device's rotation lock, so
+    -- GameActivity.setOrientationBis remaps it to FULL_USER after SDL has
+    -- run: same orientations allowed, but auto-rotate being off now wins.
+    -- iOS follows the Info.plist orientations
     -- (see mobile/ios/overlays/love-ios.plist, now portrait + landscape).
     t.window.resizable = true
     -- Starting size is a tall portrait hint; the OS resizes to the real

--- a/mobile/ANDROID.md
+++ b/mobile/ANDROID.md
@@ -79,7 +79,7 @@ scripts, tests, and mobile build sources are excluded.
 | --- | --- |
 | `app.application_id` | `com.theboisclub.pokemonred` |
 | `app.name` | Pokemon Red |
-| `app.orientation` | `portrait` |
+| `app.orientation` | `fullUser`. This is only the manifest default: SDL requests FULL_SENSOR at window creation (resizable window, no `SDL_HINT_ORIENTATIONS`), and `GameActivity.setOrientationBis` remaps that to FULL_USER so the device's rotation lock is honoured. |
 | `app.version_name` / `app.version_code` | set from `--version X.Y.Z` (code = major*10000 + minor*100 + patch); left as-is if `--version` is omitted |
 | Permissions | INTERNET / RECORD_AUDIO / WRITE_EXTERNAL_STORAGE stripped; VIBRATE + BLUETOOTH kept |
 

--- a/mobile/android/love/src/main/java/org/love2d/android/GameActivity.java
+++ b/mobile/android/love/src/main/java/org/love2d/android/GameActivity.java
@@ -41,6 +41,7 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.res.AssetManager;
 import android.media.AudioManager;
@@ -297,6 +298,54 @@ public class GameActivity extends SDLActivity {
     @Override
     public void onResume() {
         super.onResume();
+    }
+
+    /**
+     * SDL decides the activity's requested orientation at window creation
+     * (SDLActivity.setOrientationBis). With a resizable window and no
+     * SDL_HINT_ORIENTATIONS -- exactly what conf.lua produces on Android --
+     * it asks for SCREEN_ORIENTATION_FULL_SENSOR, and that request overrides
+     * the android:screenOrientation="fullUser" set in the manifest. The
+     * *_SENSOR constants follow the accelerometer even when the player has
+     * turned auto-rotate off, so the game kept rotating on a device whose
+     * rotation was locked.
+     *
+     * Remap SDL's choice onto the matching *_USER constant, which allows the
+     * same orientations but defers to the system rotation setting. Applied
+     * after super so SDL keeps deciding *which* orientations the window may
+     * take; this only changes who breaks the tie, the sensor or the player.
+     */
+    @Override
+    public void setOrientationBis(int w, int h, boolean resizable, String hint) {
+        super.setOrientationBis(w, h, resizable, hint);
+
+        // The *_USER constants only exist from API 18; below that the sensor
+        // ones are all there is, so leave SDL's request alone.
+        if (android.os.Build.VERSION.SDK_INT < 18) {
+            return;
+        }
+
+        int requested = getRequestedOrientation();
+        int userRequested;
+        switch (requested) {
+            case ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR:
+                userRequested = ActivityInfo.SCREEN_ORIENTATION_FULL_USER;
+                break;
+            case ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE:
+                userRequested = ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE;
+                break;
+            case ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT:
+                userRequested = ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT;
+                break;
+            default:
+                // SENSOR / plain LANDSCAPE / PORTRAIT etc: either already
+                // explicit or never produced by setOrientationBis.
+                return;
+        }
+
+        Log.d("GameActivity", "requestedOrientation " + requested + " -> " + userRequested
+            + " (honour the device rotation lock)");
+        setRequestedOrientation(userRequested);
     }
 
     @Keep


### PR DESCRIPTION
On Android the game ignores the device's rotation lock: if you turn auto-rotate off and then physically rotate the phone, the game rotates with it anyway.

The manifest already asks for the right thing (`android:screenOrientation="fullUser"`, set from `app.orientation` in `scripts/build_android.sh`), but SDL overrides it at window creation. `SDLActivity.setOrientationBis`, given a resizable window and no `SDL_HINT_ORIENTATIONS` -- which is exactly what `conf.lua` produces on Android -- calls `setRequestedOrientation(SCREEN_ORIENTATION_FULL_SENSOR)`. The `*_SENSOR` constants follow the accelerometer regardless of the system rotation setting, so the manifest value never gets a say.

The fix is an override of `setOrientationBis` in `GameActivity` that calls `super` and then remaps whatever SDL asked for onto the matching `*_USER` constant: `FULL_SENSOR` to `FULL_USER`, `SENSOR_LANDSCAPE` to `USER_LANDSCAPE`, `SENSOR_PORTRAIT` to `USER_PORTRAIT`. Those allow the same orientations but defer to the system rotation setting. Doing it after `super` means SDL keeps deciding *which* orientations the window may take, and I am only changing what breaks the tie, the sensor or the player. The `*_USER` constants are API 18+, so there is a `SDK_INT` guard that leaves SDL's request alone below that (`minSdk` is 16).

This only touches Android. iOS follows the `Info.plist` orientations and the OS resolves the rotation lock there on its own, and the Anbernic port is Linux.

Testing, on an API 36 emulator, with the rotation locked to portrait and the sensor pointing landscape:

| | logcat | window rotation | resolution |
| --- | --- | --- | --- |
| before | SDL: `requestedOrientation=10` (FULL_SENSOR) | `ROTATION_270` | 2400x1080 (landscape) |
| after | SDL: `10`, then GameActivity: `10 -> 13` (FULL_USER) | `ROTATION_0` | 1080x2400 (portrait) |

I also checked that nothing regressed with auto-rotate on: the game still follows the device freely, since `FULL_USER` allows the same set of orientations. `scripts/test.sh` passes (T3/T5 skipped, no ROM imported).

--- 

After the change, when the rotation is locked to portrait, changing the phone orientation will respect the user's preferences.

<img width="1392" height="1522" alt="Captura de Tela 2026-07-28 às 23 28 23" src="https://github.com/user-attachments/assets/139dc23e-b787-4bc4-adc3-c91ef4122e10" />

