### PR TITLE
Fix readme inaccuracies (add AI disclosure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# Gen1Recomp
+# Gen1LuaReimplementation
 
 A native LÖVE2D recreation of Poke Red, Blue and Yellow. The engine and map
-behavior are hand-written Lua; game data and graphics are decoded from a ROM
+behavior are converted to Lua using a LLM; game data and graphics are decoded from a ROM
 supplied by the player.
+
+## AI disclosure
+
+This project was created with heavy use of LLMs which did the grunt work of converting the disassembly code into Lua. Note that this project is completely untested, and any issues reported will be sent back to the LLM, which will attempt a fix and this will also be merged untested. What this means it that this is not a suitable way to actually play the game and should remain a curiosity. If you want a playable version of the game, please play literally any other version. 
 
 <p align="center"><img src="https://raw.githubusercontent.com/bryanthaboi/gen1recomp/refs/heads/dev/assets/logo/logo.png"></p>
 


### PR DESCRIPTION
I noticed some inaccuracies in the readme. For one, this project claims to be a recomp, when it's actually a reimplementation of the disassembly code in Lua. Additionally, the readme claims the project is hand-written, which is strange, considering it is 100% clear that the entirety of the codebase is AI-generated, particularly when seeing comments that only an LLM would write, such as this:

<img width="588" height="353" alt="test1" src="https://github.com/user-attachments/assets/01837b51-ac5e-4559-933e-ecb4a50b09fd" />

If one was cynical, one would assume that there is an attempt to hide the AI usage when seeing commits such as this one, which replaces an m-dash with a double dash:

<img width="1545" height="229" alt="test2" src="https://github.com/user-attachments/assets/7ca166d3-2bcc-4f5b-9fc8-a34de0f8ffd7" />

Of course, I do not like being cynical, and clearly this had to be an innocent mistake! Which is why I decided to help you out by fixing these inaccuracies in the readme. 

I can follow up as needed. Thanks!