### PR TITLE
Dual-screen (DS-style) rendering

### DIFF
--- a/docs/new-features.md
+++ b/docs/new-features.md
@@ -108,9 +108,14 @@ screen. Purely presentational, no Game Boy equivalent, persisted in
 - GBC FX and post-process pipelines still apply, over both screens at the
   stacked scale. Collision, movement, triggers, encounters, and scripts are
   untouched; nothing about the split reaches gameplay.
-- Desktop and Android both stack the two screens inside the one window.
-  Driving them onto two separate physical displays on multi-display Android
-  hardware is a native-shell layer that is not yet wired.
+- On desktop and single-display Android the two screens stack inside the one
+  window. On multi-display Android (e.g. the AYN Thor) the top screen fills
+  the main panel and the bottom screen is driven onto the second physical
+  display through an Android `Presentation` (native `love-android` layer:
+  `GameActivity` + the `love_android_secondary_*` bridge in
+  `src/jni/love/src/common/android.cpp`, fed the palettized bottom canvas each
+  frame), falling back to the in-window stack when no second display is present.
+  The secondary panel renders the bottom screen fullscreen (system bars hidden).
 
 ## Colors mode
 

--- a/docs/new-features.md
+++ b/docs/new-features.md
@@ -83,6 +83,35 @@ Game Boy equivalent:
 - Collision, movement, sight lines, triggers, encounters, and scripts are
   untouched; nothing about the tilt reaches gameplay.
 
+## Dual screen
+
+The Options menu **DUAL SCREEN** row stacks the game as two Game Boy screens,
+DS-style: the overworld renders on the top screen and every UI layer,  text
+boxes, the START menu, shops, the PC, and battles,  renders on the bottom
+screen. Purely presentational, no Game Boy equivalent, persisted in
+`save.options.dualScreen` (default OFF):
+
+- The engine already draws the world pass and the UI pass into separate
+  canvases; this mode lays them out as two 160×144 screens with a small black
+  gutter between them instead of compositing the UI over the world in one
+  letterbox. The stack is centred and integer-scaled into the window exactly
+  like the single screen, so pixels stay crisp and square.
+- While an overworld state is on top, the top screen shows the live world and
+  the bottom screen shows whatever UI is open (blank during free roam). When a
+  full-screen state with no overworld beneath it is on top,  a battle, or a
+  menu opened from the title,  the top screen holds the last overworld frame,
+  frozen, while the state draws on the bottom.
+- It is mutually exclusive with the modes that reshape the single world pass:
+  survey zoom and tilt are forced off while it is on (their saved levels come
+  back when it is turned off), and the wide battle layout falls back to the
+  classic 160×144 arrangement.
+- GBC FX and post-process pipelines still apply, over both screens at the
+  stacked scale. Collision, movement, triggers, encounters, and scripts are
+  untouched; nothing about the split reaches gameplay.
+- Desktop and Android both stack the two screens inside the one window.
+  Driving them onto two separate physical displays on multi-display Android
+  hardware is a native-shell layer that is not yet wired.
+
 ## Colors mode
 
 The `2` key (and the Options menu COLORS row) cycles the display mode
@@ -215,6 +244,8 @@ migrated once into `options.lua` on load.
   `-`/`=` step one level and save
 - VOID FILL (TREES / WATER / BLACK) for OVERWORLD beyond-edge space
 - GBC FX (OFF / 1 / 2 / 3 / 4),  also hotkey `5`
+- DUAL SCREEN (OFF / ON) stacks the world and UI as two screens; see "Dual
+  screen" below (mutually exclusive with ZOOM / TILT / WIDE battle)
 - MAX FPS (30 / 40 / 50 / 60 / 75 / 90 / 100 / 120 / 144 / 160, default 60),
   a hard render frame-rate cap (`save.options.fpsCap`).
 

--- a/mobile/android/love/src/jni/love/src/common/android.cpp
+++ b/mobile/android/love/src/jni/love/src/common/android.cpp
@@ -851,4 +851,51 @@ const char *getArg0()
 } // android
 } // love
 
+extern "C" __attribute__((visibility("default")))
+int love_android_secondary_ready()
+{
+	JNIEnv *env = (JNIEnv*) SDL_AndroidGetJNIEnv();
+	jclass activity = env->FindClass("org/love2d/android/GameActivity");
+	jmethodID m = env->GetStaticMethodID(activity, "hasSecondaryDisplay", "()Z");
+	jboolean ready = JNI_FALSE;
+	if (m)
+		ready = env->CallStaticBooleanMethod(activity, m);
+	else
+		env->ExceptionClear();
+	env->DeleteLocalRef(activity);
+	return ready ? 1 : 0;
+}
+
+extern "C" __attribute__((visibility("default")))
+void love_android_push_secondary(const void *rgba, int w, int h)
+{
+	if (!rgba || w <= 0 || h <= 0)
+		return;
+	JNIEnv *env = (JNIEnv*) SDL_AndroidGetJNIEnv();
+	jclass activity = env->FindClass("org/love2d/android/GameActivity");
+	jmethodID m = env->GetStaticMethodID(activity, "updateSecondaryFrame", "(Ljava/nio/ByteBuffer;II)V");
+	if (m)
+	{
+		jobject buf = env->NewDirectByteBuffer((void*) rgba, (jlong) w * (jlong) h * 4);
+		env->CallStaticVoidMethod(activity, m, buf, w, h);
+		env->DeleteLocalRef(buf);
+	}
+	else
+		env->ExceptionClear();
+	env->DeleteLocalRef(activity);
+}
+
+extern "C" __attribute__((visibility("default")))
+void love_android_secondary_enable(int on)
+{
+	JNIEnv *env = (JNIEnv*) SDL_AndroidGetJNIEnv();
+	jclass activity = env->FindClass("org/love2d/android/GameActivity");
+	jmethodID m = env->GetStaticMethodID(activity, "setSecondaryEnabled", "(Z)V");
+	if (m)
+		env->CallStaticVoidMethod(activity, m, on ? JNI_TRUE : JNI_FALSE);
+	else
+		env->ExceptionClear();
+	env->DeleteLocalRef(activity);
+}
+
 #endif // LOVE_ANDROID

--- a/mobile/android/love/src/main/java/org/love2d/android/GameActivity.java
+++ b/mobile/android/love/src/main/java/org/love2d/android/GameActivity.java
@@ -296,12 +296,14 @@ public class GameActivity extends SDLActivity {
             Log.d("GameActivity", "Cancelling vibration");
             vibrator.cancel();
         }
+        teardownSecondaryDisplay();
         super.onPause();
     }
 
     @Override
     public void onResume() {
         super.onResume();
+        setupSecondaryDisplay();
     }
 
     /**
@@ -919,6 +921,184 @@ public class GameActivity extends SDLActivity {
             }
 
             return applicationInfo.sourceDir + "!/lib/" + abi + "/?.so";
+        }
+    }
+
+    // Dual-screen: mirror the engine's bottom-screen canvas onto a secondary
+    // physical display. Driven from the engine through love_android_secondary_*
+    // in src/jni/love/src/common/android.cpp.
+    private static volatile SecondaryPresentation secondaryPresentation;
+    private static volatile boolean secondaryEnabled = false;
+
+    @Keep
+    public static void setSecondaryEnabled(final boolean on) {
+        secondaryEnabled = on;
+        final GameActivity self = (GameActivity) mSingleton;
+        if (self == null) return;
+        self.runOnUiThread(new Runnable() {
+            @Override public void run() {
+                if (on) setupSecondaryDisplay(); else teardownSecondaryDisplay();
+            }
+        });
+    }
+
+    private static void setupSecondaryDisplay() {
+        GameActivity self = (GameActivity) mSingleton;
+        if (self == null || !secondaryEnabled || secondaryPresentation != null) return;
+        try {
+            android.hardware.display.DisplayManager dm =
+                (android.hardware.display.DisplayManager) self.getSystemService(Context.DISPLAY_SERVICE);
+            if (dm == null) return;
+            Display chosen = null;
+            for (Display d : dm.getDisplays()) {
+                android.graphics.Point size = new android.graphics.Point();
+                d.getRealSize(size);
+                Log.d("GameActivity", "display id=" + d.getDisplayId() + " name=" + d.getName()
+                    + " size=" + size.x + "x" + size.y);
+                if (chosen == null && d.getDisplayId() != Display.DEFAULT_DISPLAY) {
+                    chosen = d;
+                }
+            }
+            if (chosen == null) {
+                Display[] pres =
+                    dm.getDisplays(android.hardware.display.DisplayManager.DISPLAY_CATEGORY_PRESENTATION);
+                if (pres != null && pres.length > 0) chosen = pres[0];
+            }
+            if (chosen == null) {
+                Log.d("GameActivity", "no secondary display found");
+                return;
+            }
+            SecondaryPresentation p = new SecondaryPresentation(self, chosen);
+            p.show();
+            secondaryPresentation = p;
+            Log.d("GameActivity", "secondary display presentation started on id=" + chosen.getDisplayId());
+        } catch (Throwable t) {
+            Log.d("GameActivity", "secondary display setup failed: " + t);
+            secondaryPresentation = null;
+        }
+    }
+
+    private static void teardownSecondaryDisplay() {
+        SecondaryPresentation p = secondaryPresentation;
+        secondaryPresentation = null;
+        if (p != null) {
+            try { p.dismiss(); } catch (Throwable t) {}
+        }
+    }
+
+    @Keep
+    public static boolean hasSecondaryDisplay() {
+        return secondaryPresentation != null;
+    }
+
+    @Keep
+    public static void updateSecondaryFrame(java.nio.ByteBuffer buf, int w, int h) {
+        SecondaryPresentation p = secondaryPresentation;
+        if (p != null && buf != null && w > 0 && h > 0) {
+            p.updateFrame(buf, w, h);
+        }
+    }
+
+    private static class SecondaryPresentation extends android.app.Presentation {
+        private final FrameView frameView;
+
+        SecondaryPresentation(Context context, Display display) {
+            super(context, display);
+            frameView = new FrameView(context);
+        }
+
+        @Override
+        protected void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            android.view.Window w = getWindow();
+            if (w != null) {
+                w.setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN
+                    | WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+                    WindowManager.LayoutParams.FLAG_FULLSCREEN
+                    | WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
+                w.setLayout(WindowManager.LayoutParams.MATCH_PARENT,
+                    WindowManager.LayoutParams.MATCH_PARENT);
+            }
+            setContentView(frameView);
+            applyImmersive();
+            frameView.post(new Runnable() {
+                @Override public void run() { applyImmersive(); }
+            });
+        }
+
+        @Override
+        public void onWindowFocusChanged(boolean hasFocus) {
+            super.onWindowFocusChanged(hasFocus);
+            if (hasFocus) applyImmersive();
+        }
+
+        private void applyImmersive() {
+            android.view.Window w = getWindow();
+            if (w == null) return;
+            if (android.os.Build.VERSION.SDK_INT >= 30) {
+                w.setDecorFitsSystemWindows(false);
+                android.view.WindowInsetsController c = w.getInsetsController();
+                if (c != null) {
+                    c.hide(android.view.WindowInsets.Type.systemBars());
+                    c.setSystemBarsBehavior(
+                        android.view.WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+                }
+            } else {
+                w.getDecorView().setSystemUiVisibility(
+                    android.view.View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                    | android.view.View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                    | android.view.View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                    | android.view.View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                    | android.view.View.SYSTEM_UI_FLAG_FULLSCREEN
+                    | android.view.View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+            }
+        }
+
+        void updateFrame(java.nio.ByteBuffer buf, int w, int h) {
+            frameView.updateFrame(buf, w, h);
+        }
+    }
+
+    private static class FrameView extends View {
+        private android.graphics.Bitmap bitmap;
+        private final android.graphics.Rect dst = new android.graphics.Rect();
+        private final android.graphics.Paint paint = new android.graphics.Paint();
+        private final Object lock = new Object();
+        private int fw, fh;
+
+        FrameView(Context context) {
+            super(context);
+            paint.setFilterBitmap(false);
+            paint.setAntiAlias(false);
+            setBackgroundColor(0xFF000000);
+        }
+
+        void updateFrame(java.nio.ByteBuffer buf, int w, int h) {
+            synchronized (lock) {
+                if (bitmap == null || fw != w || fh != h) {
+                    if (bitmap != null) bitmap.recycle();
+                    bitmap = android.graphics.Bitmap.createBitmap(w, h, android.graphics.Bitmap.Config.ARGB_8888);
+                    fw = w; fh = h;
+                }
+                buf.rewind();
+                bitmap.copyPixelsFromBuffer(buf);
+            }
+            postInvalidate();
+        }
+
+        @Override
+        protected void onDraw(android.graphics.Canvas canvas) {
+            synchronized (lock) {
+                if (bitmap == null || fw == 0 || fh == 0) return;
+                int vw = getWidth(), vh = getHeight();
+                int s = Math.min(vw / fw, vh / fh);
+                if (s < 1) s = 1;
+                int dw = fw * s, dh = fh * s;
+                int dx = (vw - dw) / 2, dy = (vh - dh) / 2;
+                dst.set(dx, dy, dx + dw, dy + dh);
+                canvas.drawColor(0xFF000000);
+                canvas.drawBitmap(bitmap, null, dst, paint);
+            }
         }
     }
 }

--- a/src/battle/BattleState.lua
+++ b/src/battle/BattleState.lua
@@ -32,6 +32,7 @@ local WideBattle = require("src.battle.WideBattle")
 local BattleState = {}
 BattleState.__index = BattleState
 BattleState.isOpaque = true
+BattleState.isBattleScreen = true
 -- Letterbox voids around the 160x144 battle canvas fill white so the
 -- window reads as one continuous battle screen (no black bars).
 BattleState.letterboxWhite = true

--- a/src/battle/BattleState.lua
+++ b/src/battle/BattleState.lua
@@ -28,6 +28,7 @@ local TurnOrder = require("src.battle.TurnOrder")
 local TypeChart = require("src.battle.TypeChart")
 local Strings = require("src.core.Strings")
 local WideBattle = require("src.battle.WideBattle")
+local DualBattle = require("src.battle.DualBattle")
 
 local BattleState = {}
 BattleState.__index = BattleState
@@ -52,9 +53,17 @@ function BattleState:wideLayout()
   return self:isWideBattleLayout()
 end
 
+-- DUAL SCREEN: field on the top screen, menu on the bottom, over a 160x288
+-- surface (src/battle/DualBattle.lua). Mutually exclusive with wide, which
+-- isWideBattleLayout already forces off while dual screen is on.
+function BattleState:dualLayout()
+  return require("src.render.DualScreen").active()
+end
+
 -- Renderer:setUISize asks the top state for its surface before anything draws
 function BattleState:uiSize()
   if self:wideLayout() then return WideBattle.WIDTH, WideBattle.HEIGHT end
+  if self:dualLayout() then return DualBattle.WIDTH, DualBattle.HEIGHT end
   return 160, 144
 end
 
@@ -64,6 +73,7 @@ end
 -- extra columns unremapped in the forced-mono modes (WideBattle.zones).
 function BattleState:sgbPalettes()
   if self:wideLayout() then return WideBattle.zones() end
+  if self:dualLayout() then return DualBattle.zones() end
   return nil
 end
 
@@ -5052,6 +5062,7 @@ end
 
 function BattleState:draw()
   if self:wideLayout() then return WideBattle.draw(self) end
+  if self:dualLayout() then return DualBattle.draw(self) end
   return self:drawClassic()
 end
 

--- a/src/battle/BattleState.lua
+++ b/src/battle/BattleState.lua
@@ -42,6 +42,7 @@ BattleState.letterboxWhite = true
 -- prompts pushed during a wide battle keep its wide canvas, while drawing
 -- their classic 160px UI centred within it (Game:draw).
 function BattleState:isWideBattleLayout()
+  if require("src.render.DualScreen").active() then return false end
   local options = self.game and self.game.save and self.game.save.options
   return options and options.battleLayout == "wide" or false
 end

--- a/src/battle/DualBattle.lua
+++ b/src/battle/DualBattle.lua
@@ -1,0 +1,131 @@
+-- Dual-screen battle layout (DUAL SCREEN on).
+--
+-- The battle simulation, animations, HUDs, pics and menus stay BattleState's:
+-- this module only re-composes them onto a 160x288 surface -- two stacked
+-- Game Boy screens. The field (both mons + both HUDs) is spread across the
+-- TOP screen with the enemy high and the player at the foot; the message /
+-- command / move window owns the BOTTOM screen. Each element is drawn once,
+-- per side, at its own DS anchor (never sliced out of a composite), so a
+-- send-out or attack animation that crosses the field is not torn in two.
+-- Renderer splits the 288 surface at its midpoint (144) so each half fills an
+-- equal screen.
+
+local PaletteFX = require("src.render.PaletteFX")
+
+local DualBattle = {
+  WIDTH = 160,
+  HEIGHT = 288,
+  SCREEN = 144,        -- one Game Boy screen; the split midpoint
+}
+
+-- how far each side's classic 160x144 coordinates shift on the top screen:
+-- the enemy sits near the top, the player is pushed to the foot so the pair
+-- fills the screen rather than huddling in the middle
+local ENEMY_DY = 4
+local PLAYER_DY = 48
+-- the message/menu block (classic rows 96-144) dropped onto the bottom screen
+local MENU_DY = DualBattle.SCREEN
+
+-- Draw `fn`'s classic-coordinate content translated by (0, dy) and clipped to
+-- surface rows [y, y+h). The scissor bounds the band; the translate slides the
+-- classic 160x144 coordinates into it.
+local function inRegion(y, h, dy, fn)
+  local g = love.graphics
+  local x0, y0, w0, h0
+  if g.getScissor then x0, y0, w0, h0 = g.getScissor() end
+  g.setScissor(0, y, DualBattle.WIDTH, h)
+  g.push()
+  g.translate(0, dy)
+  fn()
+  g.pop()
+  if x0 then g.setScissor(x0, y0, w0, h0) else g.setScissor() end
+end
+
+-- The animation layer is authored in the classic 160x144 field; shift it to
+-- the anchor of the side it plays on -- enemy effects stay high, player
+-- effects drop to the foot with the player pic -- so a hit flash, status
+-- animation or send-out lands on its mon instead of the classic position
+-- (mirrors WideBattle.animationOffset, vertical instead of horizontal).
+local function animOffsetY(battle)
+  local sprites
+  if battle.animPlaying and battle.animPlayer then
+    local step = battle.animPlayer.steps[battle.animPlayer.stepIndex]
+    sprites = step and step.sprites
+  elseif battle.lockedBall then
+    sprites = battle.lockedBall
+  end
+  if not sprites or #sprites == 0 then return 0 end
+  local minX, maxX = math.huge, -math.huge
+  for _, s in ipairs(sprites) do
+    minX = math.min(minX, s.x - 8)
+    maxX = math.max(maxX, s.x)
+  end
+  -- snap to the nearer side rather than blend: a cross-field dash would
+  -- otherwise drift vertically as its sprites' center crosses the field
+  local t = (maxX + minX) / 2
+  return (t < 80) and PLAYER_DY or ENEMY_DY
+end
+
+function DualBattle.draw(battle)
+  local g = love.graphics
+
+  -- both screens are the field's paper, so the space the mons stand in and
+  -- the room around the menu read as one battlefield, not black bars
+  local m = PaletteFX.mode
+  if m == "og" or m == "og_inv" or m == "classic" then
+    g.setColor(1, 1, 1, 1)
+  else
+    g.setColor(PaletteFX.paperShade(battle.data))
+  end
+  g.rectangle("fill", 0, 0, DualBattle.WIDTH, DualBattle.HEIGHT)
+  g.setColor(1, 1, 1, 1)
+
+  if battle.blankForAskName then
+    return
+  end
+
+  local slide = (battle.introSlide or 0) * 4
+
+  -- side windows are their own clip, like the wide layout, so a pic is not
+  -- trimmed to the classic move-menu rows
+  battle.wideRegion = true
+  -- TOP SCREEN: enemy high, player at the foot -- each pic drawn once
+  battle:drawPicsLayer(slide, 0, ENEMY_DY, "enemy", true)
+  battle:drawPicsLayer(slide, 0, PLAYER_DY, "player", true)
+  battle.wideRegion = nil
+
+  -- The two HUDs ride with their sides: the enemy's classic block (rows 0-48)
+  -- stays up top, the player's (rows 56-96) drops to the foot with its pic.
+  -- Shadow colorMode off for the draw so drawHPBar tints its own green/red
+  -- fill: the classic path leaves it gray for the zone pass (#229), but this
+  -- surface opts out of that pass, so nothing would recolor it.
+  local realColorMode = battle.colorMode
+  battle.colorMode = function() return false end
+  inRegion(ENEMY_DY, 56, ENEMY_DY, function() battle:drawHUDs(slide) end)
+  inRegion(56 + PLAYER_DY, DualBattle.SCREEN - (56 + PLAYER_DY), PLAYER_DY,
+           function() battle:drawHUDs(slide) end)
+  battle.colorMode = realColorMode
+
+  -- the field FX / send-out / attack animation, shifted to the side it plays
+  -- on; false so it tints its own colors (the surface opts out of the zone pass)
+  local ady = animOffsetY(battle)
+  inRegion(0, DualBattle.SCREEN, ady, function() battle:drawAnimLayer(false) end)
+
+  -- BOTTOM SCREEN: the message / command / move window (classic rows 96-144)
+  inRegion(MENU_DY, DualBattle.SCREEN, MENU_DY, function() battle:drawTextArea() end)
+end
+
+-- The pics and HUDs resolve their own species / paper / HP-bar colors, so the
+-- colorized modes take the trueColor opt-out over the whole surface; the
+-- forced-mono modes remap the finished frame and want a whole-surface gray
+-- zone (like WideBattle.zones).
+function DualBattle.zones()
+  local w, h = DualBattle.WIDTH, DualBattle.HEIGHT
+  local m = PaletteFX.mode
+  if m == "og" or m == "og_inv" or m == "classic" then
+    return { PaletteFX.zone(PaletteFX.GRAYS, 0, 0, w / 8 - 1, h / 8 - 1) }
+  end
+  return { { colors = false, x = 0, y = 0, w = w, h = h } }
+end
+
+return DualBattle

--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -627,6 +627,15 @@ function Game:applyOptions(opts)
   -- just restored back off (the two are mutually exclusive)
   require("src.render.Pipelines").applyOptions(opts)
   require("src.render.Zoom").applyOptions(opts)
+  local DualScreen = require("src.render.DualScreen")
+  DualScreen.applyOptions(opts)
+  if DualScreen.active() then
+    require("src.render.Tilt").setLevel(0)
+    local Pipelines = require("src.render.Pipelines")
+    for _, entry in ipairs(Pipelines.list()) do
+      if entry.def.drawWorld then Pipelines.setLevel(entry.id, 0) end
+    end
+  end
   require("src.render.TileRenderer").applyOptions(opts)
   -- returns true when a persisted GBC FX level was cleared on mobile
   local gbcCleared = require("src.render.GBCFX").applyOptions(opts)

--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -630,11 +630,9 @@ function Game:applyOptions(opts)
   local DualScreen = require("src.render.DualScreen")
   DualScreen.applyOptions(opts)
   if DualScreen.active() then
+    -- tilt reshapes the one world pass and cannot survive the split; a
+    -- drawWorld pipeline produces the whole top-screen image, so it stays on
     require("src.render.Tilt").setLevel(0)
-    local Pipelines = require("src.render.Pipelines")
-    for _, entry in ipairs(Pipelines.list()) do
-      if entry.def.drawWorld then Pipelines.setLevel(entry.id, 0) end
-    end
   end
   require("src.render.SecondScreen").setEnabled(DualScreen.active())
   require("src.render.TileRenderer").applyOptions(opts)

--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -636,6 +636,7 @@ function Game:applyOptions(opts)
       if entry.def.drawWorld then Pipelines.setLevel(entry.id, 0) end
     end
   end
+  require("src.render.SecondScreen").setEnabled(DualScreen.active())
   require("src.render.TileRenderer").applyOptions(opts)
   -- returns true when a persisted GBC FX level was cleared on mobile
   local gbcCleared = require("src.render.GBCFX").applyOptions(opts)

--- a/src/core/SaveData.lua
+++ b/src/core/SaveData.lua
@@ -235,6 +235,8 @@ function SaveData.defaultOptions()
     gbcfx = 0,
     -- survey zoom offset from window fit scale (0 = FIT); see Zoom.lua
     zoom = 0,
+    -- stack world (top) + UI (bottom) as two GB screens; see DualScreen.lua
+    dualScreen = false,
     -- OVERWORLD beyond-edge fill: trees | water | black
     voidFill = "trees",
     -- windowed | borderless (desktop fullscreen); ignored on mobile

--- a/src/render/DualScreen.lua
+++ b/src/render/DualScreen.lua
@@ -1,0 +1,78 @@
+-- Stacks the world pass (top) and UI pass (bottom) as two Game Boy screens
+-- instead of compositing UI over world in one letterbox. Persisted as
+-- save.options.dualScreen; mutually exclusive with survey zoom, tilt and the
+-- wide battle layout. regions() returns framebuffer pixels, layout() LOVE units.
+
+local DualScreen = {}
+
+DualScreen.enabled = false
+DualScreen.GAP = 8
+
+function DualScreen.active()
+  return DualScreen.enabled
+end
+
+function DualScreen.setEnabled(on)
+  DualScreen.enabled = on and true or false
+  return DualScreen.enabled
+end
+
+function DualScreen.toggle()
+  return DualScreen.setEnabled(not DualScreen.enabled)
+end
+
+function DualScreen.applyOptions(opts)
+  DualScreen.enabled = (opts and opts.dualScreen) and true or false
+end
+
+function DualScreen.label()
+  return DualScreen.enabled and "ON" or "OFF"
+end
+
+function DualScreen.surfaceSize(w, h)
+  w = w or 160
+  h = h or 144
+  return w, h * 2 + DualScreen.GAP
+end
+
+function DualScreen.regions(pw, ph, w, h)
+  w = w or 160
+  h = h or 144
+  local surfW, surfH = DualScreen.surfaceSize(w, h)
+  local scale = math.max(1, math.floor(math.min(pw / surfW, ph / surfH)))
+  local boxW = w * scale
+  local boxH = h * scale
+  local gap = DualScreen.GAP * scale
+  local ox = math.floor((pw - boxW) / 2)
+  local top = math.floor((ph - (boxH * 2 + gap)) / 2)
+  local world = { ox = ox, oy = top, w = boxW, h = boxH }
+  local ui = { ox = ox, oy = top + boxH + gap, w = boxW, h = boxH }
+  return scale, world, ui
+end
+
+function DualScreen.layout(pw, ph, dpiX, dpiY, w, h)
+  dpiX = dpiX or 1
+  dpiY = dpiY or 1
+  local scale, worldPx, uiPx = DualScreen.regions(pw, ph, w, h)
+  local sx, sy = scale / dpiX, scale / dpiY
+  local function toUnits(r)
+    return {
+      ox = r.ox / dpiX, oy = r.oy / dpiY,
+      w = r.w / dpiX, h = r.h / dpiY,
+      sx = sx, sy = sy,
+    }
+  end
+  return scale, toUnits(worldPx), toUnits(uiPx)
+end
+
+function DualScreen.screenAt(px, py, pw, ph, w, h)
+  local _, world, ui = DualScreen.regions(pw, ph, w, h)
+  local function inside(r)
+    return px >= r.ox and px < r.ox + r.w and py >= r.oy and py < r.oy + r.h
+  end
+  if inside(world) then return "world" end
+  if inside(ui) then return "ui" end
+  return nil
+end
+
+return DualScreen

--- a/src/render/DualScreen.lua
+++ b/src/render/DualScreen.lua
@@ -75,4 +75,22 @@ function DualScreen.screenAt(px, py, pw, ph, w, h)
   return nil
 end
 
+-- battleTop keys off the visible base (topmost opaque state), so a non-opaque
+-- overlay above a live battle keeps the split while bag/party (opaque) drops it.
+function DualScreen.battleMode(states)
+  local battle, battleTop = false, false
+  if type(states) == "table" and #states > 0 then
+    local base = 1
+    for i = #states, 1, -1 do
+      if states[i].isOpaque then base = i break end
+    end
+    local baseState = states[base]
+    battleTop = baseState and baseState.isBattleScreen and true or false
+    for i = #states, 1, -1 do
+      if states[i].isBattleScreen then battle = true break end
+    end
+  end
+  return battle, battleTop
+end
+
 return DualScreen

--- a/src/render/Renderer.lua
+++ b/src/render/Renderer.lua
@@ -11,6 +11,7 @@ local Tilt = require("src.render.Tilt")
 local PaletteFX = require("src.render.PaletteFX")
 local Pipelines = require("src.render.Pipelines")
 local PixelCanvas = require("src.render.PixelCanvas")
+local DualScreen = require("src.render.DualScreen")
 local Runtime = require("src.mods.Runtime")
 
 local Renderer = {}
@@ -178,6 +179,10 @@ end
 -- corners; flat mode returns exactly today's size (growth factor is 1 when
 -- tilt is inactive).
 function Renderer:worldViewSize()
+  -- Dual-screen shows a clean 160x144 world in the top screen; survey zoom's
+  -- window-filling view is off in this mode (they both reshape the one world
+  -- pass), so the world canvas is exactly one Game Boy screen.
+  if DualScreen.active() then return self.WIDTH, self.HEIGHT end
   local _, _, pw, ph = displayMetrics()
   local sp = Zoom.scale(self:fitScale())
   local vw, vh = math.ceil(pw / sp), math.ceil(ph / sp)
@@ -268,7 +273,13 @@ function Renderer:beginWorldPass()
     -- free the old canvas before replacing it: a zoom/tilt tween changes
     -- the view size every frame, so without this the superseded canvases
     -- pile up in VRAM until a GC finalizer happens to run
-    if self.worldCanvas and self.worldCanvas.release then self.worldCanvas:release() end
+    if self.worldCanvas and self.worldCanvas.release then
+      if self.lastWorldCanvas == self.worldCanvas then
+        self.lastWorldCanvas = nil
+        self.lastWorldZones = nil
+      end
+      self.worldCanvas:release()
+    end
     self.worldCanvas = PixelCanvas.new(vw, vh, "nearest")
   end
   self.worldActive = true
@@ -488,6 +499,7 @@ function Renderer:endFrame(zones, worldZones)
   -- Sp = integer framebuffer pixels per GB pixel;
   -- Sx/Sy = LOVE-unit draw scales (may differ when dpiX ≠ dpiY).
   local Sp = self:fitScale()
+  local composeScale = Sp
   local Sx, Sy = Sp / dpiX, Sp / dpiY
   local uiw, uih = self:uiSize()
   local vpw, vph = uiw * Sx, uih * Sy
@@ -536,7 +548,7 @@ function Renderer:endFrame(zones, worldZones)
   -- is the pack's off-white (255,239,255), which a hardcoded 1,1,1 framed in
   -- a visibly brighter border.
   local clearR, clearG, clearB = 0, 0, 0
-  if not self.worldActive then
+  if not self.worldActive and not DualScreen.active() then
     local ok, Game = pcall(require, "src.core.Game")
     local stack = ok and Game and Game.stack
     local base = stack and stack.visibleBase and stack:visibleBase()
@@ -551,7 +563,7 @@ function Renderer:endFrame(zones, worldZones)
   -- render.letterbox: SGB borders / custom void art in the bars around the
   -- 160x144 (or world) blit.  Drawn after the clear and before the game
   -- canvas so the playfield sits on top of the border.
-  if Runtime.wantsHook("render.letterbox") then
+  if Runtime.wantsHook("render.letterbox") and not DualScreen.active() then
     Runtime.call("render.letterbox", function() end, {
       ww = ww, wh = wh, pw = pw, ph = ph,
       ox = ox, oy = oy, vpw = vpw, vph = vph,
@@ -594,6 +606,21 @@ function Renderer:endFrame(zones, worldZones)
     love.graphics.setShader()
   end
 
+  if DualScreen.active() then
+    local scale, wr, ur = DualScreen.layout(pw, ph, dpiX, dpiY, self.WIDTH, self.HEIGHT)
+    composeScale = scale
+    local wc = self.worldActive and self.worldCanvas or self.lastWorldCanvas
+    local wz = self.worldActive and worldZones or self.lastWorldZones
+    if wc then
+      blit(wc, wr.sx, wr.sy, wz, wr.sx, wr.sy, wr.ox, wr.oy, wr.ox, wr.oy, wr.w, wr.h)
+    end
+    blit(self.canvas, ur.sx, ur.sy, zones, ur.sx, ur.sy,
+         ur.ox, ur.oy, ur.ox, ur.oy, ur.w, ur.h)
+    if self.worldActive then
+      self.lastWorldCanvas = self.worldCanvas
+      self.lastWorldZones = worldZones
+    end
+  else
   if self.worldOverride then
     -- A render pipeline already produced the whole world -- terrain,
     -- characters and its own FX overlay -- as one window-resolution image,
@@ -696,6 +723,7 @@ function Renderer:endFrame(zones, worldZones)
   end
   -- UI stays in the classic centered GB letterbox
   blit(self.canvas, Sx, Sy, zones, Sx, Sy, ox, oy, ox, oy, vpw, vph)
+  end
 
   if present then
     love.graphics.setCanvas()
@@ -705,10 +733,10 @@ function Renderer:endFrame(zones, worldZones)
     -- grid itself.  Each pass hands back a canvas; with none registered
     -- this returns `present` unchanged and the frame is byte-identical.
     local composed = Pipelines.present(present,
-      { width = ww, height = wh, scale = Sp, dpi = dpiY, dpiX = dpiX, dpiY = dpiY }) or present
+      { width = ww, height = wh, scale = composeScale, dpi = dpiY, dpiX = dpiX, dpiY = dpiY }) or present
     if GBCFX.active() then
       -- shader grid/shadow math is in framebuffer pixels
-      GBCFX.present(composed, Sp)
+      GBCFX.present(composed, composeScale)
     else
       -- the present canvas only existed for the post-process, so put the
       -- result on the screen at the same 1:1 unit mapping it was built at

--- a/src/render/Renderer.lua
+++ b/src/render/Renderer.lua
@@ -613,76 +613,82 @@ function Renderer:endFrame(zones, worldZones)
     local wz = self.worldActive and worldZones or self.lastWorldZones
     local wox, woy, wvpw, wvph, wsx, wsy
     local physical = SecondScreen.available()
-    local battle, battleTop = false, false
+    -- A dual-screen battle hands over a 160x288 surface: two stacked Game
+    -- Boy screens, the field on top and the message/menu below
+    -- (src/battle/DualBattle.lua). Every other state is one 160x144 screen
+    -- with the world pass above it.
+    local dsBattle = self.canvas:getHeight() >= self.HEIGHT * 2
+    -- Whether a battle sits anywhere in the stack. An opaque menu opened over
+    -- it (BAG, PARTY) collapses the surface to 160x144, but the fight must
+    -- stay on the top screen while that menu owns the bottom.
+    local battleInStack = false
     do
       local ok, G = pcall(require, "src.core.Game")
-      local stack = ok and G and G.stack
-      if stack and stack.states then
-        battle, battleTop = DualScreen.battleMode(stack.states)
+      local st = ok and G and G.stack and G.stack.states
+      if st then
+        for i = #st, 1, -1 do
+          if st[i].isBattleScreen then battleInStack = true break end
+        end
       end
     end
-    if battle then
-      local cw, ch = self.canvas:getWidth(), self.canvas:getHeight()
-      if not self.battleComposite or self.battleComposite:getWidth() ~= cw
-         or self.battleComposite:getHeight() ~= ch then
-        if self.battleComposite and self.battleComposite.release then self.battleComposite:release() end
-        self.battleComposite = PixelCanvas.new(cw, ch, "nearest")
+    -- Draw one Game Boy screen's worth of the (already colorized) UI canvas
+    -- -- source rows [qy, qy+HEIGHT) -- filling a screen region.
+    local function screenBlit(qy, r)
+      love.graphics.setColor(1, 1, 1, 1)
+      love.graphics.setScissor(r.ox, r.oy, r.w, r.h)
+      love.graphics.draw(self.canvas,
+        love.graphics.newQuad(0, qy, self.canvas:getWidth(), self.HEIGHT,
+                              self.canvas:getDimensions()),
+        r.ox, r.oy, 0, r.sx, r.sy)
+      love.graphics.setScissor()
+    end
+    -- Stash the battle field (the top screen) so an overlay that collapses
+    -- the 288 surface can keep the fight up top while it takes the bottom.
+    local function stashField()
+      if not self.dsField or self.dsField:getWidth() ~= self.WIDTH
+         or self.dsField:getHeight() ~= self.HEIGHT then
+        if self.dsField and self.dsField.release then self.dsField:release() end
+        self.dsField = PixelCanvas.new(self.WIDTH, self.HEIGHT, "nearest")
       end
-      love.graphics.setCanvas(self.battleComposite)
+      local prevC = love.graphics.getCanvas()
+      love.graphics.setCanvas(self.dsField)
       love.graphics.clear(0, 0, 0, 0)
       love.graphics.setColor(1, 1, 1, 1)
-      blit(self.canvas, 1, 1, zones, 1, 1, 0, 0, 0, 0, cw, ch)
-      love.graphics.setCanvas(present)
-      local SPLIT = 96
-      local topSrc, tqy, tqh, botSrc, bqy, bqh
-      if battleTop then
-        if not self.battleField or self.battleField:getWidth() ~= cw
-           or self.battleField:getHeight() ~= SPLIT then
-          if self.battleField and self.battleField.release then self.battleField:release() end
-          self.battleField = PixelCanvas.new(cw, SPLIT, "nearest")
-        end
-        love.graphics.setCanvas(self.battleField)
-        love.graphics.clear(0, 0, 0, 0)
-        love.graphics.setColor(1, 1, 1, 1)
-        love.graphics.draw(self.battleComposite,
-          love.graphics.newQuad(0, 0, cw, SPLIT, cw, ch), 0, 0)
-        love.graphics.setCanvas(present)
-        topSrc, tqy, tqh = self.battleComposite, 0, SPLIT
-        botSrc, bqy, bqh = self.battleComposite, SPLIT, ch - SPLIT
-      else
-        topSrc, tqy, tqh = self.battleField, 0, SPLIT
-        botSrc, bqy, bqh = self.battleComposite, 0, ch
-      end
-      local function strip(src, qy, qh, rox, roy, rw, rh, rsx, rsy)
-        if not src then return end
-        local q = love.graphics.newQuad(0, qy, src:getWidth(), qh, src:getDimensions())
-        local dy = roy + (rh - qh * rsy) / 2
-        love.graphics.setColor(1, 1, 1, 1)
-        love.graphics.setScissor(rox, roy, rw, rh)
-        love.graphics.draw(src, q, rox, dy, 0, rsx, rsy)
-        love.graphics.setScissor()
-      end
-      if physical then
-        wox, woy, wvpw, wvph, wsx, wsy = ox, oy, vpw, vph, Sx, Sy
-        strip(topSrc, tqy, tqh, ox, oy, vpw, vph, Sx, Sy)
-        if botSrc then
-          local ok, id = pcall(function()
-            return botSrc:newImageData(1, 1, 0, bqy, botSrc:getWidth(), bqh)
-          end)
-          if ok and id then self.pushImage = id end
-        end
-        self.pushSecondary = false
-      else
-        local scale, wr, ur = DualScreen.layout(pw, ph, dpiX, dpiY, self.WIDTH, self.HEIGHT)
-        composeScale = scale
-        wox, woy, wvpw, wvph, wsx, wsy = wr.ox, wr.oy, wr.w, wr.h, wr.sx, wr.sy
-        strip(topSrc, tqy, tqh, wr.ox, wr.oy, wr.w, wr.h, wr.sx, wr.sy)
-        strip(botSrc, bqy, bqh, ur.ox, ur.oy, ur.w, ur.h, ur.sx, ur.sy)
-        self.pushSecondary = false
-      end
+      love.graphics.draw(self.canvas, love.graphics.newQuad(0, 0, self.WIDTH,
+        self.HEIGHT, self.canvas:getDimensions()), 0, 0)
+      love.graphics.setCanvas(prevC)
+    end
+    -- Blit the frozen field into a top-screen region; false when none stashed.
+    local function fieldBlit(r)
+      if not self.dsField then return false end
+      love.graphics.setColor(1, 1, 1, 1)
+      love.graphics.setScissor(r.ox, r.oy, r.w, r.h)
+      love.graphics.draw(self.dsField, r.ox, r.oy, 0, r.sx, r.sy)
+      love.graphics.setScissor()
+      return true
+    end
+    if dsBattle and physical then
+      wox, woy, wvpw, wvph, wsx, wsy = ox, oy, vpw, vph, Sx, Sy
+      screenBlit(0, { ox = ox, oy = oy, w = vpw, h = vph, sx = Sx, sy = Sy })
+      stashField()
+      local okid, id = pcall(function()
+        return self.canvas:newImageData(1, 1, 0, self.HEIGHT,
+                                        self.canvas:getWidth(), self.HEIGHT)
+      end)
+      if okid and id then self.pushImage = id end
+      self.pushSecondary = false
+    elseif dsBattle then
+      local scale, wr, ur = DualScreen.layout(pw, ph, dpiX, dpiY, self.WIDTH, self.HEIGHT)
+      composeScale = scale
+      wox, woy, wvpw, wvph, wsx, wsy = wr.ox, wr.oy, wr.w, wr.h, wr.sx, wr.sy
+      screenBlit(0, wr)              -- top screen: the field
+      screenBlit(self.HEIGHT, ur)    -- bottom screen: the message/menu
+      stashField()
+      self.pushSecondary = false
     elseif physical then
       wox, woy, wvpw, wvph, wsx, wsy = ox, oy, vpw, vph, Sx, Sy
-      if wc then
+      local top = { ox = ox, oy = oy, w = vpw, h = vph, sx = Sx, sy = Sy }
+      if not (battleInStack and fieldBlit(top)) and wc then
         blit(wc, wsx, wsy, wz, wsx, wsy, wox, woy, wox, woy, wvpw, wvph)
       end
       self.pushSecondary = true
@@ -693,7 +699,7 @@ function Renderer:endFrame(zones, worldZones)
       local scale, wr, ur = DualScreen.layout(pw, ph, dpiX, dpiY, self.WIDTH, self.HEIGHT)
       composeScale = scale
       wox, woy, wvpw, wvph, wsx, wsy = wr.ox, wr.oy, wr.w, wr.h, wr.sx, wr.sy
-      if wc then
+      if not (battleInStack and fieldBlit(wr)) and wc then
         blit(wc, wsx, wsy, wz, wsx, wsy, wr.ox, wr.oy, wr.ox, wr.oy, wr.w, wr.h)
       end
       blit(self.canvas, ur.sx, ur.sy, zones, ur.sx, ur.sy,
@@ -704,14 +710,12 @@ function Renderer:endFrame(zones, worldZones)
       self.lastWorldCanvas = self.worldCanvas
       self.lastWorldZones = worldZones
     end
-    -- Voxel/diorama on the top screen: a drawWorld pipeline hands back the
-    -- whole world image (worldOverride), which replaces the flat top-screen
-    -- blit above. Held at the last frame under a battle (worldActive off), so
-    -- the top screen keeps the diorama the fight was called from. Fit and
-    -- centred, so a full-window image pillarboxes rather than stretches.
+    -- Voxel/diorama on the top screen (free-roam only; a dual-screen battle
+    -- owns both screens itself). Held at the last frame while worldActive is
+    -- off, so the top screen keeps the diorama the fight was called from.
     if self.worldActive then self.lastWorldOverride = self.worldOverride end
     local wov = self.worldActive and self.worldOverride or self.lastWorldOverride
-    if wov and not battle then
+    if wov and not dsBattle and not battleInStack then
       -- a held override can be released underneath us (Voxel3D drops its
       -- canvas on a resize / DS-region size change), so drawing it is fenced:
       -- a dangling reference blanks the top screen for a frame, never crashes.
@@ -719,8 +723,6 @@ function Renderer:endFrame(zones, worldZones)
         local ovw, ovh = wov:getWidth(), wov:getHeight()
         local sc = math.min(wvpw / ovw, wvph / ovh)
         love.graphics.setScissor(wox, woy, wvpw, wvph)
-        -- black under the fit, so a pillarboxed image shows bars rather than
-        -- the flat world blitted a moment ago in this same region
         love.graphics.setColor(0, 0, 0, 1)
         love.graphics.rectangle("fill", wox, woy, wvpw, wvph)
         love.graphics.setColor(1, 1, 1, 1)

--- a/src/render/Renderer.lua
+++ b/src/render/Renderer.lua
@@ -12,6 +12,7 @@ local PaletteFX = require("src.render.PaletteFX")
 local Pipelines = require("src.render.Pipelines")
 local PixelCanvas = require("src.render.PixelCanvas")
 local DualScreen = require("src.render.DualScreen")
+local SecondScreen = require("src.render.SecondScreen")
 local Runtime = require("src.mods.Runtime")
 
 local Renderer = {}
@@ -199,6 +200,7 @@ end
 
 -- transparent: the world pass shows through (UI pass draws overlays only)
 function Renderer:beginFrame(transparent)
+  self.worldFlashAlpha = nil
   self.worldActive = false
   self.uprightActive = false
   self.worldOverride = nil
@@ -607,18 +609,44 @@ function Renderer:endFrame(zones, worldZones)
   end
 
   if DualScreen.active() then
-    local scale, wr, ur = DualScreen.layout(pw, ph, dpiX, dpiY, self.WIDTH, self.HEIGHT)
-    composeScale = scale
     local wc = self.worldActive and self.worldCanvas or self.lastWorldCanvas
     local wz = self.worldActive and worldZones or self.lastWorldZones
-    if wc then
-      blit(wc, wr.sx, wr.sy, wz, wr.sx, wr.sy, wr.ox, wr.oy, wr.ox, wr.oy, wr.w, wr.h)
+    local wox, woy, wvpw, wvph, wsx, wsy
+    if SecondScreen.available() then
+      wox, woy, wvpw, wvph, wsx, wsy = ox, oy, vpw, vph, Sx, Sy
+      if wc then
+        blit(wc, wsx, wsy, wz, wsx, wsy, wox, woy, wox, woy, wvpw, wvph)
+      end
+      self.pushSecondary = true
+      if self.battleCascadeProg then
+        self:drawBattleCascade(self.battleCascadeProg, ww, wh, wox, woy, wvpw, wvph, wsx, wsy)
+      end
+    else
+      local scale, wr, ur = DualScreen.layout(pw, ph, dpiX, dpiY, self.WIDTH, self.HEIGHT)
+      composeScale = scale
+      wox, woy, wvpw, wvph, wsx, wsy = wr.ox, wr.oy, wr.w, wr.h, wr.sx, wr.sy
+      if wc then
+        blit(wc, wsx, wsy, wz, wsx, wsy, wox, woy, wox, woy, wvpw, wvph)
+      end
+      blit(self.canvas, ur.sx, ur.sy, zones, ur.sx, ur.sy,
+           ur.ox, ur.oy, ur.ox, ur.oy, ur.w, ur.h)
+      self.pushSecondary = false
     end
-    blit(self.canvas, ur.sx, ur.sy, zones, ur.sx, ur.sy,
-         ur.ox, ur.oy, ur.ox, ur.oy, ur.w, ur.h)
     if self.worldActive then
       self.lastWorldCanvas = self.worldCanvas
       self.lastWorldZones = worldZones
+    end
+    local fade = self.worldFadeAlpha
+    if fade and fade > 0 then
+      love.graphics.setColor(0, 0, 0, fade)
+      love.graphics.rectangle("fill", wox, woy, wvpw, wvph)
+      love.graphics.setColor(1, 1, 1, 1)
+    end
+    local flash = self.worldFlashAlpha
+    if flash and flash > 0 then
+      love.graphics.setColor(1, 1, 1, flash)
+      love.graphics.rectangle("fill", wox, woy, wvpw, wvph)
+      love.graphics.setColor(1, 1, 1, 1)
     end
   else
   if self.worldOverride then
@@ -742,6 +770,25 @@ function Renderer:endFrame(zones, worldZones)
       -- result on the screen at the same 1:1 unit mapping it was built at
       love.graphics.setColor(1, 1, 1, 1)
       love.graphics.draw(composed, 0, 0)
+    end
+  end
+  if self.pushSecondary then
+    self.pushSecondary = false
+    local w, h = self.canvas:getWidth(), self.canvas:getHeight()
+    if not self.secondCanvas or self.secondCanvas:getWidth() ~= w
+       or self.secondCanvas:getHeight() ~= h then
+      if self.secondCanvas and self.secondCanvas.release then self.secondCanvas:release() end
+      self.secondCanvas = PixelCanvas.new(w, h, "nearest")
+    end
+    love.graphics.setCanvas(self.secondCanvas)
+    love.graphics.clear(0, 0, 0, 0)
+    love.graphics.setColor(1, 1, 1, 1)
+    blit(self.canvas, 1, 1, zones, 1, 1, 0, 0, 0, 0, w, h)
+    love.graphics.setCanvas()
+    local ok, id = pcall(function() return self.secondCanvas:newImageData() end)
+    if ok and id then
+      SecondScreen.push(id, w, h)
+      if id.release then pcall(function() id:release() end) end
     end
   end
   self.worldActive = false

--- a/src/render/Renderer.lua
+++ b/src/render/Renderer.lua
@@ -612,7 +612,75 @@ function Renderer:endFrame(zones, worldZones)
     local wc = self.worldActive and self.worldCanvas or self.lastWorldCanvas
     local wz = self.worldActive and worldZones or self.lastWorldZones
     local wox, woy, wvpw, wvph, wsx, wsy
-    if SecondScreen.available() then
+    local physical = SecondScreen.available()
+    local battle, battleTop = false, false
+    do
+      local ok, G = pcall(require, "src.core.Game")
+      local stack = ok and G and G.stack
+      if stack and stack.states then
+        battle, battleTop = DualScreen.battleMode(stack.states)
+      end
+    end
+    if battle then
+      local cw, ch = self.canvas:getWidth(), self.canvas:getHeight()
+      if not self.battleComposite or self.battleComposite:getWidth() ~= cw
+         or self.battleComposite:getHeight() ~= ch then
+        if self.battleComposite and self.battleComposite.release then self.battleComposite:release() end
+        self.battleComposite = PixelCanvas.new(cw, ch, "nearest")
+      end
+      love.graphics.setCanvas(self.battleComposite)
+      love.graphics.clear(0, 0, 0, 0)
+      love.graphics.setColor(1, 1, 1, 1)
+      blit(self.canvas, 1, 1, zones, 1, 1, 0, 0, 0, 0, cw, ch)
+      love.graphics.setCanvas(present)
+      local SPLIT = 96
+      local topSrc, tqy, tqh, botSrc, bqy, bqh
+      if battleTop then
+        if not self.battleField or self.battleField:getWidth() ~= cw
+           or self.battleField:getHeight() ~= SPLIT then
+          if self.battleField and self.battleField.release then self.battleField:release() end
+          self.battleField = PixelCanvas.new(cw, SPLIT, "nearest")
+        end
+        love.graphics.setCanvas(self.battleField)
+        love.graphics.clear(0, 0, 0, 0)
+        love.graphics.setColor(1, 1, 1, 1)
+        love.graphics.draw(self.battleComposite,
+          love.graphics.newQuad(0, 0, cw, SPLIT, cw, ch), 0, 0)
+        love.graphics.setCanvas(present)
+        topSrc, tqy, tqh = self.battleComposite, 0, SPLIT
+        botSrc, bqy, bqh = self.battleComposite, SPLIT, ch - SPLIT
+      else
+        topSrc, tqy, tqh = self.battleField, 0, SPLIT
+        botSrc, bqy, bqh = self.battleComposite, 0, ch
+      end
+      local function strip(src, qy, qh, rox, roy, rw, rh, rsx, rsy)
+        if not src then return end
+        local q = love.graphics.newQuad(0, qy, src:getWidth(), qh, src:getDimensions())
+        local dy = roy + (rh - qh * rsy) / 2
+        love.graphics.setColor(1, 1, 1, 1)
+        love.graphics.setScissor(rox, roy, rw, rh)
+        love.graphics.draw(src, q, rox, dy, 0, rsx, rsy)
+        love.graphics.setScissor()
+      end
+      if physical then
+        wox, woy, wvpw, wvph, wsx, wsy = ox, oy, vpw, vph, Sx, Sy
+        strip(topSrc, tqy, tqh, ox, oy, vpw, vph, Sx, Sy)
+        if botSrc then
+          local ok, id = pcall(function()
+            return botSrc:newImageData(1, 1, 0, bqy, botSrc:getWidth(), bqh)
+          end)
+          if ok and id then self.pushImage = id end
+        end
+        self.pushSecondary = false
+      else
+        local scale, wr, ur = DualScreen.layout(pw, ph, dpiX, dpiY, self.WIDTH, self.HEIGHT)
+        composeScale = scale
+        wox, woy, wvpw, wvph, wsx, wsy = wr.ox, wr.oy, wr.w, wr.h, wr.sx, wr.sy
+        strip(topSrc, tqy, tqh, wr.ox, wr.oy, wr.w, wr.h, wr.sx, wr.sy)
+        strip(botSrc, bqy, bqh, ur.ox, ur.oy, ur.w, ur.h, ur.sx, ur.sy)
+        self.pushSecondary = false
+      end
+    elseif physical then
       wox, woy, wvpw, wvph, wsx, wsy = ox, oy, vpw, vph, Sx, Sy
       if wc then
         blit(wc, wsx, wsy, wz, wsx, wsy, wox, woy, wox, woy, wvpw, wvph)
@@ -626,7 +694,7 @@ function Renderer:endFrame(zones, worldZones)
       composeScale = scale
       wox, woy, wvpw, wvph, wsx, wsy = wr.ox, wr.oy, wr.w, wr.h, wr.sx, wr.sy
       if wc then
-        blit(wc, wsx, wsy, wz, wsx, wsy, wox, woy, wox, woy, wvpw, wvph)
+        blit(wc, wsx, wsy, wz, wsx, wsy, wr.ox, wr.oy, wr.ox, wr.oy, wr.w, wr.h)
       end
       blit(self.canvas, ur.sx, ur.sy, zones, ur.sx, ur.sy,
            ur.ox, ur.oy, ur.ox, ur.oy, ur.w, ur.h)
@@ -801,7 +869,12 @@ function Renderer:endFrame(zones, worldZones)
       love.graphics.draw(composed, 0, 0)
     end
   end
-  if self.pushSecondary then
+  if self.pushImage then
+    local id = self.pushImage
+    self.pushImage = nil
+    SecondScreen.push(id, id:getWidth(), id:getHeight())
+    if id.release then pcall(function() id:release() end) end
+  elseif self.pushSecondary then
     self.pushSecondary = false
     local w, h = self.canvas:getWidth(), self.canvas:getHeight()
     if not self.secondCanvas or self.secondCanvas:getWidth() ~= w

--- a/src/render/Renderer.lua
+++ b/src/render/Renderer.lua
@@ -668,8 +668,17 @@ function Renderer:endFrame(zones, worldZones)
       return true
     end
     if dsBattle and physical then
-      wox, woy, wvpw, wvph, wsx, wsy = ox, oy, vpw, vph, Sx, Sy
-      screenBlit(0, { ox = ox, oy = oy, w = vpw, h = vph, sx = Sx, sy = Sy })
+      -- On a second-display device each physical screen is its own 160x144
+      -- panel, so the field fills the main panel as one Game Boy screen. The
+      -- 288 surface's own fit would shrink a portrait stack into a landscape
+      -- panel (tiny battle on the AYN Thor); size to a single screen instead.
+      local sp = math.max(1, math.floor(math.min(pw / self.WIDTH, ph / self.HEIGHT)))
+      local sx1, sy1 = sp / dpiX, sp / dpiY
+      local rw, rh = self.WIDTH * sx1, self.HEIGHT * sy1
+      local rox = math.floor((pw - self.WIDTH * sp) / 2) / dpiX
+      local roy = math.floor((ph - self.HEIGHT * sp) / 2) / dpiY
+      wox, woy, wvpw, wvph, wsx, wsy = rox, roy, rw, rh, sx1, sy1
+      screenBlit(0, { ox = rox, oy = roy, w = rw, h = rh, sx = sx1, sy = sy1 })
       stashField()
       local okid, id = pcall(function()
         return self.canvas:newImageData(1, 1, 0, self.HEIGHT,

--- a/src/render/Renderer.lua
+++ b/src/render/Renderer.lua
@@ -636,6 +636,35 @@ function Renderer:endFrame(zones, worldZones)
       self.lastWorldCanvas = self.worldCanvas
       self.lastWorldZones = worldZones
     end
+    -- Voxel/diorama on the top screen: a drawWorld pipeline hands back the
+    -- whole world image (worldOverride), which replaces the flat top-screen
+    -- blit above. Held at the last frame under a battle (worldActive off), so
+    -- the top screen keeps the diorama the fight was called from. Fit and
+    -- centred, so a full-window image pillarboxes rather than stretches.
+    if self.worldActive then self.lastWorldOverride = self.worldOverride end
+    local wov = self.worldActive and self.worldOverride or self.lastWorldOverride
+    if wov and not battle then
+      -- a held override can be released underneath us (Voxel3D drops its
+      -- canvas on a resize / DS-region size change), so drawing it is fenced:
+      -- a dangling reference blanks the top screen for a frame, never crashes.
+      local ok = pcall(function()
+        local ovw, ovh = wov:getWidth(), wov:getHeight()
+        local sc = math.min(wvpw / ovw, wvph / ovh)
+        love.graphics.setScissor(wox, woy, wvpw, wvph)
+        -- black under the fit, so a pillarboxed image shows bars rather than
+        -- the flat world blitted a moment ago in this same region
+        love.graphics.setColor(0, 0, 0, 1)
+        love.graphics.rectangle("fill", wox, woy, wvpw, wvph)
+        love.graphics.setColor(1, 1, 1, 1)
+        love.graphics.draw(wov, wox + (wvpw - ovw * sc) / 2,
+                           woy + (wvph - ovh * sc) / 2, 0, sc, sc)
+        love.graphics.setScissor()
+      end)
+      if not ok then
+        love.graphics.setScissor()
+        self.lastWorldOverride = nil
+      end
+    end
     local fade = self.worldFadeAlpha
     if fade and fade > 0 then
       love.graphics.setColor(0, 0, 0, fade)

--- a/src/render/SecondScreen.lua
+++ b/src/render/SecondScreen.lua
@@ -1,0 +1,59 @@
+-- Bridge to native secondary-display output (Android Presentation). The C
+-- functions live in mobile/android/love/src/jni/love/src/common/android.cpp.
+-- Everything is guarded: off Android, or if the symbols cannot be resolved,
+-- this stays inert and the renderer keeps the in-window stacked layout.
+
+local SecondScreen = {}
+local C = nil
+
+local function log(msg)
+  pcall(function() require("src.core.Logger").info("SecondScreen: %s", msg) end)
+end
+
+do
+  local ok, ffi = pcall(require, "ffi")
+  if not (ok and ffi) then
+    log("ffi unavailable (not LuaJIT); second display disabled")
+  else
+    pcall(ffi.cdef, [[
+      int love_android_secondary_ready();
+      void love_android_push_secondary(const void *rgba, int w, int h);
+      void love_android_secondary_enable(int on);
+    ]])
+    local okLib, lib = pcall(ffi.load, "love")
+    if okLib and lib and pcall(function() return lib.love_android_secondary_ready end) then
+      C = lib
+      log("bridge linked via ffi.load('love')")
+    elseif pcall(function() return ffi.C.love_android_secondary_ready end) then
+      C = ffi.C
+      log("bridge linked via default namespace")
+    else
+      log(("bridge symbols not found (ffi.load ok=%s); second display disabled")
+        :format(tostring(okLib)))
+    end
+  end
+end
+
+function SecondScreen.usable()
+  return C ~= nil
+end
+
+function SecondScreen.available()
+  if not C then return false end
+  local ok, r = pcall(C.love_android_secondary_ready)
+  return ok and r ~= 0
+end
+
+function SecondScreen.push(imageData, w, h)
+  if not C or not imageData then return false end
+  return pcall(function()
+    C.love_android_push_secondary(imageData:getFFIPointer(), w, h)
+  end)
+end
+
+function SecondScreen.setEnabled(on)
+  if not C then return end
+  pcall(function() C.love_android_secondary_enable(on and 1 or 0) end)
+end
+
+return SecondScreen

--- a/src/render/Transition.lua
+++ b/src/render/Transition.lua
@@ -97,6 +97,8 @@ function WhiteFlash:update(dt)
 end
 
 function WhiteFlash:draw()
+  local r = self.game and self.game.renderer
+  if r then r.worldFlashAlpha = 1 end
   love.graphics.setColor(1, 1, 1, 1)
   love.graphics.rectangle("fill", 0, 0, 160, 144)
 end

--- a/src/script/Commands.lua
+++ b/src/script/Commands.lua
@@ -280,7 +280,16 @@ function Commands.start_battle(ctx, kind, a, b)
     end
     runner:resume()
   end
-  ctx.game.stack:push(battle)
+  -- Route through the overworld's own pushBattle when a map is under the
+  -- fight, so a scripted trainer (the rival, a gym leader) gets the same
+  -- transition wipe and battle theme a walked-into fight does -- and reaches
+  -- the seam a render pipeline wraps to stage its arena before the wipe. A
+  -- battle scripted with no overworld beneath it (from the title) starts bare.
+  if ctx.overworld and ctx.overworld.pushBattle then
+    ctx.overworld:pushBattle(battle)
+  else
+    ctx.game.stack:push(battle)
+  end
   runner:yield()
 end
 

--- a/src/ui/OptionsMenu.lua
+++ b/src/ui/OptionsMenu.lua
@@ -15,6 +15,7 @@ local Pipelines = require("src.render.Pipelines")
 local Tilt = require("src.render.Tilt")
 local GBCFX = require("src.render.GBCFX")
 local Zoom = require("src.render.Zoom")
+local DualScreen = require("src.render.DualScreen")
 local TileRenderer = require("src.render.TileRenderer")
 local GameSpeed = require("src.core.GameSpeed")
 local GameVersion = require("src.core.GameVersion")
@@ -254,6 +255,14 @@ local function buildRows(game)
         elseif off < lo then off = hi end
         o.zoom = off
         Zoom.offset = off
+        return true
+      end },
+    { id = "dualScreen", label = Strings("DUAL SCREEN"),
+      value = function() return DualScreen.label() end,
+      step = function(g, dir)
+        local o = g.save.options
+        o.dualScreen = not DualScreen.active()
+        g:applyOptions(o)
         return true
       end },
     { id = "voidFill", label = Strings("VOID FILL"),

--- a/tests/drivers/dual_battle_test.lua
+++ b/tests/drivers/dual_battle_test.lua
@@ -1,0 +1,85 @@
+-- Driver: DUAL SCREEN battle.  Opens a wild battle, asserts the 160x288
+-- stacked surface, and captures the command screen, the move menu and a
+-- send-out POOF so the field/menu split and animation seams are visible.
+--   DISPLAY=:1 SDL_VIDEODRIVER=x11 POKEPORT_IDENTITY=ds-shots POKEPORT_TOUCH=0 \
+--     SHOT_DIR=/tmp/shots POKEPORT_DRIVER=tests/drivers/dual_battle_test.lua \
+--     POKEPORT_SPEED=8 love .
+return function(game)
+  local U = dofile("tests/drivers/util.lua")
+  local DIR = os.getenv("SHOT_DIR") or "/tmp/shots"
+  local BattleState = require("src.battle.BattleState")
+  local Pokemon = require("src.pokemon.Pokemon")
+  local Renderer = require("src.render.Renderer")
+
+  local failures = 0
+  local function check(label, ok)
+    if not ok then failures = failures + 1 end
+    U.log(ok and "PASS" or "FAIL", label)
+    return ok
+  end
+
+  game.save.options.dualScreen = true
+  game:applyOptions(game.save.options)
+  game.save.party = { Pokemon.new(game.data, "SQUIRTLE", 5) }
+  U.teleport(game, "ROUTE_1", 5, 5, "down")
+  U.wait(30)
+  U.shot(game, DIR .. "/db_0_overworld.png")
+
+  local battle = BattleState.newWild(game, "PIDGEY", 3, { onFinish = function() end })
+  game.overworld:pushBattle(battle)
+  U.wait(360)
+
+  check("the battle is on top", getmetatable(game.stack:top()) == BattleState)
+  check("the battle asked for the 160x288 stacked surface",
+        Renderer.uiWidth == 160 and Renderer.uiHeight == 288)
+
+  battle.introSlide = 0
+  battle.introBalls = nil
+  battle.showEnemyTrainer = false
+  battle.showPlayerBack = false
+  battle.enemySendingOut = false
+  battle.sendingOut = false
+  battle.phase = "menu"
+  battle.menuIndex = 1
+  U.wait(2)
+  check("command screenshot", U.shot(game, DIR .. "/db_1_command.png"))
+
+  battle.phase = "moveSelect"
+  battle.moveIndex = 1
+  U.wait(2)
+  check("move menu screenshot", U.shot(game, DIR .. "/db_2_moves.png"))
+
+  -- an opaque menu opened over the battle (the BAG / PARTY) collapses the
+  -- 160x288 surface to 160x144; the fight must stay frozen on the top screen
+  -- while the menu takes the bottom
+  battle.phase = "menu"
+  local Font = require("src.render.Font")
+  local overlay = { isOpaque = true }
+  function overlay:draw()
+    love.graphics.setColor(1, 1, 1, 1)
+    love.graphics.rectangle("fill", 0, 0, 160, 144)
+    love.graphics.setColor(0, 0, 0, 1)
+    Font.draw("BAG", 64, 64)
+    love.graphics.setColor(1, 1, 1, 1)
+  end
+  game.stack:push(overlay)
+  U.wait(6)
+  check("overlay is on top, battle beneath", game.stack:top() == overlay)
+  check("bag screenshot", U.shot(game, DIR .. "/db_4_bag.png"))
+  game.stack:pop()
+  U.wait(4)
+
+  battle.phase = "messages"
+  battle.current = nil
+  if battle.animPlayer then
+    battle.animPlayer:start("POOF_ANIM", false)
+    battle.animPlayer.stepIndex = 3
+    battle.animPlaying = true
+  end
+  U.wait(2)
+  check("send-out POOF screenshot", U.shot(game, DIR .. "/db_3_poof.png"))
+  battle.animPlaying = false
+
+  U.log("RESULT", failures == 0 and "ALL PASS" or (failures .. " FAILURES"))
+  love.event.quit(failures == 0 and 0 or 1)
+end

--- a/tests/drivers/dualscreen_test.lua
+++ b/tests/drivers/dualscreen_test.lua
@@ -1,0 +1,41 @@
+-- Driver: dual-screen (DS-style) layout. World pass on the top screen, UI
+-- pass (menu, dialog, battle) on the bottom. During a battle the top screen
+-- holds the frozen last overworld frame.
+--   POKEPORT_IDENTITY=ds-shots POKEPORT_DRIVER=tests/drivers/dualscreen_test.lua \
+--     SHOT_DIR=/tmp/shots love .
+return function(game)
+  local U = dofile("tests/drivers/util.lua")
+  local DIR = os.getenv("SHOT_DIR") or "/tmp/shots"
+  local Pokemon = require("src.pokemon.Pokemon")
+
+  game.save.options.dualScreen = true
+  game:applyOptions(game.save.options)
+
+  U.teleport(game, "PALLET_TOWN", 10, 8, "down")
+  U.wait(30)
+  U.shot(game, DIR .. "/ds_0_overworld.png")
+
+  -- START menu: overworld stays on the top screen, the menu lands below
+  U.tap(game, "start")
+  U.wait(12)
+  U.shot(game, DIR .. "/ds_1_menu.png")
+  U.tap(game, "b")
+  U.wait(6)
+
+  -- battle: top screen freezes the last overworld frame, battle draws below
+  table.insert(game.save.party, Pokemon.new(game.data, "CHARMANDER", 12))
+  U.teleport(game, "ROUTE_1", 5, 5, "down")
+  U.wait(20)
+  U.shot(game, DIR .. "/ds_2_prebattle.png")
+  local BattleState = require("src.battle.BattleState")
+  local battle = BattleState.newWild(game, "PIDGEY", 8)
+  battle.onFinish = function() end
+  game.overworld:pushBattle(battle)
+  U.wait(40)
+  U.shot(game, DIR .. "/ds_3_battle_intro.png")
+  for _ = 1, 12 do U.tap(game, "a"); U.wait(6) end
+  U.shot(game, DIR .. "/ds_4_battle_menu.png")
+
+  game.save.options.dualScreen = false
+  game:applyOptions(game.save.options)
+end

--- a/tests/engine/dual_screen_layout.lua
+++ b/tests/engine/dual_screen_layout.lua
@@ -64,4 +64,23 @@ T.eq(vw, 160, "the world view is the classic width while dual screen is on")
 T.eq(vh, 144, "the world view is the classic height while dual screen is on")
 DualScreen.setEnabled(false)
 
+-- battle dual layout: which screen the battlefield vs the menu lands on
+local BATTLE = { isOpaque = true, isBattleScreen = true }
+local OVERWORLD = { isOpaque = true }
+local BAG = { isOpaque = true }            -- bag/party cover the battle
+local CHOICE = { isOpaque = false }        -- YES/NO etc. over a live battle
+local function mode(...) return DualScreen.battleMode({ ... }) end
+
+local b, t = mode(OVERWORLD)
+T.eq(b, false, "no battle in the stack -> not battle mode")
+T.eq(t, false, "no battle -> no split")
+b, t = mode(OVERWORLD, BATTLE)
+T.eq(b, true, "a battle on top is battle mode")
+T.eq(t, true, "battle on top -> split battlefield/menu")
+b, t = mode(OVERWORLD, BATTLE, BAG)
+T.eq(b, true, "battle still active under an opaque bag/party screen")
+T.eq(t, false, "opaque bag/party covers the battle -> whole thing to the menu screen")
+b, t = mode(OVERWORLD, BATTLE, CHOICE)
+T.eq(t, true, "a non-opaque overlay over a live battle keeps the split")
+
 T.finish("dual screen layout")

--- a/tests/engine/dual_screen_layout.lua
+++ b/tests/engine/dual_screen_layout.lua
@@ -1,0 +1,67 @@
+-- DUAL SCREEN (src/render/DualScreen.lua): the stacked composite surface,
+-- the two screen rects in framebuffer pixels and LOVE units, point routing,
+-- and the mode flag / persistence. Renderer:worldViewSize collapses to the
+-- classic 160x144 world while the mode is on.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.modkit")
+local DualScreen = require("src.render.DualScreen")
+local Renderer = require("src.render.Renderer")
+
+-- surface: one screen wide, two screens tall plus the gutter
+local sw, sh = DualScreen.surfaceSize(160, 144)
+T.eq(sw, 160, "the stacked surface is one screen wide")
+T.eq(sh, 144 * 2 + DualScreen.GAP, "two screens tall plus the gutter")
+
+-- regions in framebuffer pixels: integer fit scale, world on top, ui below
+local scale, world, ui = DualScreen.regions(640, 640)
+T.eq(scale, 2, "the fit scale floors the tighter of the two axes")
+T.eq(world.ox, 160, "the column is centred horizontally")
+T.eq(world.oy, 24, "the stack is centred vertically")
+T.eq(world.w, 320, "each screen is 160 GB px at the fit scale")
+T.eq(world.h, 288, "each screen is 144 GB px at the fit scale")
+T.eq(ui.ox, 160, "both screens share the same column")
+T.eq(ui.oy, 24 + 288 + DualScreen.GAP * scale,
+  "the ui screen sits a gutter below the world screen")
+T.eq(ui.w, 320, "the ui screen matches the world screen width")
+
+-- layout in LOVE units divides the pixel rects by each axis dpi
+local uscale, uworld, uui = DualScreen.layout(1280, 1280, 2, 2)
+T.eq(uscale, 4, "the fit scale is computed from framebuffer pixels")
+T.eq(uworld.ox, 160, "unit origin is the pixel origin over dpiX")
+T.eq(uworld.oy, 24, "unit origin is the pixel origin over dpiY")
+T.eq(uworld.sx, 2, "the draw scale is the fit scale over dpiX")
+T.eq(uworld.sy, 2, "the draw scale is the fit scale over dpiY")
+T.eq(uui.oy, uworld.oy + uworld.h + DualScreen.GAP * uscale / 2,
+  "the ui screen keeps its gutter offset in units")
+
+-- point routing across the two screens and the dead zones between/around them
+T.eq(DualScreen.screenAt(300, 100, 640, 640), "world",
+  "a point on the top screen routes to the world")
+T.eq(DualScreen.screenAt(300, 400, 640, 640), "ui",
+  "a point on the bottom screen routes to the ui")
+T.eq(DualScreen.screenAt(300, 315, 640, 640), nil,
+  "the gutter between the screens is dead")
+T.eq(DualScreen.screenAt(10, 100, 640, 640), nil,
+  "the letterbox beside the column is dead")
+
+-- the mode flag and its persistence key
+DualScreen.setEnabled(false)
+T.eq(DualScreen.active(), false, "starts off")
+T.eq(DualScreen.label(), "OFF", "label reads OFF while off")
+T.eq(DualScreen.toggle(), true, "toggle turns it on")
+T.eq(DualScreen.label(), "ON", "label reads ON while on")
+DualScreen.applyOptions({ dualScreen = false })
+T.eq(DualScreen.active(), false, "applyOptions restores the persisted state")
+DualScreen.applyOptions({ dualScreen = true })
+T.eq(DualScreen.active(), true, "applyOptions reads save.options.dualScreen")
+
+-- the world pass collapses to the classic GB screen while the mode is on
+Renderer:init()
+DualScreen.setEnabled(true)
+local vw, vh = Renderer:worldViewSize()
+T.eq(vw, 160, "the world view is the classic width while dual screen is on")
+T.eq(vh, 144, "the world view is the classic height while dual screen is on")
+DualScreen.setEnabled(false)
+
+T.finish("dual screen layout")


### PR DESCRIPTION
## Dual-screen (DS-style) rendering

Opening this as a **draft** so we can land the *engine* pieces that make a second
screen possible, and keep the opinionated layout as a mod on top — per your note:

> if you contribute just the parts that modify the stuff that makes dual screen
> possible, I can roll it in and then [the] mod can be just what hooks it and uses
> the other screen. Then other people can use the second screen for mods too.

### What this adds
Stacks the world pass (top) and UI pass (bottom) as two Game Boy screens instead
of compositing UI over world in one letterbox. The engine already renders those
into separate canvases, so this is mostly layout math plus a guarded
`Renderer:endFrame` composite branch — **the single-screen path is byte-identical
when off**. Toggled from an Options `DUAL SCREEN` row, persisted as
`save.options.dualScreen`; mutually exclusive with survey zoom, tilt, and the wide
battle layout.

- **`src/render/SecondScreen.lua` + Android native bridge** (`common/android.cpp`,
  `GameActivity.java`) — a generic "is a second physical display attached, here's a
  pixel buffer for it" capability (LuaJIT-FFI, fully pcall-guarded, inert off
  Android). This is the reusable plumbing any mod could drive.
- **`src/render/DualScreen.lua` / `src/battle/DualBattle.lua`** — the DS layout
  policy (stacking geometry, the two-screen battle split).
- **`src/script/Commands.lua`** — routes scripted `start_battle` through
  `overworld:pushBattle` so a scripted fight gets the same transition wipe / theme
  timing as a walked-into encounter (a standalone fix; no dual-screen dependency).

### Splitting engine vs. mod
The generic second-screen plumbing already stands alone. The DS *policy* modules
(`DualScreen`, `DualBattle`) are currently wired into `Renderer`, `BattleState`,
and `Game` via direct `require` + `if DualScreen.active()` branches. If you'd
prefer the layout to live entirely as a mod, the engine needs a small hook seam:
expose the world/UI canvases + the frozen "last world frame" and a
`render.secondScreen`-style hook (in the existing `Runtime` hook style), plus a
battle-layout registration point so `BattleState:draw()` consults a registry
instead of naming `DualBattle`. Happy to cut the PR down to exactly that seam and
move `DualScreen`/`DualBattle` out to a mod — just say which shape you want.

### Not included (deliberately)
Fork-only concerns are left out: the local dev environment/tooling, version-scheme
changes, and the fork's distinct app/bundle identifiers.

### Verification
`scripts/test.sh --quick` passes (T1/T2/T4; T3 needs an imported ROM). Dual-screen
layout/battle drivers green; second-display path verified on AYN Thor hardware.
