### PR TITLE
Fix Android relaunch after in-game quit

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -424,6 +424,11 @@ function love.quit()
   pcall(function()
     require("src.core.DiscordPresence").shutdown()
   end)
+  -- Worker threads must not outlive the main state: they keep love's modules
+  -- (and PhysFS) referenced, and Android reuses the cached process on the next
+  -- launch, which then fails to boot (see ChipAudio.shutdown).
+  pcall(function() require("src.core.ChipAudio").shutdown() end)
+  pcall(function() require("src.update.Check").shutdown() end)
 end
 
 function love.filedropped(file)

--- a/src/core/ChipAudio.lua
+++ b/src/core/ChipAudio.lua
@@ -485,4 +485,19 @@ function ChipAudio._renderSfxForTest(data, header, seconds)
   return ChipSynth.soundData(engine, math.floor(seconds * SAMPLE_RATE), 1)
 end
 
+-- Stop the worker thread for good (called from love.quit).  A love.thread
+-- that outlives the main state keeps love's C++ modules referenced, so PhysFS
+-- is never deinitialized.  Desktop processes die right after quit and never
+-- notice, but Android reuses the cached process: the next launch re-runs
+-- boot.lua inside it and dies with "Failed to initialize filesystem: already
+-- initialized", leaving the app unopenable until a force-stop.  The worker
+-- polls its command channel every millisecond, so the wait() returns at once.
+function ChipAudio.shutdown()
+  if not worker then return end
+  if cmdCh then cmdCh:push({ cmd = "quit" }) end
+  pcall(function() worker:wait() end)
+  worker = nil
+  workerReady = false
+end
+
 return ChipAudio

--- a/src/update/Check.lua
+++ b/src/update/Check.lua
@@ -174,4 +174,19 @@ function Check.download()
   cmdCh:push({ cmd = "download" })
 end
 
+-- Stop the worker thread (called from love.quit); same process-reuse rationale
+-- as ChipAudio.shutdown.  An idle worker wakes from its demand() immediately;
+-- one that is mid check/download only sees the command once the transfer
+-- settles, so skip the join in those states: quit must not block behind curl.
+function Check.shutdown()
+  if not worker then return end
+  drain()
+  if cmdCh then cmdCh:push({ cmd = "quit" }) end
+  if cache.status ~= "checking" and cache.status ~= "downloading" then
+    pcall(function() worker:wait() end)
+  end
+  worker = nil
+  workerReady = false
+end
+
 return Check


### PR DESCRIPTION
Fixes #339.

## Problem

On Android, after exiting the game through the in-game menu, tapping the app icon does nothing until the app is force-stopped (or swiped away from Recent Apps).

Logcat from the failed relaunch shows the actual failure:

```
SDL/APP: [LOVE] Error: [love "boot.lua"]:48: Failed to initialize filesystem: already initialized
```

## Root cause

Two background `love.thread` workers (`src/core/chip_worker.lua` and `src/update/check_worker.lua`) were never told to quit, so they outlive the main Lua state. On desktop the process dies right after quit and nobody notices. On Android the process stays cached: the surviving threads keep love's C++ modules referenced, so PhysFS is never deinitialized. When the launcher reuses the cached process, LÖVE boots again in it, `love.filesystem.init` throws "already initialized", and the activity closes instantly, which looks like the tap did nothing.

This is the same failure mode already worked around for AppImage restarts in `src/core/HostShell.lua`.

## Fix

- `ChipAudio.shutdown()`: pushes `{cmd = "quit"}` to the worker and joins it (the worker polls its command channel every millisecond, so the join returns at once).
- `Check.shutdown()`: same, but skips the join while a check/download is in flight so quit never blocks behind curl.
- `love.quit()` now calls both.

## Validation

- `scripts/test.sh --quick`: ALL TIERS PASSED.
- On an Android 16 emulator (Pixel-class AVD): reproduced the bug with the previous build, then with this fix imported a ROM, entered the game, exited via the in-game menu and relaunched from the icon repeatedly, and the game reopens normally every time.
- Also tested on a physical device. 