### PR TITLE
Recognize symlinked mod dirs on Linux (mods/ dev workflow)

### DIFF
--- a/conf.lua
+++ b/conf.lua
@@ -1,4 +1,9 @@
 function love.conf(t)
+  -- PhysFS ignores symlinks unless told otherwise, so a mod dev-linked into
+  -- mods/ (ln -s, matching the mklink /J workflow on Windows) is invisible
+  -- to love.filesystem.getDirectoryItems without this.
+  love.filesystem.setSymlinksEnabled(true)
+
   local editor = os.getenv("POKEPORT_EDITOR") == "1"
   local developer = os.getenv("POKEPORT_DEV") == "1"
   if arg then

--- a/src/mods/LauncherMods.lua
+++ b/src/mods/LauncherMods.lua
@@ -223,7 +223,9 @@ local function discover()
   for _, name in ipairs(fs.getDirectoryItems("mods")) do
     local path = "mods/" .. name
     local info = fs.getInfo(path)
-    if info and info.type == "directory" then
+    -- a dev-linked mod dir (ln -s) reports type "symlink" even with
+    -- setSymlinksEnabled(true); see the matching note in Loader:_discover.
+    if info and (info.type == "directory" or info.type == "symlink") then
       local raw = fs.read(path .. "/manifest.json")
       if raw then
         local manifest = decodeManifest(raw, path)

--- a/src/mods/Loader.lua
+++ b/src/mods/Loader.lua
@@ -206,7 +206,11 @@ function Loader:_discover()
       for _, name in ipairs(self.fs.getDirectoryItems(root)) do
         local path = root .. "/" .. name
         local info = self.fs.getInfo(path)
-        if info and info.type == "directory" then
+        -- a dev-linked mod dir (ln -s) reports type "symlink" even with
+        -- setSymlinksEnabled(true) -- PhysFS never resolves the symlink's
+        -- own getInfo, only traversal into it. readManifest below still
+        -- correctly no-ops on a symlink that isn't a directory.
+        if info and (info.type == "directory" or info.type == "symlink") then
           local manifest, err = readManifest(self.fs, path)
           if manifest then
             if self.mods[manifest.id] then


### PR DESCRIPTION
## Summary
- `love.filesystem`/PhysFS ignores symlinks by default, and even with
  `setSymlinksEnabled(true)` a symlinked mod dir reports `getInfo().type`
  as `"symlink"` rather than `"directory"` — so a mod dev-linked into
  `mods/` (`ln -s`) was invisible to both the boot-time loader and the
  launcher's MODS tab.
- Enables `setSymlinksEnabled(true)` in `conf.lua` and updates the
  `type == "directory"` check in both `Loader:_discover` and
  `LauncherMods.discover` to also accept `"symlink"`.
- This is the Linux counterpart to the `mklink /J` workflow already used
  for Windows dev mods — same dev-linking convenience, no behavior change
  for normal (non-symlinked) mod installs.

## Test plan
- [x] Ran the existing headless mod-loader suite (`tests/mod_loader_tests.lua`);
      no regressions vs. a stash of these changes.
- [x] Symlinked a real mod directory into `mods/` and launched the game with
      LÖVE against the real filesystem; confirmed both `Loader:_discover()`
      and `LauncherMods.list()` picked it up correctly.