### PR TITLE
Fix Cerulean badge menu exit

### DIFF
--- a/data/scripts/flavor/cerulean_badge_house.lua
+++ b/data/scripts/flavor/cerulean_badge_house.lua
@@ -42,6 +42,7 @@ local function middleAgedMan(game, ow, npc, done)
       end
       local menu = ListMenu.new(game, "", items, {
         onChoose = function(item)
+          game.stack:pop()
           push(game, t[BADGE_TEXT[item.value]], loop)
         end,
         onCancel = function()

--- a/tests/parity_cerulean_badge_house.lua
+++ b/tests/parity_cerulean_badge_house.lua
@@ -1,0 +1,63 @@
+-- Parity: leaving the Cerulean Badge House badge-description menu must
+-- return control to the overworld after viewing a badge (#454).
+package.path = "./?.lua;./?/init.lua;" .. package.path
+if not _G.love then _G.love = require("tests.love_stub") end
+
+local S = require("tests.harness").suite("parity Cerulean Badge House")
+local eq = S.eq
+local script = require("data.scripts.flavor.cerulean_badge_house")
+  .CERULEAN_BADGE_HOUSE.talk.TEXT_CERULEANBADGEHOUSE_MIDDLE_AGED_MAN
+
+local states = {}
+local game = {
+  data = {
+    items = {
+      BOULDERBADGE = { name = "BOULDERBADGE" },
+      CASCADEBADGE = { name = "CASCADEBADGE" },
+      THUNDERBADGE = { name = "THUNDERBADGE" },
+      RAINBOWBADGE = { name = "RAINBOWBADGE" },
+      SOULBADGE = { name = "SOULBADGE" },
+      MARSHBADGE = { name = "MARSHBADGE" },
+      VOLCANOBADGE = { name = "VOLCANOBADGE" },
+      EARTHBADGE = { name = "EARTHBADGE" },
+    },
+    text = {
+      _CeruleanBadgeHouseMiddleAgedManText = "",
+      _CeruleanBadgeHouseMiddleAgedManWhichBadgeText = "",
+      _CeruleanBadgeHouseBoulderBadgeText = "",
+      _CeruleanBadgeHouseMiddleAgedManVisitAnyTimeText = "",
+    },
+  },
+  save = { player = { name = "RED" } },
+  input = { wasPressed = function(_, key) return key == "b" end },
+  stack = {
+    push = function(_, state) states[#states + 1] = state end,
+    pop = function() return table.remove(states) end,
+    top = function() return states[#states] end,
+  },
+}
+
+local done = false
+script(game, nil, nil, function() done = true end)
+
+local function dismissText()
+  local text = game.stack:pop()
+  text.onDone()
+end
+
+-- Greeting -> prompt -> first menu -> badge description -> prompt -> second menu.
+dismissText()
+dismissText()
+local firstMenu = game.stack:top()
+firstMenu.onChoose(firstMenu.items[1])
+dismissText()
+dismissText()
+
+-- B follows ListMenu's real cancellation path: pop menu, then show goodbye.
+game.stack:top():update(0)
+dismissText()
+
+eq(#states, 0, "backing out after viewing a badge leaves no menu behind")
+eq(done, true, "backing out after viewing a badge completes the NPC script")
+
+S.finish()

--- a/tests/run_tests.lua
+++ b/tests/run_tests.lua
@@ -3274,6 +3274,7 @@ runSuites(orderedGlob("tests/parity_*.lua", {
   "tests/parity_C.lua", "tests/parity_K.lua", "tests/parity_L.lua",
   "tests/parity_H.lua", "tests/parity_G.lua", "tests/parity_I_M.lua",
   "tests/parity_B.lua", "tests/parity_J.lua", "tests/parity_A.lua",
+  "tests/parity_cerulean_badge_house.lua",
   "tests/parity_flavor.lua", "tests/parity_trainer_sight.lua",
   "tests/parity_static.lua", "tests/parity_trashcans.lua",
   "tests/parity_hof.lua", "tests/parity_trade_gift.lua",


### PR DESCRIPTION
Picking a badge in the Cerulean Badge House left the original menu beneath its description. Backing out of the next picker returned to that hidden menu, so the conversation never finished.

The handler now closes the selected picker first. The regression test follows the selection and cancel sequence.

Ran \luajit tests/parity_cerulean_badge_house.lua\.

Fixes #454