### PR TITLE
Show Snorlax's Pokédex entry

### DIFF
--- a/data/scripts/flavor/ss_anne_2f_rooms.lua
+++ b/data/scripts/flavor/ss_anne_2f_rooms.lua
@@ -7,19 +7,19 @@
 -- CheckFightingMapTrainers/TalkToTrainer via the existing trainer
 -- system, and the item pickups carry no talk text of their own here.
 --
--- TEXT_SSANNE2FROOMS_GENTLEMAN3 also opens the POKéDEX entry for
--- SNORLAX after the text box (DisplayPokedex in the original), which
--- has no equivalent talk-script hook in this port (DexEntryMenu has
--- no done-callback the way other pushed UI states do) -- only the
--- flavor line is ported here.
+-- TEXT_SSANNE2FROOMS_GENTLEMAN3 opens SNORLAX's POKéDEX entry after its
+-- text box, like DisplayPokedex in the original. The preview marks it seen
+-- but does not mark it owned.
 return {
   SS_ANNE_2F_ROOMS = {
     talk = {
-      -- SSAnne2FRoomsGentleman3Text: PrintText(_SSAnne2FRoomsGentleman3Text)
-      -- (then DisplayPokedex SNORLAX -- not ported, see note above)
+      -- SSAnne2FRoomsGentleman3Text: PrintText(_SSAnne2FRoomsGentleman3Text),
+      -- then DisplayPokedex SNORLAX.
       TEXT_SSANNE2FROOMS_GENTLEMAN3 = {
         { "face_player" },
         { "show_text", "_SSAnne2FRoomsGentleman3Text" },
+        { "mark_seen", "SNORLAX" },
+        { "push_screen", "DexEntryMenu", "SNORLAX" },
       },
 
       -- SSAnne2FRoomsGentleman4Text: PrintText(_SSAnne2FRoomsGentleman4Text)

--- a/src/script/Commands.lua
+++ b/src/script/Commands.lua
@@ -497,6 +497,17 @@ function Commands.play_cry(ctx, species, waitForButton)
   ctx.pendingCryWait = waitForButton or nil
 end
 
+-- mark_seen <species>: DisplayPokedex (pokedex.asm) records the species as
+-- seen before opening its entry. Map scripts use this for NPC-driven
+-- Pokédex previews that do not begin a battle or give the player a Pokémon.
+function Commands.mark_seen(ctx, species)
+  local dex = ctx.save and ctx.save.pokedex
+  if dex then
+    dex.seen = dex.seen or {}
+    dex.seen[species] = true
+  end
+end
+
 -- check_battle_result <r1> [r2 ...]: lastCheck = the last scripted
 -- battle ended with any of the given results
 -- ("win"|"lose"|"run"|"caught"), for branches like

--- a/tests/parity_ss_anne_snorlax_dex.lua
+++ b/tests/parity_ss_anne_snorlax_dex.lua
@@ -1,0 +1,24 @@
+-- Parity: the S.S. Anne passenger's Snorlax description opens the Pokédex
+-- entry and records Snorlax as seen (pokered/scripts/SSAnne2FRooms.asm).
+package.path = "./?.lua;./?/init.lua;" .. package.path
+local S = require("tests.harness").suite("parity ss anne Snorlax dex")
+local check, eq = S.check, S.eq
+
+local scripts = require("data.scripts.init")
+local script = scripts.talkScript("SS_ANNE_2F_ROOMS",
+  "TEXT_SSANNE2FROOMS_GENTLEMAN3")
+
+check(script ~= nil, "the S.S. Anne passenger has a talk script")
+eq(script[2][1], "show_text", "the passenger's line appears first")
+eq(script[3][1], "mark_seen", "the Pokédex preview marks Snorlax seen")
+eq(script[3][2], "SNORLAX", "the preview marks Snorlax seen")
+eq(script[4][1], "push_screen", "the Pokédex entry opens after the line")
+eq(script[4][2], "DexEntryMenu", "the Pokédex entry uses DexEntryMenu")
+eq(script[4][3], "SNORLAX", "the Pokédex entry is for Snorlax")
+
+local save = { pokedex = { seen = {}, owned = {} } }
+require("src.script.Commands").mark_seen({ save = save }, "SNORLAX")
+check(save.pokedex.seen.SNORLAX, "the preview records Snorlax as seen")
+check(not save.pokedex.owned.SNORLAX, "the preview does not mark Snorlax owned")
+
+S.finish()


### PR DESCRIPTION
Talking to the S.S. Anne passenger who describes Snorlax now records Snorlax as seen and opens its Pokédex entry after the dialogue, matching the original script.\n\nAdded a parity test for the talk-script sequence and seen flag. Ran luajit tests/parity_ss_anne_snorlax_dex.lua.\n\nFixes #352.