### PR TITLE
Fix save editor item crash on Android

### DIFF
--- a/tests/run_save_editor_tests.lua
+++ b/tests/run_save_editor_tests.lua
@@ -432,6 +432,34 @@ do
 end
 
 do
+  -- #476: on Android a high-DPI 1560x720 capture can leave the editor with
+  -- only a compact logical viewport.  The Items picker must not hand a
+  -- negative list height to love.graphics.setScissor in that layout.
+  local tmpPath = os.tmpname() .. "-items-compact-save.lua"
+  local f = io.open(tmpPath, "wb")
+  f:write(SaveData.encode(SaveData.newGame()))
+  f:close()
+
+  local oldDimensions = love.graphics.getDimensions
+  local oldScissor = love.graphics.setScissor
+  love.graphics.getDimensions = function() return 520, 240 end
+  love.graphics.setScissor = function(_, _, width, height)
+    if width and (width < 0 or height < 0) then
+      error("Can't set scissor with negative width and/or height.")
+    end
+  end
+  App.load(tmpPath, { version = "red" })
+  App.getState().tab = "items"
+  local ok, err = pcall(App.draw)
+  check(ok, "the Items tab draws in a compact Android viewport: " .. tostring(err))
+  love.graphics.getDimensions = oldDimensions
+  love.graphics.setScissor = oldScissor
+
+  os.remove(tmpPath)
+  for _, bak in ipairs(FsIo.globPrefix(tmpPath .. ".bak-")) do os.remove(bak) end
+end
+
+do
   -- Whole-editor smoke test: every tab has to survive a real headless draw,
   -- which is what catches a layout that divides by a nil font metric or
   -- indexes a save field the panel assumed was always present.

--- a/tools/save-editor/Kit.lua
+++ b/tools/save-editor/Kit.lua
@@ -381,13 +381,22 @@ end
 
 -- Clip drawing to a rect (list bodies).  No-ops under the headless stub.
 function Kit.pushClip(x, y, w, h)
-  if G and G.setScissor then
-    G.setScissor(math.floor(x), math.floor(y), math.ceil(w), math.ceil(h))
+  -- A compact mobile viewport can leave a panel with no room for a list.
+  -- LÖVE rejects negative scissor dimensions, so treat an exhausted clip
+  -- region as empty instead of passing invalid geometry through to it.
+  Kit._clipActive = G and G.setScissor ~= nil
+  if Kit._clipActive then
+    if w <= 0 or h <= 0 then
+      G.setScissor(0, 0, 0, 0)
+    else
+      G.setScissor(math.floor(x), math.floor(y), math.ceil(w), math.ceil(h))
+    end
   end
 end
 
 function Kit.popClip()
-  if G and G.setScissor then G.setScissor() end
+  if Kit._clipActive and G and G.setScissor then G.setScissor() end
+  Kit._clipActive = false
 end
 
 return Kit


### PR DESCRIPTION
On a compact Android viewport, the Items picker calculates a negative list height and passes it to setScissor, which crashes LÖVE. Empty list regions now use a zero-sized clip instead.

I added a 520x240 editor test that rejects negative scissor dimensions. The save-editor test suites pass. The full suite still stops on the four existing missing-audio fixture failures.

Fixes #476