### PR TITLE
Repeat Oak's Aide item explanations

### DIFF
--- a/data/scripts/story4.lua
+++ b/data/scripts/story4.lua
@@ -37,16 +37,15 @@ local function countOwned(save)
   return n
 end
 
-local function oaksAide(threshold, itemId)
+local function oaksAide(threshold, itemId, repeatText)
   return function(game, ow, npc, done)
     local t = text(game)
     local flags = game.save.flags
     local itemName = game.data.items[itemId].name
     local flag = "EVENT_GOT_" .. itemId
     if flags[flag] then
-      push(game, fill(t._OaksAideComeBackText or
-        "I already gave\nyou the {RAM:}!",
-        { num = threshold, ram = itemName }), done)
+      push(game, t[repeatText] or
+        fill("I already gave\nyou the {RAM:}!", { ram = itemName }), done)
       return
     end
     ask(game, fill(t._OaksAideHiText or
@@ -83,13 +82,16 @@ local function oaksAide(threshold, itemId)
 end
 
 M.ROUTE_2_GATE = {
-  talk = { TEXT_ROUTE2GATE_OAKS_AIDE = oaksAide(10, "HM_FLASH") },
+  talk = { TEXT_ROUTE2GATE_OAKS_AIDE = oaksAide(10, "HM_FLASH",
+    "_Route2GateOaksAideFlashExplanationText") },
 }
 M.ROUTE_11_GATE_2F = {
-  talk = { TEXT_ROUTE11GATE2F_OAKS_AIDE = oaksAide(30, "ITEMFINDER") },
+  talk = { TEXT_ROUTE11GATE2F_OAKS_AIDE = oaksAide(30, "ITEMFINDER",
+    "_Route11Gate2FOaksAideItemfinderDescriptionText") },
 }
 M.ROUTE_15_GATE_2F = {
-  talk = { TEXT_ROUTE15GATE2F_OAKS_AIDE = oaksAide(50, "EXP_ALL") },
+  talk = { TEXT_ROUTE15GATE2F_OAKS_AIDE = oaksAide(50, "EXP_ALL",
+    "_Route15Gate2FOaksAideExpAllText") },
 }
 
 -- -------------------------------------------------------------------

--- a/tests/parity_oaks_aide_repeat.lua
+++ b/tests/parity_oaks_aide_repeat.lua
@@ -1,0 +1,39 @@
+-- Parity: after a reward, each Oak's Aide repeats its item explanation
+-- instead of the pre-reward "come back" text (engine/events/oaks_aide.asm).
+package.path = "./?.lua;./?/init.lua;" .. package.path
+if not _G.love then _G.love = require("tests.love_stub") end
+local S = require("tests.harness").suite("parity Oak's Aide repeat text")
+local eq = S.eq
+local Data = require("src.core.Data")
+if not Data.maps then Data:load() end
+local Font = require("src.render.Font")
+Font.load(Data)
+
+local scripts = require("data.scripts.init")
+local CASES = {
+  { map = "ROUTE_2_GATE", text = "TEXT_ROUTE2GATE_OAKS_AIDE",
+    item = "HM_FLASH", label = "_Route2GateOaksAideFlashExplanationText",
+    value = "FLASH" },
+  { map = "ROUTE_11_GATE_2F", text = "TEXT_ROUTE11GATE2F_OAKS_AIDE",
+    item = "ITEMFINDER", label = "_Route11Gate2FOaksAideItemfinderDescriptionText",
+    value = "FINDER" },
+  { map = "ROUTE_15_GATE_2F", text = "TEXT_ROUTE15GATE2F_OAKS_AIDE",
+    item = "EXP_ALL", label = "_Route15Gate2FOaksAideExpAllText",
+    value = "EXP" },
+}
+
+for _, case in ipairs(CASES) do
+  local pushed = {}
+  local game = {
+    data = { items = { [case.item] = { name = case.item } },
+             text = { [case.label] = case.value } },
+    save = { flags = { ["EVENT_GOT_" .. case.item] = true },
+             player = { name = "RED" }, pokedex = { owned = {} } },
+    stack = { push = function(_, state) pushed[#pushed + 1] = state end },
+  }
+  scripts.talkScript(case.map, case.text)(game, {}, nil, function() end)
+  eq(pushed[1] and pushed[1].pages[1][1], case.value,
+    case.item .. " aide repeats its item explanation")
+end
+
+S.finish()


### PR DESCRIPTION
Oak's Aides now repeat the explanation for Flash, Itemfinder, or EXP.ALL after giving that reward. They no longer send the player back to the pre-reward prompt.\n\nAdded coverage for all three aides. Ran luajit tests/parity_oaks_aide_repeat.lua.\n\nluajit tests/run_tests.lua still has the three audio-data failures already present in this checkout: missing data/generated/audio.lua, the full-dex cry check, and parity_intro.\n\nFixes #363.