### PR TITLE
Add native Android second-screen companion

### DIFF
--- a/mobile/android/love/src/main/java/org/love2d/android/CompanionPresentation.java
+++ b/mobile/android/love/src/main/java/org/love2d/android/CompanionPresentation.java
@@ -1,0 +1,333 @@
+package org.love2d.android;
+
+import android.app.Presentation;
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.graphics.Typeface;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.Display;
+import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Locale;
+
+/**
+ * OLED-black, read-only game companion for a physically smaller Android
+ * display.  This window can neither take focus nor receive touch, which is
+ * essential on a handheld: the controls always belong to the game panel.
+ */
+final class CompanionPresentation extends Presentation {
+    private static final String SAVE_IDENTITY = "pokemon-love2d";
+    private static final String SNAPSHOT = "companion-state.json";
+
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private CompanionView companionView;
+    private File snapshotFile;
+    private long lastModified = -1;
+
+    private final Runnable poller = new Runnable() {
+        @Override
+        public void run() {
+            loadSnapshot();
+            handler.postDelayed(this, 250);
+        }
+    };
+
+    CompanionPresentation(Context context, Display display) {
+        super(context, display);
+    }
+
+    @Override
+    protected void onCreate(Bundle state) {
+        super.onCreate(state);
+
+        requestWindowFeature(Window.FEATURE_NO_TITLE);
+        Window window = getWindow();
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+                | WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
+                | WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+                | WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+                | WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
+                | WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+                | WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
+        window.setNavigationBarColor(Color.BLACK);
+        window.setStatusBarColor(Color.BLACK);
+        immersive();
+
+        companionView = new CompanionView(getContext());
+        setContentView(companionView);
+        File external = getContext().getExternalFilesDir(null);
+        snapshotFile = external == null ? null
+            : new File(new File(external, "save/" + SAVE_IDENTITY), SNAPSHOT);
+        handler.post(poller);
+    }
+
+    private void immersive() {
+        getWindow().getDecorView().setSystemUiVisibility(
+            View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                | View.SYSTEM_UI_FLAG_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                | View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        immersive();
+    }
+
+    @Override
+    protected void onStop() {
+        handler.removeCallbacks(poller);
+        super.onStop();
+    }
+
+    private void loadSnapshot() {
+        if (snapshotFile == null || !snapshotFile.isFile()) return;
+        long modified = snapshotFile.lastModified();
+        if (modified == lastModified) return;
+        try {
+            String json = readAll(snapshotFile);
+            JSONObject parsed = new JSONObject(json);
+            lastModified = modified;
+            companionView.setSnapshot(parsed);
+        } catch (Exception ignored) {
+            // A reader can catch the file between LOVE's truncate and write.
+            // Retain the last complete frame and try again on the next poll.
+        }
+    }
+
+    private static String readAll(File file) throws IOException {
+        try (BufferedInputStream input =
+                 new BufferedInputStream(new FileInputStream(file));
+             ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[4096];
+            int count;
+            while ((count = input.read(buffer)) >= 0) output.write(buffer, 0, count);
+            return output.toString("UTF-8");
+        }
+    }
+
+    private static final class CompanionView extends View {
+        private static final float DESIGN_W = 1240f;
+        private static final float DESIGN_H = 1080f;
+        private static final int TEXT = Color.rgb(244, 244, 247);
+        private static final int MUTED = Color.rgb(151, 154, 164);
+        private static final int CARD = Color.rgb(17, 18, 22);
+        private static final int CARD_STROKE = Color.rgb(37, 39, 46);
+        private static final int RED = Color.rgb(239, 73, 77);
+        private static final int BLUE = Color.rgb(76, 139, 245);
+        private static final int GREEN = Color.rgb(73, 201, 126);
+        private static final int YELLOW = Color.rgb(240, 184, 67);
+
+        private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        private final Typeface regular = Typeface.create("sans-serif", Typeface.NORMAL);
+        private final Typeface medium = Typeface.create("sans-serif-medium", Typeface.NORMAL);
+        private JSONObject snapshot;
+
+        CompanionView(Context context) {
+            super(context);
+            setBackgroundColor(Color.BLACK);
+        }
+
+        void setSnapshot(JSONObject value) {
+            snapshot = value;
+            postInvalidate();
+        }
+
+        private void text(Canvas canvas, String value, float x, float y,
+                          float size, int color, boolean bold) {
+            paint.setStyle(Paint.Style.FILL);
+            paint.setColor(color);
+            paint.setTextSize(size);
+            paint.setTypeface(bold ? medium : regular);
+            canvas.drawText(value == null ? "" : value, x, y, paint);
+        }
+
+        private void rounded(Canvas canvas, float l, float t, float r, float b,
+                             float radius, int fill, int stroke) {
+            RectF rect = new RectF(l, t, r, b);
+            paint.setStyle(Paint.Style.FILL);
+            paint.setColor(fill);
+            canvas.drawRoundRect(rect, radius, radius, paint);
+            if (stroke != Color.TRANSPARENT) {
+                paint.setStyle(Paint.Style.STROKE);
+                paint.setStrokeWidth(2);
+                paint.setColor(stroke);
+                canvas.drawRoundRect(rect, radius, radius, paint);
+            }
+        }
+
+        private void bar(Canvas canvas, float x, float y, float width,
+                         float fraction, int color) {
+            fraction = Math.max(0, Math.min(1, fraction));
+            rounded(canvas, x, y, x + width, y + 12, 6,
+                Color.rgb(43, 45, 52), Color.TRANSPARENT);
+            if (fraction > 0) {
+                rounded(canvas, x, y, x + Math.max(12, width * fraction), y + 12,
+                    6, color, Color.TRANSPARENT);
+            }
+        }
+
+        @Override
+        protected void onDraw(Canvas canvas) {
+            super.onDraw(canvas);
+            float sx = getWidth() / DESIGN_W;
+            float sy = getHeight() / DESIGN_H;
+            canvas.save();
+            canvas.scale(sx, sy);
+            canvas.drawColor(Color.BLACK);
+
+            JSONObject state = snapshot;
+            if (state == null) {
+                text(canvas, "POKéMON", 56, 92, 28, MUTED, true);
+                text(canvas, "Ready when you are", 56, 166, 52, TEXT, true);
+                text(canvas, "Game details will appear after your adventure loads.",
+                    56, 222, 24, MUTED, false);
+                canvas.restore();
+                return;
+            }
+
+            boolean blue = "blue".equalsIgnoreCase(state.optString("version", "red"));
+            int accent = blue ? BLUE : RED;
+            String context = state.optString("contextLabel", "Exploring");
+            text(canvas, state.optString("location", "Unknown location"),
+                56, 92, 46, TEXT, true);
+            text(canvas, String.format(Locale.US, "%s  •  %s",
+                    state.optString("playerName", "TRAINER"), context.toUpperCase()),
+                58, 136, 22, accent, true);
+
+            JSONObject battle = state.optJSONObject("battle");
+            if (battle != null) {
+                JSONObject enemy = battle.optJSONObject("enemy");
+                if (enemy != null) {
+                    String opponent = enemy.optString("name", "Opponent")
+                        + "  Lv" + enemy.optInt("level", 1);
+                    paint.setTextSize(28);
+                    paint.setTypeface(medium);
+                    float tw = paint.measureText(opponent);
+                    text(canvas, opponent, DESIGN_W - 56 - tw, 92, 28, TEXT, true);
+                    text(canvas, "NOW BATTLING", DESIGN_W - 247, 128,
+                        16, MUTED, true);
+                }
+            } else {
+                String position = String.format(Locale.US, "MAP %02d, %02d",
+                    state.optInt("x", 0), state.optInt("y", 0));
+                paint.setTextSize(20);
+                paint.setTypeface(medium);
+                text(canvas, position, DESIGN_W - 56 - paint.measureText(position),
+                    104, 20, MUTED, true);
+            }
+
+            JSONArray party = state.optJSONArray("party");
+            int partyCount = party == null ? 0 : party.length();
+            if (partyCount == 0) {
+                rounded(canvas, 56, 184, 1184, 790, 26, CARD, CARD_STROKE);
+                text(canvas, "Your adventure is waiting.", 94, 308, 42, TEXT, true);
+                text(canvas, "Your party will appear here after you choose a partner.",
+                    94, 360, 24, MUTED, false);
+            } else {
+                for (int i = 0; i < Math.min(6, partyCount); i++) {
+                    drawPokemon(canvas, party.optJSONObject(i), i, accent);
+                }
+            }
+
+            drawFooter(canvas, state, accent);
+            canvas.restore();
+        }
+
+        private void drawPokemon(Canvas canvas, JSONObject mon, int index, int accent) {
+            if (mon == null) return;
+            int col = index % 2;
+            int row = index / 2;
+            float x = col == 0 ? 56 : 636;
+            float y = 184 + row * 205;
+            float w = 548;
+            rounded(canvas, x, y, x + w, y + 180, 24, CARD, CARD_STROKE);
+
+            String name = mon.optString("name", "?");
+            text(canvas, name, x + 28, y + 46, 28, TEXT, true);
+            String level = "Lv " + mon.optInt("level", 1);
+            paint.setTextSize(22);
+            paint.setTypeface(medium);
+            text(canvas, level, x + w - 28 - paint.measureText(level),
+                y + 44, 22, MUTED, true);
+
+            int hp = mon.optInt("hp", 0);
+            int maxHp = Math.max(1, mon.optInt("maxHp", 1));
+            int hpColor = hp * 2 < maxHp ? (hp * 5 < maxHp ? RED : YELLOW) : GREEN;
+            text(canvas, "HP", x + 28, y + 84, 17, MUTED, true);
+            String hpText = hp + " / " + maxHp;
+            paint.setTextSize(17);
+            paint.setTypeface(medium);
+            text(canvas, hpText, x + w - 28 - paint.measureText(hpText),
+                y + 84, 17, TEXT, true);
+            bar(canvas, x + 28, y + 97, w - 56, (float) hp / maxHp, hpColor);
+
+            int exp = mon.optInt("expIntoLevel", 0);
+            int expLevel = Math.max(1, mon.optInt("expForLevel", 1));
+            text(canvas, "EXP", x + 28, y + 140, 17, MUTED, true);
+            String expText = mon.optInt("expToNext", 0) + " to next";
+            String status = mon.optString("status", "");
+            if (!status.isEmpty()) expText = status + "  •  " + expText;
+            paint.setTextSize(17);
+            paint.setTypeface(medium);
+            text(canvas, expText, x + w - 28 - paint.measureText(expText),
+                y + 140, 17, status.isEmpty() ? MUTED : accent, true);
+            bar(canvas, x + 28, y + 153, w - 56, (float) exp / expLevel, accent);
+        }
+
+        private void drawFooter(Canvas canvas, JSONObject state, int accent) {
+            float top = 816;
+            paint.setColor(CARD_STROKE);
+            paint.setStrokeWidth(2);
+            canvas.drawLine(56, top, 1184, top, paint);
+
+            text(canvas, "BADGES", 56, 866, 18, MUTED, true);
+            JSONArray badges = state.optJSONArray("badges");
+            for (int i = 0; i < 8; i++) {
+                boolean earned = badges != null && i < badges.length()
+                    && badges.optJSONObject(i) != null
+                    && badges.optJSONObject(i).optBoolean("earned", false);
+                float cx = 76 + i * 58;
+                float cy = 920;
+                paint.setStyle(Paint.Style.FILL);
+                paint.setColor(earned ? accent : Color.rgb(31, 33, 39));
+                canvas.drawCircle(cx, cy, 18, paint);
+                if (!earned) {
+                    paint.setStyle(Paint.Style.STROKE);
+                    paint.setStrokeWidth(2);
+                    paint.setColor(CARD_STROKE);
+                    canvas.drawCircle(cx, cy, 18, paint);
+                }
+                text(canvas, Integer.toString(i + 1), cx - 5, cy + 6,
+                    15, earned ? Color.WHITE : MUTED, true);
+            }
+
+            String money = String.format(Locale.US, "¥%,d", state.optInt("money", 0));
+            paint.setTextSize(34);
+            paint.setTypeface(medium);
+            text(canvas, money, 1184 - paint.measureText(money), 923, 34, TEXT, true);
+            text(canvas, "CASH", 1108, 866, 18, MUTED, true);
+            text(canvas, "LIVE COMPANION", 56, 1030, 16, Color.rgb(70, 72, 80), true);
+        }
+    }
+}

--- a/mobile/android/love/src/main/java/org/love2d/android/GameActivity.java
+++ b/mobile/android/love/src/main/java/org/love2d/android/GameActivity.java
@@ -43,10 +43,14 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.res.AssetManager;
+import android.graphics.Point;
+import android.hardware.display.DisplayManager;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.Vibrator;
 import android.util.Log;
 import android.util.DisplayMetrics;
@@ -86,6 +90,14 @@ public class GameActivity extends SDLActivity {
     private static boolean needToCopyGameInArchive = false;
     private boolean storagePermissionUnnecessary = false;
     private boolean shortEdgesMode = false;
+    private final Handler companionHandler = new Handler(Looper.getMainLooper());
+    private CompanionPresentation companionPresentation;
+    private final Runnable companionLauncher = new Runnable() {
+        @Override
+        public void run() {
+            launchCompanionOnSmallerDisplay();
+        }
+    };
     public boolean embed = false;
     public int safeAreaTop = 0;
     public int safeAreaLeft = 0;
@@ -278,6 +290,8 @@ public class GameActivity extends SDLActivity {
 
     @Override
     protected void onDestroy() {
+        companionHandler.removeCallbacks(companionLauncher);
+        dismissCompanion();
         if (vibrator != null) {
             Log.d("GameActivity", "Cancelling vibration");
             vibrator.cancel();
@@ -287,6 +301,8 @@ public class GameActivity extends SDLActivity {
 
     @Override
     protected void onPause() {
+        companionHandler.removeCallbacks(companionLauncher);
+        dismissCompanion();
         if (vibrator != null) {
             Log.d("GameActivity", "Cancelling vibration");
             vibrator.cancel();
@@ -297,6 +313,84 @@ public class GameActivity extends SDLActivity {
     @Override
     public void onResume() {
         super.onResume();
+        companionHandler.removeCallbacks(companionLauncher);
+        companionHandler.postDelayed(companionLauncher, 350);
+    }
+
+    /**
+     * AYN Thor exposes both panels as ordinary Android displays.  Discover
+     * them on every resume rather than remembering display ids: ids can
+     * change when the lower panel is switched off and back on.
+     *
+     * The LOVE activity remains on the largest active display.  Only then do
+     * we put the read-only companion on the smallest one; a single-screen
+     * device and a game that was intentionally launched on a smaller panel
+     * are both left completely unchanged.
+     */
+    private void launchCompanionOnSmallerDisplay() {
+        if (isFinishing() || android.os.Build.VERSION.SDK_INT < 26) return;
+
+        DisplayManager manager =
+            (DisplayManager) getSystemService(Context.DISPLAY_SERVICE);
+        Display current = getDisplay();
+        if (manager == null || current == null) return;
+
+        Display largest = null;
+        Display smallest = null;
+        long largestArea = -1;
+        long smallestArea = Long.MAX_VALUE;
+        int activeCount = 0;
+        Point size = new Point();
+        for (Display display : manager.getDisplays()) {
+            if (display == null || display.getState() == Display.STATE_OFF) continue;
+            display.getRealSize(size);
+            long area = (long) size.x * (long) size.y;
+            if (area <= 0) continue;
+            activeCount++;
+            if (area > largestArea) {
+                largestArea = area;
+                largest = display;
+            }
+            if (area < smallestArea) {
+                smallestArea = area;
+                smallest = display;
+            }
+        }
+        if (activeCount < 2 || largest == null || smallest == null) {
+            dismissCompanion();
+            return;
+        }
+        if (current.getDisplayId() != largest.getDisplayId()
+            || smallest.getDisplayId() == current.getDisplayId()
+            || largestArea == smallestArea) {
+            dismissCompanion();
+            return;
+        }
+        if (companionPresentation != null
+            && companionPresentation.isShowing()
+            && companionPresentation.getDisplay().getDisplayId()
+                == smallest.getDisplayId()) {
+            return;
+        }
+
+        try {
+            dismissCompanion();
+            companionPresentation = new CompanionPresentation(this, smallest);
+            companionPresentation.show();
+            Log.i("GameActivity", "second-screen companion shown on display "
+                + smallest.getDisplayId());
+        } catch (RuntimeException error) {
+            dismissCompanion();
+            Log.w("GameActivity", "could not show second-screen companion", error);
+        }
+    }
+
+    private void dismissCompanion() {
+        if (companionPresentation == null) return;
+        if (companionPresentation.isShowing()) {
+            companionPresentation.dismiss();
+        }
+        companionPresentation = null;
     }
 
     @Keep

--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -228,6 +228,9 @@ function Game:update(dt)
   -- reason: they are presentational, so fast-forward must not speed them up
   require("src.render.Pipelines").update(dt)
   pcall(function() require("src.core.DiscordPresence").update(dt) end)
+  -- Android's native companion reads a small presentation-only snapshot
+  -- from the save directory. Desktop/headless builds return immediately.
+  pcall(function() require("src.core.SecondScreen").update(dt, self) end)
   -- Steady-state memory backstop: advance the incremental collector one
   -- small step every rendered frame.  The heavy GPU objects are now freed
   -- explicitly (map eviction, battle exit, canvas/renderer swaps), so this

--- a/src/core/SecondScreen.lua
+++ b/src/core/SecondScreen.lua
@@ -1,0 +1,135 @@
+-- Live state for an Android second-screen companion.
+--
+-- LOVE owns the game display and Android owns the companion display, so the
+-- smallest honest seam between them is a tiny JSON snapshot in the game's
+-- save directory.  The snapshot is deliberately presentation-only: it reads
+-- the live game, never mutates it, and the Android side keeps its previous
+-- good frame if it catches this file between writes.
+
+local Badges = require("src.inventory.Badges")
+local DiscordPresence = require("src.core.DiscordPresence")
+local Growth = require("src.pokemon.Growth")
+local Json = require("src.link.Json")
+
+local SecondScreen = {
+  INTERVAL = 0.3,
+  FILE = "companion-state.json",
+  elapsed = 0,
+  last = nil,
+}
+
+local function clamp(n, lo, hi)
+  n = tonumber(n) or 0
+  return math.max(lo, math.min(hi, n))
+end
+
+local function monSnapshot(game, mon)
+  local def = game.data and game.data.pokemon and game.data.pokemon[mon.species]
+  local level = math.max(1, math.floor(tonumber(mon.level) or 1))
+  local exp = math.max(0, math.floor(tonumber(mon.exp) or 0))
+  local growthRate = def and def.growthRate
+  local rates = game.data and game.data.growth_rates
+  local floor = Growth.expForLevel(growthRate, level, rates)
+  local ceiling = level >= 100 and floor
+    or Growth.expForLevel(growthRate, level + 1, rates)
+  local span = math.max(1, ceiling - floor)
+  local maxHP = math.max(1, math.floor(tonumber(mon.stats and mon.stats.hp) or 1))
+
+  return {
+    name = mon.nickname or (def and def.name) or tostring(mon.species or "?"),
+    species = mon.species,
+    level = level,
+    hp = clamp(math.floor(tonumber(mon.hp) or 0), 0, maxHP),
+    maxHp = maxHP,
+    status = mon.status or "",
+    exp = exp,
+    expIntoLevel = clamp(exp - floor, 0, span),
+    expForLevel = span,
+    expToNext = level >= 100 and 0 or math.max(0, ceiling - exp),
+  }
+end
+
+local function battleSnapshot(game)
+  local states = game.stack and game.stack.states or {}
+  for i = #states, 1, -1 do
+    local state = states[i]
+    if type(state) == "table" and state.enemy and state.player
+       and state.enemy.mon and state.player.mon then
+      local enemy = state.enemy
+      return {
+        kind = state.kind or (state.trainer and "trainer" or "wild"),
+        enemy = monSnapshot(game, enemy.mon),
+        trainer = state.trainer and state.trainer.name or nil,
+      }
+    end
+  end
+  return nil
+end
+
+function SecondScreen.snapshot(game)
+  local save = game and game.save or {}
+  local player = save.player or {}
+  local overworld = game and game.overworld
+  local map = overworld and overworld.map
+  local battle = battleSnapshot(game)
+  local inWorld = false
+  for _, state in ipairs(game and game.stack and game.stack.states or {}) do
+    if state == overworld then inWorld = true break end
+  end
+  local mapId = (inWorld or battle) and ((map and map.id) or player.map) or nil
+  local party = {}
+  for i, mon in ipairs(save.party or {}) do
+    if i > 6 then break end
+    party[#party + 1] = monSnapshot(game, mon)
+  end
+
+  local badges = {}
+  for _, entry in ipairs(Badges.list(game and game.data)) do
+    badges[#badges + 1] = {
+      name = entry.name or tostring(entry.id or ""):gsub("BADGE$", ""),
+      earned = (save.inventory
+        and save.inventory[Badges.itemFor(entry)] ~= nil) and true or false,
+    }
+  end
+
+  local x = inWorld and overworld and overworld.player
+    and overworld.player.cellX or player.x
+  local y = inWorld and overworld and overworld.player
+    and overworld.player.cellY or player.y
+  local context = battle and "battle" or (inWorld and "exploring" or "menu")
+
+  return {
+    revision = 1,
+    version = save.version or "red",
+    playerName = player.name or "TRAINER",
+    location = DiscordPresence.locationName(game, mapId) or "Main Menu",
+    mapId = mapId or "",
+    x = math.floor(tonumber(x) or 0),
+    y = math.floor(tonumber(y) or 0),
+    context = context,
+    contextLabel = battle and "Battle" or (inWorld and "Exploring" or "Menu"),
+    money = math.max(0, math.floor(tonumber(save.money) or 0)),
+    badges = badges,
+    party = party,
+    battle = battle,
+  }
+end
+
+local function android()
+  return love and love.system and love.system.getOS
+     and love.system.getOS() == "Android"
+end
+
+function SecondScreen.update(dt, game)
+  if not android() then return end
+  SecondScreen.elapsed = SecondScreen.elapsed + (tonumber(dt) or 0)
+  if SecondScreen.elapsed < SecondScreen.INTERVAL then return end
+  SecondScreen.elapsed = SecondScreen.elapsed % SecondScreen.INTERVAL
+
+  local ok, encoded = pcall(Json.encode, SecondScreen.snapshot(game))
+  if not ok or encoded == SecondScreen.last then return end
+  local wrote = love.filesystem.write(SecondScreen.FILE, encoded)
+  if wrote then SecondScreen.last = encoded end
+end
+
+return SecondScreen

--- a/tests/second_screen_test.lua
+++ b/tests/second_screen_test.lua
@@ -1,0 +1,78 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+love = require("tests.love_stub")
+
+local T = require("tests.harness").suite("second screen")
+local Growth = require("src.pokemon.Growth")
+local SecondScreen = require("src.core.SecondScreen")
+
+local Data = {
+  pokemon = {
+    BULBASAUR = { name = "BULBASAUR", growthRate = "MEDIUM_SLOW" },
+    PIDGEY = { name = "PIDGEY", growthRate = "MEDIUM_SLOW" },
+  },
+  maps = { PALLET_TOWN = { label = "PalletTown" } },
+  field = {
+    townMap = { locations = { PALLET_TOWN = { name = "Pallet Town" } } },
+  },
+  constants = {
+    badges = {
+      { id = "BOULDERBADGE" }, { id = "CASCADEBADGE" },
+      { id = "THUNDERBADGE" }, { id = "RAINBOWBADGE" },
+      { id = "SOULBADGE" }, { id = "MARSHBADGE" },
+      { id = "VOLCANOBADGE" }, { id = "EARTHBADGE" },
+    },
+  },
+}
+local bulbasaur = {
+  species = "BULBASAUR", level = 10,
+  exp = Growth.expForLevel("MEDIUM_SLOW", 10),
+  stats = { hp = 30 }, hp = 15, status = "PSN",
+}
+
+local overworld = {}
+local game = {
+  data = Data,
+  save = {
+    version = "red",
+    player = { name = "RED", map = "PALLET_TOWN", x = 5, y = 6 },
+    inventory = { BOULDERBADGE = 1 },
+    party = { bulbasaur },
+    money = 1234,
+  },
+  overworld = overworld,
+  stack = { states = { overworld } },
+}
+
+local snap = SecondScreen.snapshot(game)
+T.eq(snap.playerName, "RED", "trainer name")
+T.eq(snap.location, "Pallet Town", "friendly location name")
+T.eq(snap.context, "exploring", "overworld context")
+T.eq(#snap.party, 1, "party count")
+T.eq(snap.party[1].name, "BULBASAUR", "species display name")
+T.eq(snap.party[1].status, "PSN", "status")
+T.eq(snap.party[1].hp, bulbasaur.hp, "live HP")
+T.eq(snap.party[1].expToNext,
+     Growth.expForLevel("MEDIUM_SLOW", 11) - bulbasaur.exp,
+     "experience remaining")
+T.check(snap.badges[1].earned, "earned badge")
+T.check(not snap.badges[2].earned, "unearned badge")
+
+game.stack.states = {}
+snap = SecondScreen.snapshot(game)
+T.eq(snap.context, "menu", "title/menu context")
+T.eq(snap.location, "Main Menu", "menu has no stale map")
+
+local enemy = {
+  species = "PIDGEY", level = 4,
+  exp = Growth.expForLevel("MEDIUM_SLOW", 4),
+  stats = { hp = 18 }, hp = 18,
+}
+game.stack.states = {
+  { player = { mon = bulbasaur }, enemy = { mon = enemy }, kind = "wild" },
+}
+snap = SecondScreen.snapshot(game)
+T.eq(snap.context, "battle", "battle context")
+T.eq(snap.battle.enemy.name, "PIDGEY", "battle opponent")
+T.eq(snap.battle.enemy.level, 4, "opponent level")
+
+T.finish()


### PR DESCRIPTION
## TL;DR

- Adds an OLED-black live companion on the physically smaller Android display while the game remains on the larger one.
- Shows location, party HP/EXP, status, badges, cash, and the current battle opponent without mutating game state.
- Leaves single-screen devices unchanged and keeps all focus, touch, and controller input with the game.

## What changed

Android builds now publish a small presentation-only JSON snapshot from the live game every 300 ms when its contents change. The snapshot includes:

- current location and map coordinates
- the six-party roster with HP, status, level, and EXP to the next level
- earned badges and cash
- the current battle opponent

`GameActivity` discovers active displays each time it resumes. When the game is running on the largest active display and a distinct smaller display is available, it shows a native OLED-black `Presentation` on that smaller display. Display IDs are never persisted, so panel power changes and Android display reassignment are handled on the next resume.

The presentation is both non-focusable and non-touchable. It is owned by the game activity rather than launched as a second activity; this keeps controller focus with the game and avoids Android's resumed-activity ANR behavior for windows that intentionally cannot take focus.

If only one display is active, the game was launched on the smaller display, or display presentation fails, the companion is withheld and normal behavior continues.

## Why

Dual-screen Android handhelds such as the AYN Thor have enough room to surface useful RPG state without covering the game. The companion makes that space useful while remaining optional by construction and preserving the ordinary single-screen path.

## Validation

- `lua tests/second_screen_test.lua` — 15/15 checks passed
- `scripts/build_android.sh` — `assembleEmbedNoRecordDebug` succeeded
- Live AYN Thor validation:
  - game on the 1920×1080 upper display
  - companion on the 1240×1080 lower display
  - live party/location data rendered correctly
  - game remained the focused activity
  - presentation window reported `NOT_FOCUSABLE` and `NOT_TOUCHABLE`
  - no ANR after sustained dual-display operation
