### PR TITLE
Bundle Dramatic Shape voxel mod as a shipped mod

### DIFF
--- a/mods/dramatic_shape/README.md
+++ b/mods/dramatic_shape/README.md
@@ -1,0 +1,40 @@
+# Dramatic Shape Voxel Mod
+
+A mod for the [Pokémon Gen 1 Recompilation
+Project](https://github.com/bryanthaboi/pokemon-gen1-recomp-project).
+
+The overworld as a 3D diorama. Terrain is extruded into real geometry,
+occlusion comes from a depth buffer rather than a y-sort, characters stand
+as leaning sprite slabs, a shadow map throws real cast shadows across
+whatever they land on, and an optional tilt-shift pass sells the
+miniature-model look.
+
+And battles fought on that world rather than on a white field. When
+something picks a fight the map's NPCs are culled, the engine's own wipe
+plays over the empty map, and the battle draws over the nearest patch of
+clear ground — shot over the shoulder, the player's mon low and left and
+the enemy high and right, with a slow parallax drift behind them and a
+depth-of-field pass that keeps both of them sharp.
+
+Purely presentational. Nothing here reaches collision, movement, triggers
+or scripts — it changes what the world *looks* like and nothing about what
+it *is*. The battle arena is where the **camera** goes, not where anybody
+goes: no cell, facing, flag or warp is written, so the player is standing
+exactly where the fight found them when it ends.
+
+## Controls
+
+Every key is free-roam only, and each one is also a row on the OPTIONS
+menu.
+
+| control | does |
+| --- | --- |
+| `3`, or the **VOXEL** options row | OFF → 15 → 35 → 50 → 75 → OFF (camera pitch) |
+| `5`, or the **V-GRID** options row | OFF / ON — a one-pixel wireframe on every voxel |
+| `6`, or the **T-SHIFT** options row | OFF → 1 → 2 → 3 → OFF (miniature blur) |
+| `7`, or the **V-CURVE** options row | OFF → 1 → 2 → 3 — bend the world over the horizon |
+| `8`, or the **3D-BTL** options row | ON / OFF — fight on the map instead of on a white field |
+| the **DAYTIME** options row | SYNC / DAY / NIGHT / DUSK / DAWN / CYCLE — what time it is outdoors; held at SYNC (and off the menu) while VOXEL is FULL |
+
+**3D-BTL** is on by default and is independent of **VOXEL**: battles draw
+on the world whether or not the free-roam camera is pitched over.

--- a/mods/dramatic_shape/data/battle_arenas.lua
+++ b/mods/dramatic_shape/data/battle_arenas.lua
@@ -1,0 +1,189 @@
+-- Where each map's battles happen.
+--
+-- One authored spot per area, rather than whichever clearing happens to be
+-- nearest the step the fight started on. A battle on Route 1 should look the
+-- same every time it happens on Route 1 -- and, more importantly, "open
+-- ground" is not the same question as "you can see the two of them": the
+-- battle camera sits low and a long way back, so a hedge, a ledge lip or the
+-- corner of a house anywhere along that sightline hides a Pokemon completely
+-- while every cell it is standing on is perfectly walkable.
+--
+-- Each entry is the arena's north-west corner in map CELLS, and which of
+-- BattleArena.SHAPES it is. Picked by tools/arena_pick (BattleArena.search
+-- with the clearance test on, from the middle of the map) and then looked at,
+-- one screenshot per map -- these are eyeballed answers, not just passing
+-- ones. Grass and flowers around a mon's feet are fine and wanted; anything
+-- that cuts into a body is not.
+--
+-- A map with no entry here falls back to the nearest-clear search at battle
+-- time, so a mod that adds maps, or an entry that goes stale against an
+-- edited map, degrades to the old behaviour rather than to no battle.
+--
+-- The entries below are generated; regenerate with
+--
+--   SHOT_DIR=.scratchpad/arenas \
+--   POKEPORT_DRIVER=mods/DramaticShapeVoxelMod/tests/arena_pick.lua love .
+
+-- `cam = "wide"` on an entry swaps the long default lens for the 44-degree
+-- one (BattleCam.RIGS). Both frame the same composition -- the two mons land
+-- on the same screen anchors either way -- so it is purely a choice about how
+-- much of the place is in shot, at the cost of a smaller pair. Rooms the long
+-- lens cannot stand back from NEED it; anywhere that simply reads better with
+-- more of itself visible may ask for it.
+--
+-- Tall grass is never part of an arena (BattleArena.openCell rejects it), so
+-- a route's spot is always its bare path rather than the field beside it --
+-- grass is knee-high geometry to a Pokemon and this camera is nearly level
+-- with the floor, so tufts on the mon's own tile stand between it and the
+-- lens. Flowers are left alone: they are ankle height and read as ground.
+
+return {
+  -- ------- routes
+  -- narrow, deliberately: the route's interior is a 3-cell-wide lane and the
+  -- wide shape only fits in the western connection border, which staged every
+  -- fight at the edge of the world instead of on the road
+  ["ROUTE_1"] = { x = 9, y = 16, shape = "narrow" },
+  ["ROUTE_2"] = { x = 1, y = 49, shape = "wide" },
+  ["ROUTE_3"] = { x = 57, y = 1, shape = "wide" },
+  ["ROUTE_4"] = { x = 46, y = 7, shape = "wide" },
+  ["ROUTE_5"] = { x = 13, y = 24, shape = "wide" },
+  ["ROUTE_6"] = { x = 5, y = 17, shape = "narrow" },
+  ["ROUTE_7"] = { x = 8, y = 8, shape = "narrow" },
+  ["ROUTE_8"] = { x = 25, y = 7, shape = "wide" },
+  -- the whole route admits six bare wide arenas, all in the west cliff
+  -- corridor; this is the best of them. A flower cluster crosses the far
+  -- mon's hind legs, which the brief allows -- every alternative put a
+  -- terrace through the near mon's waist, which it does not.
+  ["ROUTE_9"] = { x = 1, y = 11, shape = "wide", cam = "wide" },
+  ["ROUTE_10"] = { x = 7, y = 40, shape = "wide" },
+  ["ROUTE_11"] = { x = 9, y = 6, shape = "wide" },
+  ["ROUTE_12"] = { x = 0, y = 73, shape = "wide" },
+  ["ROUTE_13"] = { x = 50, y = 8, shape = "narrow" },
+  ["ROUTE_14"] = { x = 11, y = 25, shape = "wide" },
+  ["ROUTE_15"] = { x = 9, y = 10, shape = "wide" },
+  ["ROUTE_16"] = { x = 6, y = 10, shape = "wide" },
+  ["ROUTE_17"] = { x = 14, y = 70, shape = "wide" },
+  ["ROUTE_18"] = { x = 11, y = 4, shape = "wide" },
+
+  -- ------- buildings and caves
+  --
+  -- Indoors the narrow shape earns its keep: a room with furniture, machinery
+  -- or gravestones in it rarely holds a 3x6 clearing whose whole width is
+  -- also SEEN, and giving up the apron is usually the difference between a
+  -- fight in the open and one behind a console.
+  ["POKEMON_MANSION_1F"] = { x = 4, y = 12, shape = "wide" },
+  ["POKEMON_MANSION_2F"] = { x = 15, y = 17, shape = "wide" },
+  ["POKEMON_MANSION_3F"] = { x = 23, y = 2, shape = "narrow", cam = "wide" },
+  ["POKEMON_MANSION_B1F"] = { x = 19, y = 10, shape = "wide" },
+  ["POKEMON_TOWER_2F"] = { x = 4, y = 7, shape = "narrow" },
+  ["POKEMON_TOWER_3F"] = { x = 4, y = 6, shape = "wide" },
+  -- every one of 4F's thirty candidate spots puts a gravestone through a
+  -- mon; the floor below is the same tower and has the room, so the fight
+  -- is shot there
+  ["POKEMON_TOWER_4F"] = { map = "POKEMON_TOWER_3F", x = 4, y = 6,
+                           shape = "wide" },
+  ["POKEMON_TOWER_5F"] = { x = 10, y = 1, shape = "narrow" },
+  ["POKEMON_TOWER_6F"] = { x = 14, y = 6, shape = "narrow" },
+  ["POKEMON_TOWER_7F"] = { x = 9, y = 5, shape = "wide" },
+  ["POWER_PLANT"] = { x = 18, y = 5, shape = "narrow" },
+  ["ROCK_TUNNEL_1F"] = { x = 14, y = 15, shape = "wide" },
+  ["ROCK_TUNNEL_B1F"] = { x = 20, y = 17, shape = "wide" },
+  ["ROCKET_HIDEOUT_B1F"] = { x = 11, y = 6, shape = "narrow" },
+  ["ROCKET_HIDEOUT_B2F"] = { x = 19, y = 7, shape = "narrow" },
+  ["ROCKET_HIDEOUT_B3F"] = { x = 22, y = 11, shape = "narrow" },
+  ["ROCKET_HIDEOUT_B4F"] = { x = 17, y = 3, shape = "narrow" },
+  ["SAFARI_ZONE_CENTER"] = { x = 1, y = 8, shape = "wide" },
+  ["SAFARI_ZONE_EAST"] = { x = 21, y = 8, shape = "wide" },
+  ["SAFARI_ZONE_NORTH"] = { x = 19, y = 14, shape = "wide" },
+  ["SAFARI_ZONE_WEST"] = { x = 18, y = 3, shape = "wide" },
+  ["SEAFOAM_ISLANDS_1F"] = { x = 14, y = 7, shape = "wide" },
+  ["SEAFOAM_ISLANDS_B1F"] = { x = 11, y = 1, shape = "wide" },
+  ["SEAFOAM_ISLANDS_B2F"] = { x = 16, y = 2, shape = "wide" },
+  ["SEAFOAM_ISLANDS_B3F"] = { x = 25, y = 7, shape = "wide" },
+  ["SEAFOAM_ISLANDS_B4F"] = { x = 12, y = 6, shape = "narrow" },
+  -- Silph Co is office floors partitioned into small rooms, so the long lens
+  -- often lands outside the walls it is meant to be looking between; the
+  -- floors that could not be framed any other way ask for the wide one.
+  ["SILPH_CO_2F"] = { x = 16, y = 8, shape = "narrow" },
+  ["SILPH_CO_4F"] = { x = 24, y = 2, shape = "narrow" },
+  ["SILPH_CO_5F"] = { x = 16, y = 7, shape = "wide" },
+  ["SILPH_CO_6F"] = { x = 10, y = 8, shape = "narrow" },
+  ["SILPH_CO_7F"] = { x = 1, y = 2, shape = "wide", cam = "wide" },
+  ["SILPH_CO_8F"] = { x = 8, y = 6, shape = "narrow" },
+  ["SILPH_CO_9F"] = { x = 20, y = 11, shape = "wide", cam = "wide" },
+  ["SS_ANNE_1F_ROOMS"] = { x = 10, y = 1, shape = "narrow", cam = "wide" },
+  -- the ship is all two-cell corridors, so the wide arena shape fits nowhere
+  -- aboard and the long lens always lands outside the hull
+  ["SS_ANNE_2F"] = { x = 36, y = 8, shape = "narrow", cam = "wide" },
+  -- these two decks are byte-identical geometry, so they take the same spot
+  ["SS_ANNE_2F_ROOMS"] = { x = 11, y = 12, shape = "narrow" },
+  ["SS_ANNE_B1F_ROOMS"] = { x = 11, y = 12, shape = "narrow" },
+  ["SS_ANNE_BOW"] = { x = 8, y = 3, shape = "wide" },
+  ["VICTORY_ROAD_2F"] = { x = 16, y = 6, shape = "wide" },
+  ["VICTORY_ROAD_3F"] = { x = 20, y = 1, shape = "wide" },
+
+  -- ------- towns and the last interiors
+  ["CERULEAN_CITY"] = { x = 15, y = 16, shape = "wide" },
+  ["GAME_CORNER"] = { x = 8, y = 7, shape = "wide" },
+  -- the lab is ten cells by twelve, so the long lens is always off-map, and
+  -- on it a desk clipped one mon and a pillar the other
+  ["OAKS_LAB"] = { x = 3, y = 2, shape = "narrow", cam = "wide" },
+  -- Saffron's gym is a grid of small walled cells: no wide shape exists
+  -- anywhere in it, and the long lens sits inside a divider
+  ["SAFFRON_GYM"] = { x = 9, y = 7, shape = "narrow", cam = "wide" },
+  ["SILPH_CO_3F"] = { x = 18, y = 11, shape = "wide", cam = "wide" },
+  ["SILPH_CO_10F"] = { x = 1, y = 2, shape = "wide" },
+  ["SILPH_CO_11F"] = { x = 1, y = 11, shape = "wide", cam = "wide" },
+  -- the upper corridor (cols 4-5, rows 1-4) is sealed at runtime by the
+  -- gym's barrier, so arenas there silently fail the fit test
+  ["VERMILION_GYM"] = { x = 4, y = 11, shape = "narrow" },
+  ["VICTORY_ROAD_1F"] = { x = 11, y = 2, shape = "narrow" },
+  ["VIRIDIAN_FOREST"] = { x = 16, y = 34, shape = "narrow" },
+
+  -- ------- the remaining routes
+  ["ROUTE_19"] = { x = 8, y = 6, shape = "narrow" },
+  -- the two surf routes fight AFLOAT, in the middle of their own sea rather
+  -- than on the rim of beach the land search would otherwise find
+  ["ROUTE_20"] = { x = 23, y = 7, shape = "wide" },
+  ["ROUTE_21"] = { x = 8, y = 46, shape = "wide" },
+  ["ROUTE_22"] = { x = 35, y = 7, shape = "wide" },
+  ["ROUTE_23"] = { x = 4, y = 36, shape = "wide" },
+  ["ROUTE_24"] = { x = 13, y = 15, shape = "wide" },
+  ["ROUTE_25"] = { x = 32, y = 2, shape = "wide", cam = "wide" },
+
+  -- ------- caves, gyms and the Elite Four
+  --
+  -- None of these tilesets has a grass tile at all, so the no-grass rule
+  -- constrained nothing here; what constrains them is furniture, rock
+  -- pillars and how small the rooms are.
+  ["AGATHAS_ROOM"] = { x = 2, y = 1, shape = "narrow", cam = "wide" },
+  ["BRUNOS_ROOM"] = { x = 3, y = 1, shape = "narrow" },
+  ["CELADON_GYM"] = { x = 0, y = 3, shape = "narrow" },
+  ["CERULEAN_CAVE_1F"] = { x = 1, y = 7, shape = "narrow" },
+  -- 2F is a maze of one-cell rock corridors; all 24 of its candidate spots
+  -- hide a mon, so it borrows the floor below -- the same cave
+  ["CERULEAN_CAVE_2F"] = { map = "CERULEAN_CAVE_B1F", x = 2, y = 0,
+                           shape = "wide" },
+  ["CERULEAN_CAVE_B1F"] = { x = 2, y = 0, shape = "wide" },
+  ["CERULEAN_GYM"] = { x = 0, y = 1, shape = "narrow" },
+  ["CHAMPIONS_ROOM"] = { x = 2, y = 2, shape = "narrow", cam = "wide" },
+  ["CINNABAR_GYM"] = { x = 18, y = 10, shape = "narrow" },
+  ["DIGLETTS_CAVE"] = { x = 19, y = 16, shape = "wide" },
+  ["FIGHTING_DOJO"] = { x = 4, y = 1, shape = "narrow" },
+  ["LANCES_ROOM"] = { x = 5, y = 15, shape = "wide" },
+  ["LORELEIS_ROOM"] = { x = 5, y = 2, shape = "narrow" },
+  ["MT_MOON_1F"] = { x = 24, y = 17, shape = "wide" },
+  ["MT_MOON_B1F"] = { x = 5, y = 12, shape = "wide" },
+  ["MT_MOON_B2F"] = { x = 2, y = 16, shape = "wide" },
+
+  -- The three gyms the default rig cannot stand back from. Five blocks is
+  -- further than these rooms are wide, so the eye landed outside the map and
+  -- the border ring -- extruded into a cliff by this mode -- crossed the near
+  -- mon wherever it stood. `cam = "wide"` swaps in the 44-degree lens (see
+  -- BattleCam), which fits inside the room; the mons come out smaller and all
+  -- three became stageable. It is asked for HERE, per map, so every area that
+  -- does not ask keeps the long lens it was framed for.
+  ["FUCHSIA_GYM"] = { x = 7, y = 6, shape = "narrow", cam = "wide" },
+  ["PEWTER_GYM"] = { x = 4, y = 8, shape = "narrow", cam = "wide" },
+  ["VIRIDIAN_GYM"] = { x = 10, y = 8, shape = "narrow", cam = "wide" },
+}

--- a/mods/dramatic_shape/data/voxel_heights.lua
+++ b/mods/dramatic_shape/data/voxel_heights.lua
@@ -1,0 +1,3235 @@
+-- Voxel world mode: the shape PROFILE -- hand-authored pins over the
+-- automatic structure detector, the way a 3dSen game profile pins a
+-- graphic to a geometry type.
+--
+-- Hand-authored by this mod, and read only from here: unlike the tables the
+-- ROM extractor writes into the player's own cache, nothing below is
+-- extracted, derived or copied from the ROM.
+-- Nothing here reaches gameplay, collision or scripts; an entry can only
+-- ever change how a tile LOOKS in voxel mode.
+--
+-- Most of the world needs no entry. The runtime detects structures on its
+-- own (src/render/voxel/Structures.lua): it flood-fills each connected
+-- drawn thing, voxelizes small props per pixel at their real drawn height
+-- with transparency (a 2-row plant is a 16px-tall silhouette, not a box),
+-- and raises everything else as a volume whose height is measured from the
+-- drawing itself -- repeat-aware, so a 6-row house is 48px while a 40-row
+-- border forest is rows of 16px trees, not a monolith.
+--
+-- Listing a tile here BYPASSES that detection: the tile takes the class's
+-- height and art mode, always. Use it where the detector reads art wrong,
+-- or from a mod to pin its own tiles. Resolution order per tile:
+--
+--   1. a group listed under tilesets[<id>] below        (this profile)
+--   2. the tile sits in a water cell                    -> "water"
+--   3. the tile sits in a WALKABLE cell                 -> "ground"
+--   4. tile-level fallback: the map's water set -> "water", its walkable
+--      list -> "ground", anything left over             -> "wall"
+--
+-- Rules 2-3 work at CELL granularity (16x16, the walk grid) because that
+-- is the granularity collision actually has: the engine judges a cell by
+-- its bottom-left tile alone, so the other three tiles of a cell carry no
+-- collision meaning -- flowers and grass tufts sit in walkable cells and
+-- must stay flat ground even though no walkable list names them.
+--
+-- Classes (heights in world pixels; a map cell is 16x16):
+--   ground / water / void   flat; water recesses so shorelines show a lip
+--   ledge / roof / bed      box with the art on its TOP face; partial side
+--                           faces crop the art (a 6px ledge face is the
+--                           bottom of the lip drawing; a bed is its
+--                           mattress drawn from above, lying low)
+--   wall / tree / fence / sign / counter / table / desk
+--                           box whose SOUTH face folds the 2D artwork
+--                           upright, 8px band by band; authored boxes fold
+--                           every face and wear their top row's art on top.
+--                           A counter is half a cell -- one band, so its
+--                           drawn front panel stands and its top stays on top
+--   stair_e / stair_w       real steps rising toward the named side, the
+--                           full cell deep, treads and slices textured
+--                           from the drawn staircase
+--   stair_down_e / _down_w  a sunken stairwell: the cell opens into a
+--                           hole with steps descending toward the named
+--                           side -- stairs that lead DOWN a floor
+--   relief                  a prop drawn from above (a console on the
+--                           floor): the drawing stays flat and the
+--                           pixels inside its black outline extrude a
+--                           few voxels, art on top
+--   bookcase                a free-standing shelf drawn tall: each rank
+--                           collapses onto a one-cell-deep box at its
+--                           full drawn height; back rows become hidden
+--                           floor, and an unpinnable trim row above
+--                           becomes the cap
+--   billboard / prop        a prop drawn face-on: a standing per-pixel
+--                           cutout, black-outline segmented; drawn above
+--                           a pinned box it stands ON that box (a
+--                           monitor on its desk).  prop is a second pool
+--                           so two touching cutouts stay separate
+--
+-- A tileset entry may also carry `prop_ground` (not a class): a map of
+-- prop tile id -> ground tile id naming the tile painted under that
+-- pinned prop, overriding the flat-neighbour vote -- the cuttable bush
+-- stands on the grass Cut leaves behind, whatever borders it.
+--
+-- And `prop_bg` (not a class either): which GB shades count as BACKGROUND
+-- when a pinned per-pixel prop is cut out, for the drawings whose own body
+-- reaches the edge of their bounding box and so vote themselves away.
+-- Keyed by tile, because two props sharing an atlas can want opposite
+-- answers on the same shade.
+--
+-- And it may carry `figures` (not a class either): hand-drawn pixel masks
+-- that lift a FIGURE PAINTED INTO furniture off it and stand it up as a
+-- standee, leaving the furniture its own geometry.  A pin resolves a
+-- whole 8x8 tile, so it can never separate two things that share one --
+-- and nothing automatic can either when the figure has no background
+-- margin to flood from and wears the same shades as what it sits on.
+-- The Pokemon Center's seated man is the case; see POKECENTER below for
+-- the format.
+--
+-- Whole BUILDINGS are not tile pins -- one drawing packs a roof seen from
+-- above, a facade seen face-on and sloped ends as diagonal silhouettes,
+-- and no single class covers that.  They live in the `buildings` list at
+-- the bottom of this file, as a band table over the drawing's rows.
+
+return {
+  version = 1,
+
+  -- class -> height in world pixels
+  heights = {
+    ground = 0,
+    water = -2,
+    void = 0,
+    ledge = 6,
+    fence = 10,
+    sign = 12,
+    wall = 16,
+    -- masonry drawn two courses tall (the Indigo Plateau's rim, the
+    -- badge-check gates): as tall as a statue on its plinth
+    cliff = 32,
+    tree = 16,
+    roof = 28,
+    bed = 7,
+    stool = 8,
+    counter = 8,
+    table = 12,
+    desk = 24,
+    prop = 16,
+    cutout = 16,
+    relief = 3,
+    bookcase = 32,
+    stair_e = 16,
+    stair_w = 16,
+    stair_down_e = 16,
+    stair_down_w = 16,
+  },
+
+  -- Only tiles the detector must not touch need listing. Tile ids are
+  -- indices into the tileset's own 8x8 atlas.
+  tilesets = {
+    OVERWORLD = {
+      -- the hop-down edges named by data.field.ledges' ledgeTile: their
+      -- art is a ground lip seen from above, which the detector would
+      -- otherwise raise as a wall
+      -- $34 is the cliff slope's FOOT, and it also punctuates the ledge
+      -- rows: the hop-down runs are set into the cliff face and this
+      -- tile is the pillar between segments.  It was `wall` with the
+      -- rest of the slope chain, which stood those pillars 16px beside
+      -- a 6px lip -- the ledge line came out interrupted by blocks
+      -- nearly three times its height.  At ledge height the run reads
+      -- as one continuous lip, and the mound loses nothing: its foot
+      -- row simply reads as the talus it is drawn as.
+      ledge = { 13, 29, 39, 52, 54, 55 },
+      -- trees are drawn ROUND -- the lone canopy (42/43/58/59) and the
+      -- border tree wall (64/65/80/81, blockset $0F). Boxes and per-pixel
+      -- cutouts both read wrong for them; the cylinder archetype carves
+      -- one voxel ball per 16x16 cell from the canopy's darkest-pixel
+      -- outline, round in depth, so tree rows become rows of real canopies
+      cylinder = { 42, 43, 58, 59, 64, 65, 80, 81 },
+      -- the town sign (blockset 8's SE cell): a standing per-pixel slab
+      -- 2 voxels thin, transparency respected -- never a solid box
+      signpost = { 70, 71, 86, 87 },
+      -- the fence posts drawn in VERTICAL runs (14 the post tops, 85
+      -- the bottoms -- across all 222 maps the two tiles pair only in
+      -- this one cell). The detector already turns the HORIZONTAL runs
+      -- (tile 57) into per-post standees, but a vertical run of repeated
+      -- cells trips its scenery guard and fell to the volume path as a
+      -- fence-textured tower. `post` extracts each cell alone, so these
+      -- render as the same thin posts, marching north
+      post = { 14, 85 },
+      -- the cliff-mound's dark east slope and its NE corner ($24 the
+      -- slope column, $02 the corner).  Their drawn runs span the whole
+      -- mound drawing, so the detector raised them to 32px towers --
+      -- the rock pillar beside Diglett's Cave -- and the doorway
+      -- column, which adopts its REGION's height, inherited the same 32
+      -- and put the cave entrance a block above the mound around it.
+      -- Pinned to one 16px course they match the plateau body, and the
+      -- doorway drops with them.  ($34, the slope's foot, is `ledge`
+      -- instead -- see there.)
+      wall = { 2, 36 },
+
+      -- the cuttable bush ($2D/$2E/$3D/$3E, the four tiles Cut deletes
+      -- -- across the whole tileset they appear only in the five
+      -- cut-tree blocks): a standing per-pixel cutout 5 voxels deep,
+      -- black-outline segmented with the pixels the outline encloses
+      -- kept, its drawn grass dither flooding away as background
+      prop = { 45, 46, 61, 62 },
+      -- the ground painted under those pinned props, by the prop tile's
+      -- own id: the bush stands on plain grass ($2C) -- the very tile
+      -- Cut leaves behind (field.cutTreeSwaps' after-blocks) -- rather
+      -- than whatever flat tile its neighbours vote
+      prop_ground = { [45] = 44, [46] = 44, [61] = 44, [62] = 44 },
+    },
+
+    -- The badge gyms and Bruno's room (one tileset): the bird statues
+    -- that flank every gym's aisles, and Lt. Surge's trash cans.  A
+    -- statue is one cell of figure ($02/$38/$12/$13) drawn over one
+    -- cell of plinth ($22/$23/$32/$33); the trash can is one cell
+    -- ($0B/$0C/$1B/$1C, blocks 38/39 only).  Across the whole blockset
+    -- none of these tiles appears anywhere else.  The plinth stays a
+    -- SOLID 16px block; the figure stands ON it as a per-pixel cutout
+    -- 5 voxels deep (the thin `prop` pool), collapsing to the plinth's
+    -- single cell of footprint (Structures' wall-support rule); the
+    -- can is the same 5-voxel cutout at floor level.  Both are
+    -- black-outline segmented -- backgrounds flood away, the pixels
+    -- the outline encloses stay.  Everything stands on the gyms' main
+    -- floor tile ($11), which is also Bruno's floor.
+    -- (The round boulder drawn beside some statues, $07/$08/$17/$18,
+    -- is NOT pinned: it also tiles wall-to-wall as Pewter's rock rows,
+    -- which are scenery for the detector, not a lone prop.  Probed:
+    -- the repeat-aware scenery path already gives every one of them a
+    -- single 16px course in Pewter's and Bruno's rock walls alike, so
+    -- a pin would only restate the derived answer.)
+    --
+    -- The rest of the tileset is the ten rooms' own furniture: the six
+    -- badge gyms it serves (Pewter, Cerulean, Vermilion, Celadon,
+    -- Fuchsia, Viridian) plus Bruno's and Lorelei's rooms, the
+    -- Champion's room and the Hall of Fame.  (Saffron's and Cinnabar's
+    -- gyms are FACILITY, Agatha's room is CEMETERY and Lance's is DOJO,
+    -- so none of them takes a pin from here.)  Same failure as every
+    -- other interior: the detector reads the black interior walls as
+    -- volumes measured off the whole drawn run, so Vermilion's side
+    -- walls and Viridian's north-south maze arms came out as 48px fins
+    -- with their black fill VOIDED flat between them, and the Hall of
+    -- Fame's recording machine merged into the wall band as a 32px slab
+    -- whose feet had been flattened away by the walkable-cell rule.
+    GYM = {
+      -- The wall band is ONE 16px face, whatever the artist drew into
+      -- it.  The plinths (34/35/50/51 -- 50 is the $32 water-fallback
+      -- trap and would recess into a pond lip); the room's own band
+      -- ($05 white course, $10 trim, $06 the doorway's dark head); the
+      -- BLACK interior walls every gym is partitioned with -- $0F the
+      -- fill (near-black, so the void rule flattens it unless it is
+      -- AUTHORED, which is the whole reason it is listed), $24/$26/$27
+      -- the top edge and its corners, $25/$35 the sides, $42/$3E the
+      -- west and east end caps of a horizontal arm and $10 again as its
+      -- lit south face.  Then the things drawn built INTO those walls,
+      -- exactly like the Center's healing consoles: Vermilion's target
+      -- band ($44-$47 with $05 between, over the $54/$56/$57 stripe),
+      -- the barred gate ($20/$21/$30/$31 -- Lorelei's north door, and
+      -- the barrier VermilionGymScript paints in until both switches
+      -- are thrown), and Vermilion's corner switchboard ($29/$2A over
+      -- $0D/$0E and $1D/$1E), which is drawn 32px tall and so reads as
+      -- two stacked courses of the same band.
+      wall = { 34, 35, 50, 51,
+               5, 16,
+               15, 36, 37, 38, 39, 53, 62, 66,
+               68, 69, 70, 71, 84, 86, 87,
+               32, 33, 48, 49,
+               13, 14, 29, 30, 41, 42 },
+      -- Fuchsia's invisible maze walls ($1F) are deliberately NOT here.
+      -- The artist drew them as the floor with its stripes broken: on
+      -- the GB they are invisible, and the puzzle IS walking into them.
+      -- Raising them to a course would read better as a room and give
+      -- the player something to bump into -- and would also hand them
+      -- the solution, turning a maze into a corridor.  A shape is
+      -- purely presentational and this file's job is to reproduce what
+      -- was drawn, so the drawn answer wins: left to the derived path,
+      -- $1F stays the floor it is painted as and the gym plays exactly
+      -- as the flat game does.
+      -- Cerulean's pools are the ONE place the $14 water-fallback trap
+      -- is right: $14 really is the gym's water, so it is left to fall
+      -- through to the engine's water set and recess.  Its north coping
+      -- ($04, the grated lip) is drawn in the TOP half of a water cell,
+      -- so the cell rule dragged it down to the water line with it;
+      -- pinned flat it stays the poolside at floor level and the water
+      -- shows a real lip.  The pool's south lip ($01) needs nothing --
+      -- it is always the top half of a walkable FLOOR cell, so rule 3
+      -- already lays it flat.  Lorelei's room uses the same pair for
+      -- the paved plaza that stands out of her water.
+      -- the entrance mat every gym lays inside its door ($06 over $16,
+      -- 28 placements and nowhere else): drawn from straight above, so
+      -- it lies FLAT.  $06 was in the wall band above, which stood the
+      -- mat's top half up as a 16px box in the doorway -- the cell rule
+      -- could not save it, because a pin outranks the cell.
+      ground = { 4, 6, 22 },
+      -- Celadon's hedge: a round shrub, one per cell ($2C/$2D over
+      -- $2E/$2F), 35 of them planted wall to wall.  Round drawings get
+      -- the cylinder archetype -- one voxel ball per 16x16 cell carved
+      -- from the darkest-pixel outline -- the same treatment the
+      -- overworld's tree canopies take, and per-CELL, so a hedge row
+      -- becomes a row of bushes instead of one boxed monolith.
+      cylinder = { 44, 45, 46, 47 },
+      -- The statues, the cans, and Celadon's three little trees
+      -- ($40/$41 canopy over $50/$51 trunk).  A trunk is not round, so
+      -- the tree cannot be a ball like the shrubs beside it -- it takes
+      -- the thin standee pool every interior plant takes, which is also
+      -- a pool apart from the cylinders it touches.
+      prop = { 2, 56, 18, 19, 11, 12, 27, 28,
+               64, 65, 80, 81 },
+      -- The Hall of Fame's recording machine, the one piece of real
+      -- furniture in the tileset.  It is drawn 32px wide and THREE tile
+      -- rows tall against the north band, and the detector made a mess
+      -- of it twice over: the top two rows merged into the wall band as
+      -- one 32px slab, and the base row -- whose cell is walkable,
+      -- because the Hall's floor tile ($19) is its own bottom-left --
+      -- was flattened into the floor, so the machine stood on nothing.
+      -- Split at the drawn seam: the plinth row ($58/$59/$5A) is a
+      -- half-cell counter, and the console above it ($5B-$5E over
+      -- $36/$37/$55/$5F) is a standing per-pixel billboard that rides
+      -- the plinth's top face through the authored-box support rule.
+      -- 8 + 16 is exactly the 24px the machine is drawn.
+      counter = { 88, 89, 90 },
+      billboard = { 91, 92, 93, 94, 54, 55, 85, 95 },
+      -- the ground painted under each pinned prop, by the prop tile's
+      -- own id: statues and cans stand on the gyms' main floor ($11),
+      -- Celadon's trees on the garden's light dither ($2B) rather than
+      -- on whatever their neighbours vote.
+      -- (Celadon's flowerbed tile $03 is deliberately absent: the
+      -- tileset ANIMATES it by frame rewrite, so TileShape derives the
+      -- `flower` pin for it already -- flat ground plus a standing
+      -- 1px cutout -- and listing it here would take that away.  The
+      -- floors need nothing either.  $11/$16/$2B and Viridian's arrow
+      -- and dot markings $3C/$3D/$3F/$4C/$4D are in the walkable list
+      -- outright; the paved slabs the Hall of Fame is floored with and
+      -- Lorelei's plaza is built of ($09/$0A over $19/$1A) get there
+      -- through the CELL: only $19 is listed, but it is the cell's
+      -- bottom-left, so rule 3 lays all four of them flat together.
+      -- Cerulean uses the very same slab as its poolside deck, which is
+      -- why that gym's perimeter is a deck and not a wall -- the room's
+      -- only wall band is the one drawn course along its north edge.)
+      prop_ground = { [2] = 17, [56] = 17, [18] = 17, [19] = 17,
+                      [11] = 17, [12] = 17, [27] = 17, [28] = 17,
+                      [64] = 43, [65] = 43, [80] = 43, [81] = 43 },
+    },
+
+    -- The caves: one blockset serves nineteen maps -- Mt Moon's three
+    -- floors, Rock Tunnel's two, Seafoam Islands' five, Victory Road's
+    -- three, Cerulean Cave's three, and Diglett's Cave with its two
+    -- route-side stubs.
+    --
+    -- THE CAVE'S VERTICAL SCHEME.  A Gen 1 cave is drawn on two floor
+    -- levels, and the game's own collision data says which is which.
+    -- data.field.tilePairs forbids stepping between $20/$21/$2A/$41 and
+    -- $05 on land, and between $14 and $05 while SURFING -- but nothing
+    -- forbids $14 <-> $20.  Read that back and the elevation falls out:
+    -- the dark floor and the water are one plane, the lit floor is a
+    -- step above both, and the rock is the room around them.
+    --
+    --        h  what                                 tiles
+    --        0  DARK LOWER FLOOR -- the datum         $20 $21 $2A
+    --        0  CAVE WATER, the surfable pool         $14
+    --        0  fall-through drop hole                $2F $22
+    --        0  unlit black (the void rule, no pin)   $3C
+    --        3  Victory Road's boulder switch plate   $2B $2C $2D $2E
+    --        6  LIT SHELF, one step up (`ledge`)      $05 $29
+    --        6  the stair plate down off that shelf   $15 $16
+    --       16  ROCK -- one band for the masses, the  everything else
+    --           faces, the caps and the ceiling mass
+    --   0 up 16  ladder shaft UP a floor              $0A $0B $1A $1B
+    --   0 dn 16  ladder shaft DOWN a floor            $08 $09 $18 $19
+    --
+    -- NO CAVE SURFACE SITS BELOW 0.  The datum is the dark floor; the
+    -- water is level with it (you surf off a pool straight onto the dark
+    -- floor, which is exactly what the missing $14/$20 tile pair says);
+    -- every other surface is above it.  A cave is underground, not
+    -- underwater, and the only class in this file that goes negative is
+    -- `water` (-2), which exists to cut the overworld's shoreline lip.
+    -- It is deliberately NOT used anywhere in this entry.  The one thing
+    -- that does reach below the datum is the DOWN ladder's stairwell,
+    -- which is a hole on purpose: it is the shaft to the floor below,
+    -- and no walkable surface is drawn in it.
+    --
+    -- What the detector made of it: the rock EDGES towered.  A shelf's
+    -- side is drawn as a cap over a run of face tiles over a corner
+    -- pair -- $04 / $31 x5 / $28 / $10 down one column -- and the volume
+    -- builder's repeat scan anchors on the column's FRONT tile, which
+    -- here is a one-off corner that never recurs above it.  Neither the
+    -- repeat read nor the trim rule (two identical rows directly above
+    -- the front) fires, so the column keeps its whole extent and caps at
+    -- MAX_ROWS: a 48px fin out of the 16px band beside it, while the
+    -- column one tile west -- ending on $28 with two $31 above -- reads
+    -- 16.  Probed before pinning: MT_MOON_B2F tiles (5,4)-(5,11) and
+    -- (17,8)-(17,15) at 48 with 16 either side; VICTORY_ROAD_2F
+    -- (25,26)-(25,31); SEAFOAM_ISLANDS_B4F (22,0)-(22,7),
+    -- (13,12)-(13,19) and (12,13)-(12,19).  The same reading turns a
+    -- column of four DIFFERENT rock tiles into 32px -- VICTORY_ROAD_1F
+    -- (28,20)-(29,23) and (30,20)-(31,23), $02/$12 over $0C/$1C, next
+    -- to identical rock at 16.  An authored tile never reaches the
+    -- volume builder, so pinning the rock is the whole fix: there is no
+    -- run left to misread.
+    CAVERN = {
+      -- ---- 16: the rock, one band ----
+      --
+      -- Reading across the blockset: $02/$03 over $12/$13 is the
+      -- speckled rock mass and $0C/$0D over $1C/$1D the boulder-cluster
+      -- mass, both solid wall-to-wall fills; $10/$11 is the cobble
+      -- course facing the south side of every lit shelf, $31 its west
+      -- face and $17 its east; $04/$07/$28 are the caps and $25/$26 the
+      -- inner corners where two faces meet.  $0E/$0F over $1E/$1F is the
+      -- barred rock shelf that stands alone on the dark floor
+      -- (MT_MOON_1F, ROCK_TUNNEL_1F and twice in SEAFOAM_ISLANDS_B4F):
+      -- one cell of face-on drawing, so one 16px face -- never a
+      -- standee, its black surround touches all four rims and would
+      -- segment into a solid slab.
+      --
+      -- $06/$27 over $24/$01 is the CEILING MASS: a pale dithered rock
+      -- fill with a black rim dithered along its north and south edges,
+      -- so a run of it tiles into the grid of light blocks that walls
+      -- off most of MT_MOON_B2F (37 cells) and stands as one lump in
+      -- each of VICTORY_ROAD_1F/2F/3F.  It is blocked in every map that
+      -- places it ($24 is not on the walkable list) and it is NOT in the
+      -- engine's water set, so it is rock and belongs in the band with
+      -- the rest of the rock.  The first pass read the checker as a pond
+      -- and pinned it `water`: that recessed 612 tiles to -2 and cut
+      -- open trenches down the middle of Mt Moon B2F -- 06w-2 27w-2 /
+      -- 24w-2 01w-2 for ten cells straight, hard against 31w16 rock and
+      -- the 05l06 shelf.  Its unpinned reading was 48px (eight rows of
+      -- alternating $06/$24 read as one drawing); 16 is the answer.
+      wall = { 2, 3, 18, 19,       -- $02/$03 over $12/$13, speckled mass
+               12, 13, 28, 29,     -- $0C/$0D over $1C/$1D, boulder mass
+               16, 17,             -- $10/$11, the shelf's south cobbles
+               49, 23,             -- $31 west face, $17 east face
+               4, 7, 40,           -- $04 NW cap, $07 NE cap, $28 SW cap
+               37, 38,             -- $25/$26, the inner corners
+               14, 15, 30, 31,     -- $0E/$0F over $1E/$1F, barred shelf
+               6, 39, 36, 1 },     -- $06/$27 over $24/$01, ceiling mass
+      -- ---- 6: the lit shelf, and the stairs off it ----
+      --
+      -- $05 is the lit floor -- the shipped pin, and the step
+      -- data.field.tilePairs encodes ($20/$21/$2A/$41 <-> $05).  $29 is
+      -- the SAME surface: the artist's shadow row where the shelf runs
+      -- up against the rock above it.  It sits in walkable cells, so
+      -- unpinned it resolved to flat ground and cut a 6px trench along
+      -- the north edge of every lit room (`29g00` with `05l06` one tile
+      -- south, all the way across MT_MOON_B2F).
+      --
+      -- $15/$16 is the STAIR down off that shelf, and the elevation it
+      -- spans is 6px, not 16.  Its art is four treads seen from above,
+      -- each a light tread over a black riser line, stacked NORTH-SOUTH:
+      -- every one of the 54 stair cells in the tileset has the lit floor
+      -- $05 to its NORTH and the low ground to its SOUTH (dark floor x35,
+      -- water x14, lit floor x5 where two flights meet), so the flight
+      -- climbs NORTHWARD, one cell deep, 0 -> 6.
+      --
+      -- It is NOT pinned `stair_e`/`stair_w`, and that is deliberate.
+      -- Those classes build a flight that marches along X -- 16px tall,
+      -- rising toward the named side -- so either of them here would
+      -- throw a 16px staircase sideways across a 6px north-south step,
+      -- blocking the passage it is supposed to open and climbing at
+      -- right angles to the drawn risers.  A wrong-way flight is worse
+      -- than a flat one.  `ledge` is the honest reading available: the
+      -- stair cell joins the shelf it belongs to, wears its four treads
+      -- on the TOP face (which is how they are drawn -- from above), and
+      -- puts its 6px riser face at the FOOT of the flight where the
+      -- player actually steps down onto the dark floor.  See the report:
+      -- a real sloped cave stair wants `stair_n`/`stair_s` in
+      -- Structures.stairCell, which is an engine change, not a pin.
+      ledge = { 5, 41,             -- $05 lit floor, $29 its north shading
+                21, 22 },          -- $15/$16, the stair plate off it
+      -- ---- 0: the floor plane ----
+      --
+      -- The dark lower floor, pinned rather than left derived so the
+      -- datum this whole entry measures from is stated in it.  $20 is
+      -- the rough floor, $21 the bright checker, $2A the fine checker;
+      -- all three are on the tileset's walkable list and all three
+      -- already resolved here -- the pins restate the level, they do not
+      -- move it.
+      --
+      -- $14 IS THE CAVE WATER: the tileset animates by TILEANIM_WATER,
+      -- and TileRenderer's WATER_TILE is $14 -- it is the tile that
+      -- h-shifts to ripple.  Map's water set names it too, so its cells
+      -- are the ones Surf works on: Cerulean Cave's lake (352 + 272
+      -- tiles on 1F/B1F) and the Seafoam channels (304 on B3F, 816 on
+      -- B4F).  The first pass read its blocky white dither as "bright
+      -- rubble mass" and pinned it `wall`, which stood both lakes up as
+      -- 16px rock -- two thirds of SEAFOAM_ISLANDS_B4F was a rock slab
+      -- you were meant to surf across.  It is water, and it lies at the
+      -- floor plane: `ground` keeps the drawn (and animated) water art
+      -- exactly as it is and puts its surface at 0, level with the dark
+      -- floor you step off onto, one 6px step below the lit shelf you
+      -- cannot surf onto.  NOT the `water` class -- that is -2, a
+      -- shoreline lip for the overworld sea, and a cave pool must never
+      -- read as a trough sunk into the floor you are walking on.
+      --
+      -- $2F over $22 is Seafoam's and Victory Road's fall-through drop
+      -- hole (Map's warpPadTiles calls $22 a "hole").  Its art is a lit
+      -- rim over solid black and its cell is walkable -- you step on it
+      -- and drop a floor -- so it stays flat at the floor plane; the pin
+      -- keeps the rim out of the wall fallback.
+      ground = { 32, 33, 42,       -- $20/$21/$2A, the dark lower floor
+                 20,               -- $14, the surfable cave water
+                 47, 34 },         -- $2F over $22, the drop hole
+      -- ---- 0 to 16: the ladders, the caves' real staircases ----
+      --
+      -- Both ladder graphics are drawn from above as a shaft with two
+      -- rails and rungs between them, and which one is which is not a
+      -- guess -- it is in the warp table.  Across all nineteen maps,
+      -- every one of the 37 $08 cells warps to a LOWER floor
+      -- (MT_MOON_1F->B1F, B1F->B2F, ROCK_TUNNEL_1F->B1F, each
+      -- SEAFOAM_ISLANDS floor to the next one down, CERULEAN_CAVE_2F->1F
+      -- and 1F->B1F, the Diglett's route stubs down into the cave) and
+      -- every one of the 40 $0A cells warps to a HIGHER one (the exact
+      -- reverse, plus MT_MOON_B1F's and ROCK_TUNNEL_1F's exits back out
+      -- to daylight).  $08 is the ladder DOWN, $0A the ladder UP: 77
+      -- cells, no exceptions.
+      --
+      -- So they take the two classes that MOVE between floors.  $0A
+      -- becomes a rising flight -- four real steps climbing 0 -> 16, the
+      -- height of the rock band it disappears into -- and $08 becomes an
+      -- excavated stairwell, four steps descending below the floor into
+      -- a dark opening.  East for both: the ladder art is symmetric
+      -- about its own centre line so the drawing does not choose a side,
+      -- the cell's east neighbour is the closed (rock) side more often
+      -- than its west, and the rest of this profile's staircases
+      -- (REDS_HOUSE_1, UNDERGROUND) climb east too.  The flight's treads
+      -- land one rung apiece, which is as close to a drawn ladder as
+      -- stepped geometry gets.
+      --
+      -- All four tiles of each cell are listed, the way REDS_HOUSE_1
+      -- lists its flight: buildStairs anchors on the cell's TOP-LEFT
+      -- tile ($08 / $0A) and claims the other three, but pinning them
+      -- too keeps them out of the region flood and the door fold.
+      stair_e = { 10, 11, 26, 27 },        -- $0A/$0B over $1A/$1B, UP
+      stair_down_e = { 8, 9, 24, 25 },     -- $08/$09 over $18/$19, DOWN
+      -- ---- 3: the boulder switches ----
+      --
+      -- Victory Road's four plates ($2B/$2C over $2D/$2E, on 1F, 2F and
+      -- 3F).  Round art, but NOT a round object: the Strength boulders
+      -- themselves are overworld SPRITES, and this is the plate they get
+      -- pushed onto -- drawn from straight above as a black ring, a
+      -- white highlight rim and a grey disc.  `cylinder` was tried here
+      -- first, because a circle is what the overworld's round canopies
+      -- take, and it came out wrong: the plate's own dithered background
+      -- carries stray black pixels the darkest-outline flood cannot
+      -- reach, so they joined the mask, inflated the top and bottom row
+      -- spans to the full 16, and the hull rendered as a clutch of white
+      -- shards standing where the plate should be (VICTORY_ROAD_1F cell
+      -- 17,13).  `relief` is the reading anything drawn from above
+      -- wants: the disc stays flat and the pixels inside its black ring
+      -- lift a few voxels, so it reads as a plate -- and the cell is
+      -- walkable, so you step on it.
+      relief = { 43, 44, 45, 46 },
+      -- Left to the derived default on purpose: $3C is solid black --
+      -- the unlit rock that is most of MT_MOON_B1F -- and the void rule
+      -- flattens it (`3Cv00`).  Pinning it would BREAK that, since the
+      -- void rule skips authored tiles; a 16px black band there would
+      -- also wall the corridors in with something the 2D art draws as
+      -- nothing at all.  $30 and $41 are on the walkable list and in
+      -- tilePairs but no block in this tileset places either, so there
+      -- is nothing for a pin to catch.
+    },
+    -- Viridian Forest.  Nearly everything drawn here is ROUND, and the
+    -- detector was boxing all of it: the big trees came out as ragged
+    -- mixed-height volumes (their sparse canopy-edge tiles read 0px,
+    -- their bodies 32px), the stump rows merged into 16px crate walls
+    -- wearing folded stump art, and the trail sign was a broken pile --
+    -- its $32 tile is the water-fallback trap and recessed into a pond
+    -- lip in the middle of the woods.
+    FOREST = {
+      -- the hop-down edge, from data.field.tilePairs (CAVERN's entry
+      -- above carries the same note for its own pair)
+      ledge = { 46 },
+      -- the big trees: the whole 2x2-CELL drawing carves as ONE 32px
+      -- voxel hull, so a tree is a single tall canopy instead of four
+      -- ground-level quarter-pancakes ("cut in half", as the first
+      -- attempt read).  `canopy` pins the drawing's top-left corner
+      -- tile ($04) as the group anchor; every other tile of the
+      -- drawing stays `cylinder` so the group build can verify and
+      -- claim its cells -- and so a stray partial drawing degrades to
+      -- per-cell hulls rather than boxes
+      canopy = { 4 },
+      cylinder = { 5, 6, 7, 21, 22, 23,
+                   35, 36, 37, 38, 39, 53, 54 },
+      -- the stumps ($02/$03/$12/$13): a hull whose drawn top is a CUT
+      -- FACE.  The body builds from the bark rows alone, and the drawn
+      -- ellipse of growth rings projects onto the hull's round flat
+      -- top -- its bottom arc to the south, the way the 2D art means
+      -- it.  stump_cap is the ellipse's height in art rows
+      stump = { 2, 3, 18, 19 },
+      stump_cap = 7,
+      -- the white sparkle filler inside the tree masses: flat, not an
+      -- invisible zero-height box
+      ground = { 0 },
+      -- the trail signs: the standing thin-slab treatment every town
+      -- sign gets ($32 pinned is also what lifts it out of the water
+      -- trap)
+      signpost = { 33, 34, 49, 50 },
+    },
+
+    -- Oak's Lab (the tileset also serves the Fighting Dojo and Lance's
+    -- room, which use none of these tiles).  The free-standing shelf
+    -- ranks: book rows and base pinned; the shared trim tiles above
+    -- (41/42, also the lab tables' corners) are adopted as caps by the
+    -- bookcase builder rather than pinned.
+    DOJO = {
+      bookcase = { 13, 14, 29, 30 },
+      -- the lab tables (the starter-ball display and the north tables):
+      -- 41/42 are also the shelf trim the bookcase builder adopts as
+      -- caps, which its cap rule allows for authored table rows.
+      -- Pinning stops the display frame's black corner brackets from
+      -- auto-extracting into standing prisms, and the ball/Pokedex
+      -- sprites ride the table's authored height.
+      table = { 41, 42, 57, 59, 78, 79 },
+    },
+
+    -- Red's room and the Copycat's room (one tileset).  The detector reads
+    -- this furniture as wall-height volumes -- and merges the wall-touching
+    -- table and desk INTO the wall, towering both -- so every object here
+    -- is pinned to the shape it depicts.
+    REDS_HOUSE_2 = {
+      -- the wall band with its windows stays one 16px face
+      wall = { 0, 36, 37, 52, 53 },
+      -- the bed: a mattress drawn from above, half a block high
+      bed = { 45, 46, 47, 61, 62, 63 },
+      -- stools: a seat-high box, seat art on top, legs on the front
+      stool = { 2, 3, 18, 19 },
+      -- the long table under the windows, and the PC desk's body with
+      -- its hutch row -- the monitor standing on it is pinned below
+      table = { 38, 39, 41, 42, 43, 44, 50, 51,
+                58, 59, 60, 66, 67 },
+      -- standing per-pixel props, black-outline segmented.  The PC
+      -- (64/65 monitor top, 32/33 monitor bottom + keyboard) is drawn
+      -- above the desk's body, so it stands ON the desk; the TV stands
+      -- on the floor
+      billboard = { 6, 7, 22, 23, 32, 33, 64, 65 },
+      -- the potted plant: mostly silhouette, so it takes the THIN
+      -- standee pool
+      prop = { 8, 9, 24, 25, 68, 69, 70, 71 },
+      -- the small potted plant on the table: a paper-thin profile
+      -- cutout standing on the tabletop, its leaf crown (in 40) included
+      cutout = { 40, 54, 55, 56, 57 },
+      -- the game console in front of the TV is drawn from above: it
+      -- lies flat and extrudes a few voxels inside its outline
+      relief = { 14, 15, 30, 31 },
+      -- the staircase leads DOWN to 1F: a sunken stairwell.  The player
+      -- enters at the east lip and the flight descends westward, the way
+      -- the drawn railing slopes (high at the east, low at the west)
+      stair_down_w = { 10, 11, 26, 27 },
+    },
+
+    -- Red's and the Copycat's ground floor (one tileset, same atlas as
+    -- the floor above).  Bookcases, dining table with its flower pot,
+    -- stools, the TV on the floor, and the staircase up.
+    REDS_HOUSE_1 = {
+      wall = { 0, 36, 37, 52, 53 },
+      stool = { 2, 3, 18, 19 },
+      -- the dining table (38-44/58-60); its top row also caps the
+      -- bookcases below
+      table = { 38, 39, 41, 42, 43, 44, 58, 59, 60 },
+      -- the bookcase bodies: tall shelf boxes; their drawn top-edge row
+      -- (38/41, pinned table above) becomes their top face
+      desk = { 34, 35, 48, 49, 50, 51 },
+      -- the TV on the floor
+      billboard = { 6, 7, 22, 23 },
+      -- the small potted plant on the table: a paper-thin profile
+      -- cutout standing on the tabletop, its leaf crown (in 40) included
+      cutout = { 40, 54, 55, 56, 57 },
+      -- the staircase leads UP to 2F: a rising flight climbing east
+      stair_e = { 12, 13, 28, 29 },
+      -- the front-door mat: its collision tile is $14, which the engine's
+      -- stale-cache fallback counts as water in every tileset, so the rug
+      -- would recess into a pond lip.  It is a flat rug on the floor
+      ground = { 4, 20 },
+    },
+
+    -- The generic town house (Blue's, Daisy at her table, and eighteen
+    -- more homes; the schoolhouse and the trashed house reuse it too).
+    -- Same failure as Red's rooms: the detector reads the furniture as
+    -- wall-height volumes and towers the table, so every object is
+    -- pinned to the shape it depicts.
+    HOUSE = {
+      -- the wall band stays one 16px face: blank courses, the window,
+      -- the framed picture, and the schoolhouse blackboard (72-75/88-91)
+      wall = { 0, 36, 45, 46, 52, 61, 62, 72, 73, 75, 88, 89, 90, 91 },
+      -- stools: a seat-high box that also seats Daisy
+      stool = { 2, 3, 18, 19 },
+      -- the dining table (top edge 38/41 also caps the bookcases);
+      -- 80-83 are its ransacked corner in CERULEAN_TRASHED_HOUSE, which
+      -- stays at table height rather than de-merging into a wall stub
+      table = { 38, 39, 41, 47, 54, 57, 58, 59, 60, 80, 81, 82, 83 },
+      -- the bookcase bodies: book ranks (14/15 left pair, 48/49 right)
+      -- and the base course; the drawn top edge (38/41, pinned table
+      -- above) becomes their top face
+      desk = { 14, 15, 30, 31, 48, 49 },
+      -- the corner potted plants: mostly silhouette, the THIN standee
+      -- pool (crown 10/11, leaves 8/9/26/27, pot 24/25)
+      prop = { 8, 9, 10, 11, 24, 25, 26, 27 },
+      -- the open book on the schoolhouse table: a paper-thin cutout
+      -- standing on the pinned tabletop
+      cutout = { 70, 71, 86, 87 },
+      -- the front-door mat: same $14 water-fallback trap as Red's; flat
+      ground = { 4, 20 },
+    },
+
+    -- The Pokemon Center lobby.  One tileset serves all eleven Centers
+    -- and the Celadon Hotel, and VIRIDIAN_POKECENTER places every tile
+    -- the other maps use, so this list -- read off Viridian -- covers
+    -- them all.  (The Marts are a DIFFERENT tileset id, MART, that only
+    -- shares the atlas image; pins do not carry over.)  Same failure as
+    -- the houses: the detector merges the wall-touching counters and
+    -- machines into the wall and towers them, and the lounge seat --
+    -- which has a PERSON drawn into the tile art -- becomes a monolith
+    -- wearing his face.
+    POKECENTER = {
+      -- the wall band stays one 16px face: striped panels (40), the high
+      -- windows (92-95; 94 doubles as the map's warp tile, and pins are
+      -- look-only), the pokeball poster (2/3/18/19), and the pillars
+      -- (16/41) with their bases (4/5/20/21; 20 is the $14 water-fallback
+      -- trap and would recess into a pond lip).  The healing machines'
+      -- bodies (72/76/77 console face, 6/22 button panel, 73 light edge,
+      -- 7/13 shadowed edge) are ALSO wall: drawn 16px tall against the
+      -- band, so wall height is their drawn height and they read as
+      -- consoles jutting from it; the near-black screen tiles must be
+      -- pinned or the void rule flattens them, and 72 is the $48
+      -- water-fallback trap
+      wall = { 2, 3, 4, 5, 6, 7, 13, 16, 18, 19, 20, 21, 22, 40, 41,
+               72, 73, 76, 77, 92, 93, 94, 95 },
+      -- the counters, half a cell high: top band (8) with the nurse's
+      -- tray (10), front face (24/25, the game's counterTiles), left end
+      -- cap (56) and the Cable Club's light sections (90/91).  8px is
+      -- one clean band, so the drawn front panel stands up and the
+      -- counter top stays on top; at 12 they read as wall stubs
+      counter = { 8, 10, 24, 25, 56, 90, 91,
+                  -- and the lounge couch with the man sitting on it.
+                  -- Same half-cell box: its bottom row (42/43, the front
+                  -- base) stands up as the couch's front, and the three
+                  -- rows above it -- cushion (38/39) and the man
+                  -- (36/37 head, 52/53 face) -- ride the top face in
+                  -- drawn order, each exactly once.  See the note below
+                  -- on why he cannot be stood upright.
+                  36, 37, 38, 39, 42, 43, 52, 53 },
+      -- standing per-pixel props, black-outline segmented: the healing
+      -- machines' screen tops (58/59/74/75, drawn above the pinned
+      -- bodies so they stand ON them) and the PC (66/70/82/86), which
+      -- stands on its pinned desk
+      billboard = { 58, 59, 66, 70, 74, 75, 82, 86 },
+      -- The man on the couch, cut out by hand and stood up (see `figures`
+      -- below).  Nothing automatic reaches him.  A class pin resolves a
+      -- whole 8x8 tile and he SHARES his tiles with the couch, so pinning
+      -- them stands the furniture up with him; riding the couch's top
+      -- face (what this did before) draws him lying flat on the cushion;
+      -- and he cannot be segmented into a standee either, because the
+      -- drawing has no background margin for a flood to enter by and his
+      -- skin is the same light shade as the couch -- the mask drained 307
+      -- of his 420 interior pixels, 46% of him, even segmented alone.
+      -- An authored mask is the only thing that can tell a man from the
+      -- sofa he is painted into, so that is what `figures` carries.
+      -- the PC's desk body, which the PC stands on
+      table = { 9, 88 },
+      -- the potted plants: bush (32/33/48/49) over pot (34/35/50/51,
+      -- 50 is the $32 water-fallback trap).  Standing per-pixel
+      -- billboards in the THIN pool, like every other interior plant --
+      -- and a pool apart from the sofa, which touches the corner pair
+      -- and must stay a separate object.  The bush's light checker
+      -- highlights share the floor's shades, so the mask drains some of
+      -- them; the standee reads darker than the flat art, which is the
+      -- accepted trade for a real plant silhouette
+      prop = { 32, 33, 34, 35, 48, 49, 50, 51 },
+      -- ...but the POTS were draining outright.  The plant pair is drawn
+      -- as one 4x4-tile block and the pot's olive base is flush on that
+      -- block's bottom row, so the background vote -- which reads the
+      -- shades touching the drawing's own bounding box -- came back with
+      -- "dark" in it, and every dark pixel in the plant left with the
+      -- floor.  The pots rendered as hollow black frames around one or
+      -- two surviving pixels while the flat art has solid olive bodies.
+      --
+      -- So name the background outright for these eight tiles: the floor
+      -- IS light and white here, and nothing else is.  That restores 152
+      -- pixels of the block (55% -> 69% of it kept) and cannot move any
+      -- other prop, which matters -- the same call tileset-wide would pull
+      -- the dark wall band into the healing consoles' screens and strip
+      -- three pixels off the PC, because those two want the opposite
+      -- answer on the very same shades.
+      prop_bg = {
+        { tiles = { 32, 33, 34, 35, 48, 49, 50, 51 },
+          shades = { "light", "white" } },
+      },
+      -- THE MAN ON THE COUCH.  He is drawn INTO the lounge furniture and
+      -- spills out of it in BOTH directions, which is why he needs three
+      -- tile columns:
+      --
+      --   36 / 52   the couch's west arm.  36's two RIGHTMOST columns are
+      --             the back of his head; 52 is the plain arm, and is also
+      --             what 36 wears once his hair comes off it
+      --   37 / 53   him: head, then face and body
+      --   57 / 60   the floor east of the couch, which his hair and his
+      --             foot overhang.  1 and 26 are those same two floor
+      --             tiles as the artist drew them WITHOUT him -- 8 and 5
+      --             pixels apart respectively -- so lifting him off is
+      --             lossless there
+      --
+      -- `pixels` is the hand-drawn line between the man and the furniture;
+      -- `under` is what each tile wears once he is lifted off it.  The
+      -- couch keeps its polygonal box and he stands on top of it.
+      --
+      -- The mask keeps ALL of 37/53's column 7, the couch's east edge.
+      -- Where that column is drawn dark it is the couch's own rule -- but
+      -- it is also where his hair crosses the tile seam, so dropping it
+      -- floats the overhang free of his head.  And where it is drawn WHITE
+      -- it is the right side of his face, so dropping it opens a slit down
+      -- his cheek (rows 5-8, which is exactly what the first cut did).
+      -- Keeping the rule twice costs nothing: tile 39 redraws it on the
+      -- couch beneath him either way.  Repainting 36 as 52 does cost one
+      -- row -- 36's top trim band, which 52 does not carry -- and that is
+      -- the accepted price for not leaving a second copy of his head lying
+      -- on the arm.  The background corners around his head and the
+      -- cushion wedge under his legs are the only pixels given back.
+      figures = {
+        {
+          w = 3,
+          tiles = { 36, 37, 57,
+                    52, 53, 60 },
+          under = { 52, 39,  1,
+                    52, 39, 26 },
+          pixels = {
+            "..........XXXXX.........",
+            "........XXXXXXXX........",
+            ".......XXXXXXXXXX.......",
+            "......XXXXXXXXXXXX......",
+            "......XXXXXXXXXXXX......",
+            "......XXXXXXXXXXX.......",
+            "......XXXXXXXXXXX.......",
+            "......XXXXXXXXXXX.......",
+            "........XXXXXXXXX.......",
+            "........XXXXXXXX........",
+            "........XXXXXXXX........",
+            "........XXXXXXXX........",
+            "........XXXXXXXXX.......",
+            ".........XXXXXXXXX......",
+            "...........XXXXXX.......",
+            "..............XX........",
+          },
+        },
+      },
+    },
+
+    -- The Poke Marts (one 4x4 layout serves every city; the tileset
+    -- shares the Center's atlas image but is its own id, so the pins
+    -- above do not carry over).  Same failures as everywhere indoors:
+    -- the detector towered the whole north display band to 32px, merged
+    -- the clerk's booth into a 48px slab wearing the juice poster, and
+    -- boxed the two free-standing shelf racks into one 4-tile-deep
+    -- monolith.
+    MART = {
+      -- THE BACK WALL.  It is drawn FOUR tile rows tall -- trim (40, or
+      -- the fridge tops 90/91), the SALE signs (78/79) or glass upper
+      -- (44/45), the black display niche (76/77) or glass lower (46/47),
+      -- and the cases' base and goods (23/29, 62/63) -- which is 32px of
+      -- artwork depicting ONE wall, not four things at four depths.
+      --
+      -- Pinned `wall` that is exactly what it became: every row got its
+      -- own 16px box marching north, so the only face you ever saw was
+      -- the southmost row (the cases' base), the signs and the niche hid
+      -- behind it, and the trim ended up lying flat as a gold shelf on
+      -- the roofs of the boxes behind.  Laid out in depth instead of
+      -- stacked up.
+      --
+      -- `bookcase` is the class that collapses a tall drawing onto a
+      -- one-cell-deep box at its real drawn height, so the run of four
+      -- rows becomes a single 32px wall: bands from the south are base,
+      -- niche, sign, trim, its top face wears the trim, and the three
+      -- rows behind become hidden floor.  Same treatment the shelf racks
+      -- below already get -- a Mart's back wall IS a wall of display
+      -- cases, and the geometry does not care which we call it.
+      bookcase = { 23, 29, 40, 44, 45, 46, 47, 62, 63, 76, 77, 78, 79,
+                   90, 91,
+                   -- the free-standing shelf racks: TALL drawings, not
+                   -- deep ones -- each rank collapses onto a
+                   -- one-cell-deep shelf at its drawn height (the
+                   -- Dojo/Red's-house treatment). 64/65/67 and 80/81/83
+                   -- are the bottle rows the clerk's booth also wears as
+                   -- its top display; 68/69/71 and 84/85/87 the goods
+                   -- rows below
+                   64, 65, 67, 68, 69, 71, 80, 81, 83, 84, 85, 87 },
+      -- The wall's own tiles are reused elsewhere, and the back wall is
+      -- the one place they are drawn on the map's TOP EDGE.  So `bookcase`
+      -- is their default and this hands every other use back to `wall`,
+      -- which is what all of them were before: 40 is also the clerk's
+      -- booth back panel (under the shelf rows 80/81 or under itself), and
+      -- 40/76/77/90/91 all recur in INDIGO_PLATEAU_LOBBY, the ninth map on
+      -- this id, where they draw the hall and the lift bank.
+      --
+      -- NEVER put 0 in an `above` set.  Map:tileAt does not answer nil off
+      -- the top of a map -- it border-extends, so row 0 reads the map's
+      -- borderBlock, which indoors is the black void block 0.  Listing 0
+      -- to catch the Lobby's void-backed 90/91 fired the rule on every
+      -- Mart's fridge row as well: row 0 dropped out of the bookcase run,
+      -- the fridges came out 24px against the SALE cases' 32px, and their
+      -- trim row stood as a separate box BEHIND the wall instead of on top
+      -- of it.  Nothing can separate those two cases from above -- both
+      -- see void -- so the Lobby (already out of scope here) gets the
+      -- bookcase reading too, and the Marts come out right.
+      when_above = {
+        [40] = { { above = { 40, 80, 81, 83, 90, 91 }, class = "wall" } },
+        [76] = { { above = { 74, 75 }, class = "wall" } },
+        [77] = { { above = { 74, 75 }, class = "wall" } },
+        [90] = { { above = { 17 }, class = "wall" } },
+        [91] = { { above = { 27 }, class = "wall" } },
+      },
+      -- the clerk's counter, half a cell high like every service
+      -- counter.  It is a C wrapping the alcove the clerk stands in: the
+      -- south arm's drawn front (24/25) under its top band (8/56), the
+      -- light work surface the east arm and the rest of the south arm
+      -- share (16/41), and the north arm's end panel (89).  8 and 56 are
+      -- the two halves of one top band -- the first pass read 8 as the
+      -- cash register, pinned it `billboard`, and got a bare black
+      -- outline standing on the counter with the tile's own art replaced
+      -- by its neighbour's.
+      -- ...and the register's own two tile rows (14/15 over 30/31) are
+      -- part of that same work surface now that the machine has been cut
+      -- off them as a sprite -- see `figures` below.
+      counter = { 8, 14, 15, 16, 24, 25, 30, 31, 41, 56, 89 },
+      -- Left to the derived default on purpose: the floor checker and
+      -- its shadowed variants (1/11/17/26/27/54) and the exit mat
+      -- (12/28) all sit in cells the ROM marks walkable, so the cell
+      -- rule lays them flat unaided.  (76/77, the SALE case's black
+      -- interior, used to be left to the volume path here; it is now the
+      -- back wall's third band, because a run of four rows has to be
+      -- contiguous for the wall to collapse into one box at all.)
+      -- THE CASH REGISTER: a keypad and a curl of receipt paper drawn
+      -- face-on across two tile rows in the middle of the counter's east
+      -- arm.  Like the Center's seated man it is a FIGURE drawn into the
+      -- furniture, so it gets the same treatment -- a flat sprite card
+      -- standing on the counter -- and for the same reason: no class pin
+      -- can separate it from the counter, because the counter draws its
+      -- own edging down columns 0 and 15 of the very same tiles.
+      --
+      -- That edging is what defeated every automatic reading. Black
+      -- always survives the shade flood, so the standee pools extruded
+      -- the two rules along with the machine and it stood flanked by a
+      -- pair of tall black slabs; `console`'s keep-the-largest-drawing
+      -- rule dropped them, but only by throwing away the receipt curl
+      -- too whenever the flood happened to cut it loose.  The mask just
+      -- says where the machine is: columns 2-13, plus the curl climbing
+      -- to the top right, and the counter keeps its edging and its light
+      -- work surface.
+      --
+      -- `under` is 16/41 twice -- the plain work surface, which already
+      -- carries the west edging (black over white) and the east (dark
+      -- over black), so the counter closes up behind the machine with no
+      -- synthesis at all.
+      figures = {
+        {
+          w = 2,
+          tiles = { 14, 15,
+                    30, 31 },
+          under = { 16, 41,
+                    16, 41 },
+          pixels = {
+            ".........XX.....",
+            "........XXXX....",
+            "........XXXXX...",
+            "........XXXXXX..",
+            "...XXXXXXXXXXX..",
+            "..XXXXXXXXXXXX..",
+            "..XXXXXXXXXXX...",
+            "..XXXXXXXXXXX...",
+            "..XXXXXXXXXXX...",
+            "..XXXXXXXXXXX...",
+            "..XXXXXXXXXXX...",
+            "..XXXXXXXXXXX...",
+            "..XXXXXXXXXXX...",
+            "..XXXXXXXXXXX...",
+            "..XXXXXXXXXXX...",
+            "..XXXXXXXXXXX...",
+          },
+        },
+      },
+      -- NOT covered: INDIGO_PLATEAU_LOBBY, the ninth map on this id and
+      -- the only one that is not the 4x4 shop.  It draws its own hall,
+      -- lift bank and rope stanchions from tiles no Mart places, three
+      -- of which fall in the engine's stale water set -- see
+      -- reports/COUNTERS_pass2.md.  Pinning them is a tileset pass of
+      -- its own and is deliberately not attempted here.
+    },
+
+    -- The route gates and their upstairs lounges, the four Underground
+    -- Path entrance huts, the Safari Zone gate and its four rest houses
+    -- -- twenty-five maps on one tileset.  (Viridian Forest's two gates
+    -- draw the very same art from a SEPARATE id, FOREST_GATE below, and
+    -- pins do not carry between ids.)  Before this entry every one of
+    -- them was a swimming pool: 50/51 -- the dark panel the artist reuses
+    -- as the wall's base course AND as every counter's front -- is one of
+    -- the three ids (20/50/72, the $14/$32/$48 of the stale cache) that
+    -- the engine's water set claims in every tileset, so the whole wall
+    -- perimeter and every counter front recessed into a moat.  The other
+    -- two are placed here as well: 20 is the exit doormat, 72 the top
+    -- course of Route 2's wall.  What survived the water was towered
+    -- instead -- the counters raised to a 16px slab, the cabinets boxed,
+    -- the 2F window read as a 16-to-40px skyline, and the tables and
+    -- binoculars flattened into the floor because their cells are
+    -- walkable.
+    GATE = {
+      -- The wall band stays ONE 16px face.  Three wall drawings share
+      -- it: the route gates' panelled course (32/33 -- its base course
+      -- 50/51 is `counter`, see below), the
+      -- Underground Path huts' and Route 22's plain stripes (0), and
+      -- Route 2's speckled plaster (72 over its dark skirting 74).  0
+      -- and 74 need no height correction but are pinned anyway, so the
+      -- detector cannot swallow the corner plants into the band and
+      -- tower them with it.  The gate 2F's big window is the same band
+      -- two cells deep (58 glass, 45 its dither, 61 the diagonal glare,
+      -- 62 the black mullions).  The door panes (41/43, the leaf drawn
+      -- above the walkable threshold) are wall too, so a doorway reads
+      -- as a recess in the band instead of a picture of a door lying on
+      -- the floor -- the Center's warp-tile treatment, and pins are
+      -- look-only so the cell stays walkable.
+      --
+      -- 50/51 is NOT in that list, and that is the one deliberate cost in
+      -- this entry.  The artist draws one panel twice: as the wall cell's
+      -- base course (32/33 over 50/51) and as the front of every counter
+      -- (7/9/8 or 17/18 over 50/51).  A pin is per tile id and a class
+      -- carries one height, so the two uses cannot be separated here at
+      -- all -- only in `lib`, by letting a pin be conditional on the tile
+      -- drawn ABOVE (see reports/COUNTERS_pass2.md).  Pinned `wall` (16)
+      -- the band is one clean face and the counter the guard stands
+      -- behind is a full 16px slab that hides him to the shoulders.
+      -- Pinned `counter` (8) every counter is the half cell it is drawn
+      -- as -- which is what the room is FOR -- and the price is that the
+      -- wall cell's front 8px of depth drops with it: a shallow wall
+      -- gains an 8px plinth (reads as a wainscot), and the deep margin
+      -- masses that run two to eight cells north-south down the east and
+      -- west sides of the fourteen maps that place both drawings (Routes
+      -- 5/6/7/8, the five gate 1Fs, the Safari gate and its four rest
+      -- houses) corrugate, their exposed flank stepping 16/8/16/8 every
+      -- 8px of depth.  The other six -- Route 2, Route 22 and the four
+      -- Underground Path huts -- place 50/51 and never 32/33, so they
+      -- take the half cell for nothing.  The counters win where it costs:
+      -- they are the object the player walks up to and talks over, they
+      -- sit mid-room, and the margin masses are pure border filler seen
+      -- edge-on.  This also puts GATE and FOREST_GATE on the same footing
+      -- at last -- ROUTE_2_GATE draws the forest gates' room tile for
+      -- tile and used to be the only one of the three with a 16px front.
+      wall = { 0, 32, 33, 41, 43, 45, 58, 61, 62, 72, 74 },
+      -- the counter, half a cell high everywhere it is drawn: its north
+      -- rim and end caps (7/8), the long run between them (9), the top
+      -- surface a counter drawn running north-south wears (23/24), and
+      -- the drawn front panel (50/51) standing up as one clean 8px band
+      -- with the surface riding the top face.  The guard leans on it
+      -- instead of standing behind a wall stub, and a counter that runs
+      -- wall to wall (Route 12's pair) matches one that ends in the open.
+      counter = { 7, 8, 9, 23, 24, 50, 51 },
+      -- 50/51 draws BOTH the counter's front and the wall's base course,
+      -- and it is the bottom row of its cell either way -- so a flat pin
+      -- has to pick one and be wrong about the other. Pinned `wall` the
+      -- counters stood a full 16px; pinned `counter` the deep border
+      -- banks corrugated 16/8 for sixteen rows and the room read as
+      -- crates. What tells the two uses apart is what is drawn ABOVE:
+      -- the wall stacks its panelled course (32/33) over the base, while
+      -- a counter carries its own top (7/8/9). So the counter pin above
+      -- is the default and this puts the wall back wherever the panel
+      -- sits on top of it -- resolved per position, in TileShape.at.
+      when_above = {
+        [50] = { { above = { 32 }, class = "wall" } },
+        [51] = { { above = { 33 }, class = "wall" } },
+      },
+      -- the tall glass-fronted cabinets: three shelf ranks (34/35)
+      -- folded up a 24px box whose top face adopts the drawn top rim
+      -- (7/8, pinned `counter` directly above it) through the mesher's
+      -- authored-fold rule -- the HOUSE / Red's-house bookcase
+      -- treatment.  Deliberately not `bookcase`: that collapses the
+      -- drawing to one cell of depth, which would leave the wall cell
+      -- behind each cabinet as bare floor, and its cap rule refuses a
+      -- row pinned anything but `table`, so the cabinets would lose
+      -- their tops as well.
+      desk = { 34, 35 },
+      -- standing per-pixel props with body, black-outline segmented: the
+      -- little tables of the 2F lounges and the Safari rest houses (2/3
+      -- the top, 18/19 the legs) and the 2F observation binoculars (36
+      -- eyepieces, 52 barrels, 57 pedestal).  Both are drawn face-on
+      -- with air between their legs and a clean white floor margin, so
+      -- the standee segments whole -- and both were invisible before,
+      -- flattened by the walkable-cell rule.  They stand on the floor:
+      -- the window band is drawn ABOVE them, and the support rule only
+      -- lifts a prop drawn above a box.
+      billboard = { 2, 3, 18, 19, 36, 52, 57 },
+      -- the plants, in the THIN pool like every other interior plant:
+      -- the potted palm that stands in every hut and rest-house corner
+      -- (5/6 crown, 21/22 fronds, 37/38 over 53/54 the pot), and Route
+      -- 22's wall plant (14/15 crown, 30/31 pot), which stands on the
+      -- half-cell planter its base course (50/51) makes -- a planter box
+      -- now rather than the 16px pedestal it used to perch on.
+      prop = { 5, 6, 14, 15, 21, 22, 30, 31, 37, 38, 53, 54 },
+      -- the exit doormat (4 over 20): drawn from straight above, so it
+      -- has to lie flat -- and 20 is the $14 water-fallback trap, which
+      -- sank every gate's own doorway into a pond lip.
+      ground = { 4, 20 },
+      -- the flight up to a gate's 2F: real steps climbing east, the way
+      -- the drawn treads rise to the right.  Pixel for pixel the same
+      -- staircase as Red's house 1F, on the same four tile ids.
+      stair_e = { 12, 13, 28, 29 },
+      -- the flight down -- to 1F from a gate 2F, into the tunnel from an
+      -- Underground Path hut: a sunken stairwell descending westward,
+      -- high at the east lip where the player enters.  Again the same
+      -- drawing and the same ids as Red's room upstairs.
+      stair_down_w = { 10, 11, 26, 27 },
+      -- Left to the derived default on purpose: the two floor checkers
+      -- (1/17) and every threshold -- the door mats (55/56/94) and the
+      -- tile under the door panels (42/59) -- sit in walkable cells, so
+      -- the cell rule already lays them flat; and tile 16 is solid
+      -- black, which the void rule flattens into exactly the darkness
+      -- that should sit above Route 16's north wall.
+    },
+
+    -- Viridian Forest's north and south gates.  Tile for tile they are
+    -- the same drawing as ROUTE_2_GATE, but they are their own tileset
+    -- id, so they need their own copy of the pins.  These two maps never
+    -- place the panelled wall course (32/33), so 50/51 is a counter
+    -- front here and nothing else -- the half cell it is drawn as costs
+    -- this id nothing at all, where GATE pays for it in the wall (see
+    -- the note there).  Both ids run 50/51 `counter` now, so the three
+    -- rooms that share this drawing -- the two forest gates and
+    -- ROUTE_2_GATE -- finally match.  Before this entry the room was a
+    -- pond with an island: 72 ($48) sank the north wall's top course, 50
+    -- ($32) sank all four counter fronts, and 20 ($14) sank the exit
+    -- doormat -- the three stale-cache water ids, all three placed in
+    -- one small room.
+    FOREST_GATE = {
+      -- the wall band, one 16px face: the speckled plaster course (72)
+      -- over its dark skirting (74), plus the door pane (41/43) drawn
+      -- above the walkable threshold, so the doorway reads as a recess
+      -- in the band rather than a door lying flat on the floor (pins are
+      -- look-only; the cell stays walkable).  72 is the $48
+      -- water-fallback trap and took the whole north wall down with it.
+      wall = { 41, 43, 72, 74 },
+      -- the four counters, half a cell high: end caps (7/8), the top
+      -- surface running north-south (23/24), and the front panel (50/51)
+      -- standing up as one clean 8px band with the surface riding the
+      -- top face.  50 is the $32 water-fallback trap -- unpinned, every
+      -- counter's front cell was a pond notch.
+      counter = { 7, 8, 23, 24, 50, 51 },
+      -- the potted palms down both side walls, three to a side, in the
+      -- THIN standee pool like every other interior plant: 5/6 crown,
+      -- 21/22 fronds, 37/38 over 53/54 the pot.  They stack with no gap
+      -- between them, and each still segments as its own plant.
+      prop = { 5, 6, 21, 22, 37, 38, 53, 54 },
+      -- the exit doormat (4 over 20), drawn from straight above so it
+      -- lies flat; 20 is the $14 water-fallback trap.
+      ground = { 4, 20 },
+      -- Left to the derived default on purpose: the two floor checkers
+      -- (1/17) and the tile under the door panes (42/59) sit in walkable
+      -- cells, so the cell rule already lays them flat.
+    },
+
+    -- Celadon's department store and the rooms that share its blockset:
+    -- CELADON_MART_1F..5F and the ROOF, the two 2x2 lift cabins
+    -- (CELADON_MART_ELEVATOR, SILPH_CO_ELEVATOR), ROCKET_HIDEOUT_ELEVATOR,
+    -- the GAME_CORNER with its PRIZE_ROOM, and CELADON_DINER -- twelve
+    -- maps off one atlas.  Everything the store owns was wrong: the
+    -- U-shaped sales counters read their whole north-south arm as one
+    -- drawing and towered to 48px (dragging the wall band they touch up
+    -- with them), the merchandise racks fused sideways into 32px
+    -- monoliths FOUR tiles deep -- the Poke Mart's failure exactly --
+    -- the diner and roof stools sit in walkable cells and so flattened
+    -- into the floor entirely, and three separate tiles fell into the
+    -- engine's stale water set and sank into ponds indoors.
+    LOBBY = {
+      -- The two exit cells of every map (the sliding-door threshold, 4
+      -- over 20).  20 is $14, which the stale-cache fallback counts as
+      -- water in EVERY tileset, and rule 2 judges the whole CELL by it:
+      -- both tiles of the doorway recessed into a pond lip just inside
+      -- the shop door.  It is a flat mat, and the lift cabins use the
+      -- same pair for their car door.
+      ground = { 4, 20 },
+      -- The wall band stays ONE 16px face.  The blank course (1) and the
+      -- skirting course below it (33) are the band itself; everything
+      -- else here is drawn BUILT INTO it at 16px, so wall height is the
+      -- drawn height and each reads as a fitting jutting from the band
+      -- rather than a tower:
+      --   6/22    the framed notice beside the stairwell, every floor
+      --   2/3/18/19   the pair of pay phones on 1F
+      --   46/47   the floor-directory plaque (it also sits at the east
+      --           end of 1F's counter top, where 16px reads as a sign
+      --           board standing on the counter -- the one placement
+      --           that is not wall, and the least bad of the two)
+      --   62/63   the lift call-button panel in both 2x2 cabins
+      --   72/73/88/89 the framed picture (72 is $48, a water-set id, so
+      --           unpinned its top half sank)
+      --   68/84   the roof's perimeter safety railing, drawn 16px tall
+      --   75/76/77/78/79 the roof parapet and the Rocket lift's cabin
+      --           walls (79 also rings the roof map as its border block);
+      --           the Game Corner reuses 75/76/77/78 as the dark south
+      --           end of its machine banks, where 16px reads as the
+      --           bank's end cabinet
+      --   91      the dithered wall course above the Prize Room counter
+      --           and the roof stairhead
+      --   92/93   the Rocket lift's horizontal cabin frame
+      --   70/71   NOT wall panelling: the round tables' lower-left and
+      --           lower-right rim ($46/$47).  They are here to lift the
+      --           terrace and diner tabletops to the one height their
+      --           middle can be built at -- see the long round-table
+      --           note under `counter`.  The tileset places them in the
+      --           two table blocks (29, 49) and nowhere else, so 16px
+      --           costs nothing anywhere in the group.
+      wall = { 1, 2, 3, 6, 18, 19, 22, 33, 46, 47,
+               62, 63, 68, 70, 71, 72, 73, 75, 76, 77, 78, 79, 84,
+               88, 89, 91, 92, 93 },
+      -- 3F's television sets ($0E/$0F/$1E/$1F): the one drawing in this
+      -- tileset that is a deliberate object with a body -- a black-framed
+      -- cabinet, a bezel and a lit screen, drawn face-on -- and the same
+      -- thing Red's living room stands up.  Six placements: four on the
+      -- two goods counters, two against the east wall band.  As `wall`
+      -- each was a 16px CUBE with the TV art folded onto one face, so the
+      -- counters wore grey filing cabinets and the TV shop read as a
+      -- stockroom.  The standee pool cuts the drawing per pixel at 10
+      -- voxels of body instead, and the support rule does the rest: the
+      -- four counter sets are drawn directly above an authored 8px
+      -- `counter` row, so they STAND ON the counter and the tiles they
+      -- claim keep rendering as counter top rather than holing it.  (The
+      -- art carries a full black frame with light margin inside it, so
+      -- the segmentation flood has nothing to drain and the whole set
+      -- survives.)  Its own pool, away from `stool`, so a TV never stacks
+      -- with a chair drawn beside it.
+      billboard = { 14, 15, 30, 31 },
+      -- Every service counter in the group, half a cell high like the
+      -- Center's and the Mart's.  One 8px band means the drawn front row
+      -- stands up and everything above it rides the TOP face in drawn
+      -- order -- which is what a counter arm running north-south IS: the
+      -- rows above the front are its top surface seen from above, not
+      -- height.  Unpinned the arms measured their full 7-row run and
+      -- towered to 48px, taking the wall band they touch with them.
+      --   38/39/41    the top surface and its end caps
+      --   21/48/49    the south front panel and its end caps
+      --   54/57       the arms' left and right side edges
+      --   36/37/52/53 the games console and its controller laid out on
+      --               3F's counter.  This is pixel for pixel the drawing
+      --               Red's house pins `relief` -- a prop seen from
+      --               ABOVE -- and `relief` is the class it wants.  It
+      --               cannot have it here: Structures.buildRelief anchors
+      --               its extrusion at y=0 and has no support lookup,
+      --               while every placement of this drawing in the
+      --               tileset is on a counter TOP.  Pinned `relief` the
+      --               cell is claimed, dropped to floor level and punched
+      --               a 16x16 hole clean through the counter (verified
+      --               in-engine, pass-2 report).  `counter` leaves the
+      --               console exactly where relief would put it -- flat,
+      --               flush with the surface, art on the top face, drawn
+      --               once -- and gives up only relief's three voxels of
+      --               lift.  The report carries the one-place engine
+      --               change that would free it.
+      --   9/25/85/86/87  the round tables of the diner and the roof
+      --               terrace: their north rim (9/25 = $09/$19) and the
+      --               pedestal course at the south (85/86/87).
+      --
+      -- THE ROUND TABLES in full, because the shape is a compromise.  The
+      -- drawing (block 29, and the same four rows split across blocks 45
+      -- and 49 in the diner) is
+      --      $09 $27 $27 $19      an octagonal top seen from above, with
+      --      $36 $37 $37 $39      a pedestal drawn below its southern
+      --      $46 $37 $37 $47      rim
+      --      $55 $56 $57 $37
+      -- Its four INTERIOR tiles are $37, which is ALSO the light half of
+      -- the checkerboard floor and the plain upper wall of the Prize Room
+      -- and the roof stairhead, so $37 cannot be pinned at all (see the
+      -- closing note).  Left to the detector those four are a two-row
+      -- column, which buildVolume reads as a repeat, floors at unit 2 and
+      -- builds at 16px -- and with the whole rim pinned `counter` at 8px
+      -- the terrace tables came out as grey CUBES sitting on trays.
+      --
+      -- So stop fighting the 16px and let it BE the tabletop: 70/71
+      -- ($46/$47, the lower-left and lower-right rim) move to `wall`, and
+      -- the table's whole front course then stands at the same 16px its
+      -- middle already does -- one flat disc, the drawn octagon on its
+      -- top face and the lower arc folded down its front.  What stays at
+      -- 8px is the FAR rim (9/25, and the shared 39/54/57) and the
+      -- pedestal (85/86/87): the far rim is occluded by the 16px top in
+      -- front of it, and the pedestal is meant to sit low.  16px is also
+      -- the right height against the 8px `stool` chairs drawn around it
+      -- -- a terrace table you sit at, not a footstool.
+      counter = { 9, 21, 25, 36, 37, 38, 39, 41, 48, 49, 52, 53, 54,
+                  57, 85, 86, 87 },
+      -- Free-standing merchandise racks and glass cases: TALL drawings,
+      -- not deep ones.  The four-row rack (42-45 / 58-61 / 64-67 /
+      -- 80-83) stands two racks abreast on floors 2F-5F and along the
+      -- Game Corner's north wall, and the detector boxed each pair into
+      -- ONE 32px slab four tiles deep -- the Poke Mart's exact failure.
+      -- A bookcase rank collapses onto a one-cell-deep box at the full
+      -- drawn height instead, and the back rows become hidden floor, so
+      -- racks standing side by side stay separate objects with an aisle
+      -- behind them.
+      -- 34/35/50/51 is the glass display case / vending machine, which
+      -- the same rule fits at BOTH its drawn sizes: 16px where it wears
+      -- the 1F phones or the 3F TV above it, 24px where a counter cap
+      -- (38/41) tops it on the roof, the Prize Room and the Game
+      -- Corner.  50 is $32, a water-set id, so every one of these cases
+      -- stood in a pond before it was pinned.
+      bookcase = { 34, 35, 42, 43, 44, 45, 50, 51, 58, 59, 60, 61,
+                   64, 65, 66, 67, 80, 81, 82, 83 },
+      -- The stools: the diner's chairs, the roof terrace's, the six
+      -- rows in front of the Game Corner's machine banks and the four
+      -- on 1F.  Their cell's bottom-left tile is 23 ($17), which IS on
+      -- the tileset's walkable list, so rule 3 resolved every one of
+      -- them to flat ground and they vanished into the floor
+      -- completely.  A pin is the only thing that overrides that.  The
+      -- drawing carries a full black outline with the floor dither
+      -- showing at all four corners, so the standee segments cleanly --
+      -- and `stool` keeps its own pool, apart from anything it touches.
+      stool = { 7, 8, 23, 24 },
+      -- Deliberately NOT pinned:
+      --   $37 (55) is three different things -- the light half of the
+      --     checkerboard floor, the interior of the round tables, and
+      --     the plain upper wall of the Prize Room and the roof
+      --     stairhead -- and every class that suits one ruins the
+      --     others: `ground` holes the wall and the tabletop, `counter`
+      --     turns every second floor tile into an 8px lump, `wall` turns
+      --     it into a 16px pillar.  The cell rules already answer the
+      --     floor (its cells are walkable through their $45 bottom-left
+      --     tile) and the wall (its cells are not), and the tabletop is
+      --     answered above by raising 70/71 to meet the 16px the
+      --     detector builds there.  Left unpinned on purpose.
+      --   $10 (16) is pure black and the void rule already flattens it
+      --     to the interior darkness above the Game Corner's wall.
+      --   The stair openings (10/11/26/27, 40/56) and the lift doors
+      --     (12/13/28/29) all sit in WALKABLE cells and fold into the
+      --     facade on their own, which is what the doorway fold is for.
+      --   $20/$45 (32/69) are the two floors and are walkable.
+    },
+
+    -- Pewter's museum, both floors (the tileset shares the gates' atlas
+    -- image but is its own id).  The exhibits were the worst case in the
+    -- whole building: 50 is $32, a water-set id, and it is the base row
+    -- of EVERY display case, so rule 2 judged each case's bottom cell
+    -- water and sank the fossil vitrines, the space shuttle and the
+    -- glass cabinets into ponds.  72 is $48 and is the wall band's upper
+    -- course, so the north wall recessed too -- leaving its lower course
+    -- alone as an 8px stub.  On top of that the benches sat in walkable
+    -- cells and flattened away, the corner plants towered to 32px, and
+    -- both staircases (also walkable) were flat floor.
+    MUSEUM = {
+      -- the two street doors on 1F: the same $14 mat trap as the
+      -- department store's, flat
+      ground = { 4, 20 },
+      -- the wall band as one 16px face: the dithered upper course (72,
+      -- the $48 water-set id) over the skirting course (74), and the
+      -- two framed paintings hung in it (78/79)
+      wall = { 72, 74, 78, 79 },
+      -- The low partitions that divide both floors -- the tileset's own
+      -- counterTiles name 23 ($17) -- drawn exactly like the department
+      -- store's counter arms: a light top surface seen from above with
+      -- dark side edges.  Half a cell, so they read as barriers you see
+      -- over rather than interior walls.  Their north caps and their
+      -- south base rows belong to the case group below, at the same 8px.
+      counter = { 23, 24 },
+      -- Every vitrine in the museum, as tall drawings one cell deep:
+      --   7/8/34/35   the run of eight glass cabinets along 1F's north
+      --               wall (7/8 is the cabinet's top surface, so the
+      --               rank wears it as its top face -- which is why it
+      --               is here and not in `counter` with the partitions
+      --               whose north cap it also draws)
+      --   9/50/51     the low case at 1F's centre (9 the top surface,
+      --               50/51 the base panels) and the base row under the
+      --               partition ends
+      --   25/39/40/44/46/48/49/58/60/63/70/71/83  the fossil vitrine,
+      --               four drawn rows inside one black frame: the dark
+      --               top surface, the ammonite specimens on their
+      --               light bed, the placard, and the base.  Two on 1F,
+      --               one on 2F.  Collapsed to one cell of depth it
+      --               stands as a 32px case instead of a 16px lid
+      --               floating over a pond.
+      --   64-69/80-91 the space-shuttle vitrine on 2F, the same drawing
+      --               shape three cells wide.
+      -- 50/51 is $32/$33 -- the water-set id that sank all of them.
+      bookcase = { 7, 8, 9, 25, 34, 35, 39, 40, 44, 46, 48, 49, 50,
+                   51, 58, 60, 63, 64, 65, 66, 67, 68, 69, 70, 71,
+                   80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91 },
+      -- the visitors' benches on 1F: their cell's bottom-left tile is
+      -- 18 ($12), which is on the walkable list, so they resolved to
+      -- flat ground and disappeared.  Seat-height standees in their own
+      -- pool, like the department store's stools
+      stool = { 2, 3, 18, 19 },
+      -- the corner potted plants (crown 5/6/21/22, pot 37/38/53/54):
+      -- the THIN standee pool, like every other interior plant in this
+      -- profile.  Unpinned they were a 32px two-cell tower.
+      prop = { 5, 6, 21, 22, 37, 38, 53, 54 },
+      -- the Old Amber in its rounded case, drawn face-on with a clean
+      -- black outline and a light margin at every corner: the standee
+      -- with body, segmented so the backing floods away and the amber
+      -- inside the outline stays
+      billboard = { 76, 77, 92, 93 },
+      -- 1F's staircase UP to 2F: a real rising flight climbing east,
+      -- the way the treads are drawn (low at the west, high at the
+      -- east).  Its cell is walkable, so without the pin it was flat
+      -- floor with the stair art painted on it.
+      stair_e = { 12, 13, 28, 29 },
+      -- 2F's staircase DOWN to 1F: the same flight from above, so it
+      -- descends westward -- the player steps on at the east lip.  Same
+      -- tile ids Red's bedroom uses for its stairwell, which is the
+      -- convention across Gen 1's interior blocksets.
+      stair_down_w = { 10, 11, 26, 27 },
+      -- Deliberately NOT pinned: 1 and 17 ($01/$11), the two halves of
+      -- the checkerboard floor.  Every floor cell's bottom-left tile is
+      -- $01, which is walkable, so the cell rule already makes the whole
+      -- cell flat ground.
+    },
+
+    -- Cinnabar Lab and its three side rooms (trade, metronome, fossil),
+    -- the Fuchsia Warden's house, the Fuchsia meeting room and the Safari
+    -- Zone's secret house -- seven maps on one tileset.  Every indoor
+    -- failure mode shows up here at once: the detector raised the machine
+    -- banks as 32px monoliths TWO cells deep, boxed the free-standing
+    -- shelf racks the same way (and CAPPED the metronome room's racks at
+    -- 16px because their book rows repeat, so a 32px shelf came out a
+    -- 4-tile-deep 16px slab), cut every lab bench into a patchwork of
+    -- 8/16/32px stubs, flattened the chairs into floor, merged the
+    -- meeting room's long partition with the corner plants into a 48px
+    -- tower -- and dropped six tile ids into the engine's stale-cache
+    -- water set, so the bench tops ($04/$05/$14/$15), the table's monitor
+    -- ($48) and the Warden's round specimens ($32) recessed into pond
+    -- lips inside the building.  Oak's Lab (the DOJO entry) is the
+    -- reference: same rooms, same answers.
+    LAB = {
+      -- the wall band stays one 16px face.  Blank courses ($22), the
+      -- pillar/corner that turns Cinnabar Lab's L ($23), the framed
+      -- Pokeball picture (16/17/32/33), the metronome room's row of
+      -- wall brackets (48/49 -- drawn INTO a band that is two cells
+      -- deep there, so both cell rows stay one 16px face), the vent
+      -- panel over Cinnabar Lab's three doorways (24/25), and the low
+      -- dark base course with its end caps (42/43) that the meeting
+      -- room's partition and the Warden's machine both stand on.
+      -- The Warden's big machine (87/88/89 top, 28/71/29 the dial row,
+      -- 36/37 the grille row, over 24/25 and the 42-34-34-43 base) is
+      -- ALSO wall: it is drawn 32px tall and free-standing, so a
+      -- `bookcase` would be the honest shape -- but its grille tiles
+      -- 24/25 are the very tiles Cinnabar Lab hangs in its wall band
+      -- above the doors, and its base row is the shared $22 band, so no
+      -- per-tile pin can make it 32px without either stubbing the Lab's
+      -- wall panel or splitting the machine into columns of different
+      -- heights.  One clean 16px console beats both.
+      wall = { 16, 17, 24, 25, 28, 29, 32, 33, 34, 35, 36, 37,
+               42, 43, 48, 49, 71, 87, 88, 89 },
+      -- the equipment banks and the shelf racks: TALL drawings, not deep
+      -- ones.  Each rank collapses onto a ONE-CELL-DEEP box at its full
+      -- drawn height and its back rows become hidden floor -- the
+      -- Dojo/Mart treatment, and the only thing that stops the fossil
+      -- room's and the secret house's machine walls from being 32px
+      -- blocks two cells thick.  69/70 + 85/86 are the cabinet tops,
+      -- 10/11 the dial faces, 74/75 + 90/91 the narrow filler columns,
+      -- 26/27 the plinth with its feet, 59 the black end pilaster;
+      -- 40/41 are the metronome room's and the meeting room's shelf
+      -- ranks.
+      --
+      -- 64/65/66 -- the TOP-TRIM row (one black line, one white
+      -- highlight, then grey) that every flat-topped unit in this
+      -- tileset wears -- are here too, and this is the load-bearing
+      -- decision in the entry.  They used to be `table`.  A `table` is
+      -- an authored upright BOX, and the support rule stands a pinned
+      -- standee drawn directly above an authored box ON it: every chair
+      -- on the FAR side of a table in this tileset is drawn directly
+      -- above that table's trim row, so the trade room's two north
+      -- chairs and the meeting room's spare chair were lifted onto the
+      -- tabletops -- and their cells were re-tiled as tabletop, marching
+      -- each table two tile rows north to meet them.  A `bookcase` is
+      -- authored but is NOT a box (its art mode is the rank collapse),
+      -- so the support rule does not fire and those three chairs stand
+      -- on the floor where they are drawn.
+      -- Nothing else about the trim changes for the worse.  Where it
+      -- caps a shelf rank (64/66 over 40/41 or 10/11, in the metronome
+      -- room, the meeting room, the fossil room and the secret house)
+      -- it simply becomes the rank's fourth row: the same 32px height
+      -- and the same top-face art the cap-adoption rule used to hand it,
+      -- minus the 12px stub the trim used to render as BEHIND the shelf.
+      -- Where it tops a table or the Warden's bench it becomes that
+      -- unit's own 8px back rim, tucked behind the 12px top.
+      -- (The one thing it costs is named in the report: the meeting
+      -- room's two partitions used to hand this trim to the 16px band's
+      -- TOP face -- the mesher gives a full-height course the authored
+      -- UPRIGHT row above it -- and now top with their own band art.)
+      bookcase = { 10, 11, 26, 27, 40, 41, 59, 64, 65, 66, 69, 70,
+                   74, 75, 85, 86, 90, 91 },
+      -- the lab furniture, at table height.  The benches in the fossil
+      -- and metronome rooms (2/3 the specimen tray, 4/5 + 20/21 the
+      -- microscope, 18/19 the tray's rack row) and the big lab tables
+      -- (80/81/82 the top, 83/58/84 the front rail and its legs).
+      -- 72/73 -- the monitor and the ball lying on the table -- ride the
+      -- table's authored height rather than standing as separate
+      -- cutouts, exactly as Oak's starter balls do; pinning them also
+      -- stops the display frame's black corner brackets from
+      -- auto-extracting into standing prisms.  Four of these ids
+      -- ($04/$05/$14/$15) plus $48 are the tileset's water-fallback
+      -- traps: unpinned they sink into a pond lip in the middle of the
+      -- room.  With the trim row moved to `bookcase` the top face of
+      -- each table now wears its own drawn surface instead of the trim
+      -- -- which is how the Warden's bench finally shows the monitor and
+      -- the Pokeball the artist drew on it.
+      table = { 2, 3, 4, 5, 18, 19, 20, 21, 58, 72, 73,
+                80, 81, 82, 83, 84 },
+      -- seats, the 8px standee pool, all of them in WALKABLE cells and
+      -- therefore flat floor until pinned: the four chairs round the
+      -- trade room's table and the meeting room's spare (14/15/30/31,
+      -- a whole cell each) and the little stool tucked under every lab
+      -- bench (6/7 its top edge, 22/23 its seat and legs).  6/7 also
+      -- carry the bench's apron along their top edge -- the standee
+      -- wears a thin dark cap for it, which is cheaper than dropping
+      -- the stool to a half-cell drawing with no floor margin.
+      -- The chairs on the far side of a table stay on the FLOOR only
+      -- because the trim row above them is no longer a box; see the
+      -- bookcase group.
+      stool = { 6, 7, 14, 15, 22, 23, 30, 31 },
+      -- the tall corner plants: two cells of drawing (44/45 + 60/61 the
+      -- frond crown, 46/47 + 62/63 the stem and pot), mostly silhouette,
+      -- so the THIN standee pool -- as in every other interior.  The
+      -- detector had them at 0/8/16/24/32px depending on which corner
+      -- they stood in, and in the meeting room it fused them into the
+      -- partition and towered the pair to 48px.
+      prop = { 44, 45, 46, 47, 60, 61, 62, 63 },
+      -- the five round specimens in the Warden's house: one 16x16 cell
+      -- each, drawn ROUND with a dithered shell and a lit underside.
+      -- Neither a box nor a flat cutout reads them; the round archetype
+      -- carves a voxel ball per cell from the drawing's darkest-pixel
+      -- outline, which is what they are.  50 is a water-fallback trap,
+      -- so unpinned the row sat in five pond lips.
+      cylinder = { 50, 51, 67, 68 },
+      -- Deliberately NOT pinned: the checker floor (1/38) and the fossil
+      -- room's striped carpet (12/13) are walkable cells and already
+      -- flat; the doormat (39/55) likewise; the three doorways
+      -- (76/77 over 52/53) are walkable and the engine folds them into
+      -- the facade; Cinnabar Lab's black surround (54) is authored void
+      -- by the void rule; and the bench aprons 8/9 stay flat floor,
+      -- which is where the artist drew them -- inside the walkable cell
+      -- in front of the bench.
+    },
+
+    -- Celadon Mansion's three floors and its roof, plus the Celadon
+    -- chief's house -- five maps on one tileset.  The mansion maps are
+    -- half interior and half OUTSIDE: the east third of every floor is
+    -- the open-air stair landing, so the entry has to keep an outdoor
+    -- strip flat while it furnishes the rooms.  The detector towered the
+    -- display cabinets, boxed the potted palms into 32px 4-tile-deep
+    -- monoliths, raised the 2F larder cabinet as a 48px tower taller than
+    -- the walls, gave the same wall band three different heights
+    -- (8/16/48) on one map -- and sank the whole cabinet bank AND both
+    -- front-door mats into pond lips, because nine tile ids here
+    -- ($04/$14/$22/$23/$32/$33/$38/$48/$57) sit in the engine's
+    -- stale-cache water set.
+    MANSION = {
+      -- one 16px face for every wall course, indoors and out: the rooms'
+      -- north band (80), the interior partition (30) with its white top
+      -- rim (76/77), the doorway lintel over the front door (22/23), the
+      -- east exterior wall the landing runs along (74/75) with its
+      -- junction pieces (72/73 -- 72 is a water trap -- and 88/89), the
+      -- band's feet and corners (90/91/92/93), and the roof's own rim
+      -- and corner blocks (78/79).  The roof parapet railing (15 over
+      -- 31, with end caps 42/43 and 33/49) is drawn a full 16px tall, so
+      -- it stays in the same band rather than dropping to `fence`: on an
+      -- open roof a knee-high rail reads as a kerb.  48 and 6/7 are the
+      -- rooftop shed's base course.
+      wall = { 6, 7, 15, 22, 23, 30, 31, 33, 42, 43, 48, 49, 72, 73,
+               74, 75, 76, 77, 78, 79, 80, 88, 89, 90, 91, 92, 93 },
+      -- the display cabinets along the north wall of 1F and the chief's
+      -- house: TALL drawings, not deep ones, so each rank collapses onto
+      -- a one-cell-deep box at its drawn height.  34/35 are the shelf
+      -- row of the short cabinets, 40/21 + 56/87 the two rows of the
+      -- tall ones (the pair with the trophy in the glass), 50/51 the
+      -- plinth.  Their top row is 38/41, pinned `table` below because
+      -- the mansion's big tables wear the same trim -- the bookcase
+      -- builder adopts it as the rank's CAP, which lands the short
+      -- cabinets at 24px and the tall ones at 32px, exactly their drawn
+      -- heights.  45/46 + 61/62 + 63/47 is 2F's larder cabinet, four
+      -- drawn rows standing free of any wall: 32px and one cell deep
+      -- instead of the 48px tower the detector built.
+      -- Six of these ids are water-fallback traps ($22/$23/$32/$33/$38
+      -- /$57) -- the whole cabinet bank was a pond.
+      bookcase = { 21, 34, 35, 40, 45, 46, 47, 50, 51, 56, 61, 62, 63,
+                   87 },
+      -- table height.  The long tables in 1F and the chief's house
+      -- (38/39/41 top edge, 54/55/57 body, 60/58/59 the front rail with
+      -- its two legs) and the writing desks on 2F and 3F (36/37/52/53
+      -- the back edge with the papers and the ball on it, 64/65/66/67
+      -- the body).  The desks' aprons (2/3/85/86 over 18/19) are drawn
+      -- into the WALKABLE cell in front and stay flat floor, which is
+      -- how the artist placed them.
+      -- Known compromise: the rooftop shed on CELADON_MANSION_ROOF is
+      -- drawn with the table's own top and body tiles (38/39/41 over
+      -- five rows of 54/55/57) with a door punched in its base, so it
+      -- comes out a 12px block rather than a shed.  Nothing towers there
+      -- any more -- the detector had its east columns at 48px -- and no
+      -- per-tile pin can give one drawing two heights.
+      table = { 36, 37, 38, 39, 41, 52, 53, 54, 55, 57, 58, 59, 60,
+                64, 65, 66, 67 },
+      -- the stool at the 2F/3F desk: a whole cell of drawing (2/3 over
+      -- 18/19) sitting in a WALKABLE cell, so flat floor until pinned.
+      -- The 8px standee pool, seat height, as in Red's rooms.
+      stool = { 2, 3, 18, 19 },
+      -- the potted palms: two cells of drawing (68/69 crown, 8/9 fronds,
+      -- 70/71 stem, 24/25 pot), mostly silhouette, so the THIN standee
+      -- pool -- the same numbers the generic HOUSE entry uses, and the
+      -- same answer every interior plant gets.  The detector had them as
+      -- 32px boxes four tiles deep.
+      prop = { 8, 9, 24, 25, 68, 69, 70, 71 },
+      -- the front-door mats of 1F and the chief's house.  Their bottom
+      -- tile is $14, which the engine's stale-cache fallback counts as
+      -- water in every tileset, so the mat -- and the whole cell with it
+      -- -- recessed into a pond lip just inside the door.  It is a flat
+      -- rug on the floor.
+      ground = { 4, 20 },
+      -- Deliberately NOT pinned: the interior checker floor (17), the
+      -- landing's open-air ground (1), the black surround (16, authored
+      -- void), the back and rooftop doors (81-84, walkable and folded
+      -- into their facade), the desk aprons (85/86), and the landing
+      -- edge (5).
+      -- CANNOT be pinned, engine-side: the four staircases (12/13/28/29
+      -- the rising flight, 10/11/26/27 the sunken one) are in this
+      -- tileset's doorTiles, and Structures' door fold OVERWRITES the
+      -- resolved shape of any door cell whose north neighbour is upright
+      -- -- without checking `authored` -- so a stair_e / stair_down_w pin
+      -- is silently discarded.  The indoor flights therefore read as
+      -- doorways folded into the north wall band, which is at least what
+      -- they are (you walk into them from the room).  The roof's two
+      -- flights, which stand clear of any wall, come out as a shallow
+      -- 8px lip -- a stairwell mouth, near enough -- and pinning them
+      -- `wall` would be worse: it would plug the openings with a 16px
+      -- block in the middle of the roof.  See the report.
+    },
+
+    -- Silph Co's 11th floor (the president's office), Bill's house and
+    -- the Pokemon Fan Club -- three rooms that share one tileset and
+    -- almost no furniture.  The detector raised Silph's side walls as
+    -- 48px towers (the drawn band is three cell rows deep, so it
+    -- measured the whole column), split the Fan Club's wall band across
+    -- 0/8/16px AND a pond lip, boxed Bill's two transporter drums into
+    -- 48px slabs five tiles deep, and left every chair flat because they
+    -- sit in walkable cells.  Six ids here ($14/$1F/$32/$34/$40/$48) sit
+    -- in the engine's stale-cache water set -- including $1F, the main
+    -- FLOOR tile, which sank wherever it shared a cell with $48.
+    INTERIOR = {
+      -- the wall band, one 16px face throughout: the rooms' face-on
+      -- courses (52 upper, 68 lower; 16 in Bill's house and Silph's
+      -- outer band), the courses seen from above along the south and the
+      -- partitions (87 top, 88 bottom), the side walls (89/90), the end
+      -- caps and junction blocks (45/46), the framed Pokemon portraits
+      -- hung in the band (19/20 over 35/36), and the padded bench built
+      -- into the Fan Club's north wall (49/50/51 -- its lower half,
+      -- 65/66/67, is drawn into the walkable cell in front and stays
+      -- flat, the way the artist drew it).
+      -- 93/94 are Silph's CARD KEY door: the block only exists while the
+      -- door is locked (data.field.cardKey swaps it out), so it never
+      -- appears in maps.lua -- but the probe sees it, and unpinned it
+      -- came out 0px/8px in the middle of a 16px wall.
+      -- Bill's pipework belongs here too: the stubs either side of each
+      -- drum (32/48, 37/53) and the run between them (38/54), all drawn
+      -- 16px tall against the band.
+      wall = { 16, 19, 20, 32, 35, 36, 37, 38, 45, 46, 48, 49, 50, 51,
+               52, 53, 54, 68, 87, 88, 89, 90, 93, 94 },
+      -- Bill's two transporter drums: a TALL drawing (four rows of
+      -- cylinder plus a base course), not a deep one.  The bookcase
+      -- collapse gives each drum one cell of depth at its full 32px
+      -- height instead of the 48px, five-tile-deep slab the detector
+      -- built, and its top face wears the drum's own lid.  7/8/9/10 is
+      -- the lid, 23/24/25/26 and 39/40/41/42 the barrel, 55/56/57/58 the
+      -- footing.
+      bookcase = { 7, 8, 9, 10, 23, 24, 25, 26, 39, 40, 41, 42,
+                   55, 56, 57, 58 },
+      -- The big OCTAGONAL boardroom table -- the Fan Club's and Silph
+      -- 11F's, the same drawing in both -- half a cell high, and half a
+      -- cell on purpose.  A `counter` is ONE band: exactly the drawing's
+      -- bottom row stands up as the front and every row above it rides
+      -- the top face IN DRAWN ORDER.  For a table drawn in PLAN that is
+      -- the only class that reproduces the plan; a taller box wears its
+      -- NORTH row's art across the whole top face and smears it.
+      --
+      -- The octagon itself is cut at TILE granularity, which is the
+      -- finest the mesher has: an authored tile is its own 8x8 column,
+      -- so the bevel is drawn by choosing which tiles rise.  Reading the
+      -- Fan Club rows (Silph is the identical shape eight rows further
+      -- down the map):
+      --   row 4        72 74 74 74 74 73         6 tiles wide
+      --   rows 5-8   72 <----- 8 tiles -----> 73  8 tiles wide
+      --   row 9        63 64 64 64 64 81         6 tiles wide
+      --   row 10          75 76 76 75            4 tiles wide
+      -- 72/73 are the north chamfer, 63/81 the south one, 77/78 the
+      -- straight flanks, 74 the north rim and 64 the top itself.  75/76
+      -- -- the front apron with its two drawn legs -- is pinned so the
+      -- octagon's south edge closes and the legs stand on the front face
+      -- instead of lying painted on the floor; it sits in the walkable
+      -- cell in front of the table, which is the cell a player stands in
+      -- to talk across it, and an 8px apron there reads as standing AT
+      -- the table (the same arrangement as the Center's counter).
+      -- 79 and 82, the OUTER corner of the south bevel, are `ground` --
+      -- see the ground group.
+      --
+      -- 91/92, the statue's pedestal, ride the top face here rather than
+      -- standing with the statue: those two ids are ALSO the wall band's
+      -- base blocks where a side wall meets the south course in Silph,
+      -- so six tiles at the foot of Silph's walls sit 8px instead of
+      -- 16px.  It is a notch at the foot of a wall the player never
+      -- faces, and the alternatives are worse in both directions -- a
+      -- 16px stub standing in the middle of the boardroom table, or a
+      -- paper cutout standing at the foot of every south wall.
+      -- 40 and 48 are water-fallback traps: unpinned, the table's whole
+      -- north-west cell was a pond, and it dragged the floor tile $1F
+      -- sharing that cell down with it.
+      counter = { 63, 64, 72, 73, 74, 75, 76, 77, 78, 81, 91, 92 },
+      -- The Pokemon statue standing in the middle of both boardroom
+      -- tables: a per-pixel cutout, ONE voxel deep, standing ON the
+      -- table through the authored-box support rule -- a standee drawn
+      -- directly above an authored box rises from that box's top, which
+      -- is how the gym's bird statues stand on their plinths and the
+      -- potted plant stands on Red's table.  17/18 is the crown and the
+      -- head, 33/34 the face and the top rim of the pedestal it stands
+      -- in; the pedestal proper (91/92) stays `counter` under its feet.
+      -- The four claimed tiles keep rendering as the tabletop they were
+      -- cut out of, so the table is whole underneath.
+      -- `cutout` and not `prop`: the drawing has NO floor margin -- it
+      -- is surrounded on all four sides by the tabletop's own mid grey
+      -- -- and the cutout pool's stricter contract makes mid shades
+      -- background unconditionally, so the tabletop drains away cleanly
+      -- while the black outline, the paint whites and everything they
+      -- enclose survive.  Pinned `counter` with the rest of the table
+      -- (what it was) the statue was painted FLAT on the tabletop.
+      cutout = { 17, 18, 33, 34 },
+      -- Bill's desk and the Silph president's, at table height: 11-14
+      -- the surface with the terminal and the ball on it, 27-30 the
+      -- front edge.  Their aprons (43/44 + 91/92 on the row below) are
+      -- drawn into the WALKABLE cell in front; 43/44 belong to the stool
+      -- there, not to the desk.
+      table = { 11, 12, 13, 14, 27, 28, 29, 30 },
+      -- the seats: Bill's desk stool (43/44 over 59/60) and the Fan
+      -- Club's four members' chairs (61/62 over 59/60), a whole cell
+      -- each.  All of them sit in WALKABLE cells, so they were flat
+      -- floor until pinned; the 8px standee pool puts them at seat
+      -- height, which is also where a character standing on the cell
+      -- ends up.
+      stool = { 43, 44, 59, 60, 61, 62 },
+      -- flat, and pinned flat on purpose.  31 is the rooms' floor tile
+      -- and needs no pin for its 980 walkable placements -- but the
+      -- water test runs per CELL on the engine's own stale set, BEFORE
+      -- any neighbouring pin can help, so the floor tiles sharing the
+      -- Fan Club's and Silph's north-west table cell with $48 sank into
+      -- the pond with it.  A pin is the only rule that outranks it.
+      -- 1/2 are the curve of Bill's drums where they meet the floor,
+      -- drawn below the pinned barrel and flat where they lie.
+      -- 79/82 are the OUTER corner of the octagon's south bevel, one
+      -- tile beyond 63/81 on each side.  Raised with the rest of the
+      -- table they squared both bottom corners off and left an 8px stub
+      -- standing in the floor a tile away from the table on each side;
+      -- flat they are what they are drawn as -- the table's cast shadow
+      -- where the bevel meets the floor -- and the octagon closes with a
+      -- clean 45 degree step on all four corners.
+      ground = { 1, 2, 31, 79, 82 },
+      -- Deliberately NOT pinned: the doormats (70/71) and Silph's warp
+      -- pads, stairwells and elevator mouth (3/4, 5/6/21/22, 83-86) are
+      -- walkable and already flat; 47 is the black surround outside the
+      -- building's footprint and the void rule authors it; 69 is the
+      -- shadow course under Bill's drums, drawn into a walkable cell and
+      -- correct flat.
+    },
+
+    -- The Cable Club rooms and the Bike Shop (one tileset, three maps).
+    -- COLOSSEUM and TRADE_CENTER are the same 5x4 room with a different
+    -- machine in the middle and a different board on the wall; BIKE_SHOP
+    -- reuses the same wall, floor and counter for a showroom full of
+    -- bicycles.  Between them the three maps place every tile.
+    --
+    -- What was wrong: the Bike Shop's bicycles came out at 0 and 8 --
+    -- each bike sliced in half at ankle height with its top row missing,
+    -- and the leftmost rack fused into the wall and towered to 32.  The
+    -- shop's whole L-shaped counter stood at wall height, a 16px slab
+    -- you could not see over.  Both Cable Club rooms lost their stools
+    -- (a walkable cell, so they flattened to floor) and their machine
+    -- came out 0/8/16 in the same object.  And the Game Boy link poster
+    -- above the door has $32 in its bottom-left corner, so the poster
+    -- had a pond in it -- the shore-set trap, and TRADE_CENTER's link
+    -- table carries the other one, $48.
+    CLUB = {
+      -- The wall band stays ONE 16px face.  6 is the striped panel,
+      -- 52 the fluted pillar that breaks it every three cells (its
+      -- rounded foot, 53, stands one row lower on the floor and is
+      -- walkable, so it stays flat ground in front of the band).
+      -- Drawn INTO the band and therefore wall as well: the two
+      -- bicycles hung on the Bike Shop's wall (1/2/3 over 17/18/19,
+      -- exactly two tile rows = exactly the band's height), the Cable
+      -- Club's link poster (48/49/50/51 -- 50 is $32, the shore trap
+      -- that had it recessing to -2), and the Trade Center's pair of
+      -- lit notice boards (63/68/68/69 over 66/67/67/70).
+      wall = { 1, 2, 3, 6, 17, 18, 19, 48, 49, 50, 51, 52, 63, 66, 67,
+               68, 69, 70 },
+      -- Counters, half a cell high -- the house rule for anything you
+      -- lean on.  The Bike Shop's L: the till run's top (7/8, the
+      -- tileset's own counterTiles) with its inside corner (54), east
+      -- arm (16) and end cap (5), all over the front panel 23/24.  8px
+      -- is one clean band, so the drawn front stands up and the counter
+      -- top stays a top; at 12 or 16 it reads as a wall stub.
+      -- 71/72/73/74 is the TRADE_CENTER link table, which shares that
+      -- same 23/24 front: its surface is drawn from ABOVE (two Game
+      -- Boys lying on it, cables between), so it belongs riding the top
+      -- face, not standing up.  72 is $48, the second shore trap.
+      counter = { 5, 7, 8, 16, 23, 24, 54, 71, 72, 73, 74 },
+      -- The Colosseum's battle machine: a console drawn face-on, four
+      -- tiles wide and three rows tall, grilled side towers (59/62 and
+      -- 55/58), a dark screen bay (60/61, 56/57) and the two white
+      -- horns that crown it (64/65).  24px is its drawn height, so
+      -- `desk` folds the whole drawing upright as one machine instead
+      -- of the 0/8/16 rubble the detector left.
+      desk = { 55, 56, 57, 58, 59, 60, 61, 62, 64, 65 },
+      -- The two stools that flank each Cable Club machine: seat 42/43
+      -- over base 38/39, in every one of the four placements across
+      -- both rooms and nowhere else in the tileset.  Their cells are
+      -- walkable, so without a pin they were floor; at seat height a
+      -- character standing on one sits on it.
+      stool = { 38, 39, 42, 43 },
+      -- The showroom bicycles -- six of them standing on the Bike Shop
+      -- floor, in two columns, each drawn 3 tiles by 2 side-on.  The
+      -- THIN standee pool, not `bookcase`: a bike is nearly all air
+      -- (two wheel rings and a frame), and collapsing a rack of them
+      -- onto a one-cell-deep box at full height would trade six
+      -- bicycles for one blank 32px panel wearing a bicycle print.  As
+      -- cutouts they segment cleanly -- the drawing has floor margin on
+      -- three sides and its own black outline seals the wheels -- and
+      -- the standee builder's connected-component split gives each bike
+      -- its own feet in its own cell even where a lower bike's
+      -- handlebar stem touches the wheel of the one drawn above it.
+      -- 11/12/14 the saddle and bar row, 27/28/9 the frame and wheels.
+      prop = { 9, 11, 12, 14, 27, 28 },
+      -- The crate and the standing pump beside the shop's south wall
+      -- (29/13 over 21/22), twice.  A separate pool from the bicycles
+      -- on purpose, and the thicker one: a crate is a deliberate object
+      -- with a body, where a bike is a silhouette.
+      billboard = { 13, 21, 22, 29 },
+      -- The Bike Shop floor's second checker phase.  It is NOT in the
+      -- tileset's walkable list, so the cells it floors resolve by rule
+      -- 4 and it rose as a wall stub -- or, worse, got swept into the
+      -- bicycle beside it and dragged to 8px.  It is floor; it is flat.
+      ground = { 30 },
+      -- Left to the derived default on purpose:
+      --   $0F $1F    the main floor checker -> walkable, ground
+      --   $0A $1A    the dark slab under the Bike Shop's exit warp -> a
+      --              threshold mat, walkable, flat
+      --   $35        the pillar's rounded foot -> its cell is walkable
+      --              (you walk in front of the pillar), so it lies flat
+      --              against the 16px band, which is what a plinth does
+      --   $26-$29 $2C-$2F  the octagon painted on both Cable Club
+      --              floors.  Ground markings seen from above, and every
+      --              cell they sit in is walkable, so rule 3 already
+      --              keeps them perfectly flat.  ($26/$27 are shared
+      --              with the stool bases above and pinned there; they
+      --              appear nowhere else in either room.)
+    },
+
+    -- The S.S. Anne, inside: both cabin decks and their corridors, the
+    -- bow, the kitchen, the captain's room -- and two Kanto houses
+    -- (Cerulean's badge man, Fuchsia's Good Rod fisher) that borrow the
+    -- liner's furniture set.  Twelve maps, and SS_ANNE_CAPTAINS_ROOM plus
+    -- SS_ANNE_KITCHEN between them place every tile the group uses.
+    --
+    -- Everything was wrong here, in every one of the ways indoors goes
+    -- wrong.  The wall-touching cabin table and the BED were merged into
+    -- the wall and towered to 32px, so a bunk read as a bank of lockers
+    -- wearing a porthole on top.  The corridor wall band measured 24px
+    -- instead of 16.  In the two houses the band came out at height 0 --
+    -- the drawing runs off the top of the map, so the detector had no run
+    -- to measure and the room had no walls at all.  Every stool, chair and
+    -- staircase sat in a WALKABLE cell and flattened to floor, so the
+    -- captain's room had no stairs, no chairs and no seat.  And the
+    -- barrels' top-left tile is $48, which the engine's stale-cache shore
+    -- set counts as water in every tileset but SHIP_PORT: each barrel had
+    -- a pond dug into its lid.
+    SHIP = {
+      -- The wall band stays ONE 16px face.  Blank courses (16), the
+      -- lower trim (18/19), the portholes (2/3), and the band's corner
+      -- pieces where a corridor meets it (32/33 white, 48/49 trim,
+      -- 34/50 the black outer corner).  $32 (50) is the shore-set trap:
+      -- unpinned it recesses into a pond lip in the middle of a
+      -- bulkhead, and it drags the whole 16x16 cell down with it,
+      -- because rule 2 judges a cell by its bottom-left tile.
+      --
+      -- The black rim is wall too, not void: 17 is the band's cap seen
+      -- from above (so the fold tops the bulkhead with it), 21/22 the
+      -- vertical faces that run down both sides of every corridor, 51
+      -- the ship's south bulkhead, and 5/6/37/38 the four corners of the
+      -- notch each cabin doorway is cut into.  Left to the detector
+      -- these came out 8, 16, 24 and 48 in the same room.  Only $01 --
+      -- pure black, the space OUTSIDE the hull -- is left alone: the
+      -- void rule flattens it, which is what darkness should do.
+      --
+      -- 14/15/30/31 are the cabin door drawn INTO the band (its cell is
+      -- walkable, since the player steps on it to warp, so unpinned the
+      -- door punched a flat hole through the wall).  84/85 are the
+      -- captain's chair BACK, drawn into the band above his seat -- so
+      -- the chair reads as a high-backed swivel chair jutting from the
+      -- wall instead of a separate tower.  45/61 are the bow deck's
+      -- rope rail and 46/47/62/63 its stepped bulwark: the same 16px
+      -- course, so the open deck is fenced at one height.
+      wall = { 2, 3, 5, 6, 14, 15, 16, 17, 18, 19, 21, 22, 30, 31, 32,
+               33, 34, 37, 38, 45, 46, 47, 48, 49, 50, 51, 61, 62, 63,
+               84, 85 },
+      -- Every table in the group, at 12px: the kitchen's three banquet
+      -- tables (twelve tile rows deep), the counter run along the
+      -- kitchen's south wall, the captain's desk, and the writing table
+      -- in the two houses.  Corners 9/12, north edge 10, side edges
+      -- 25/28, the surface 44, the plain apron 11 and the drawer front
+      -- 59/60.  One 8px band folds up, so the drawn apron stands as the
+      -- front and every row above rides the top face in drawn order --
+      -- which is how the tableware stays tableware: the plate (26), the
+      -- covered platter (64/65/80/81), the kitchen stove's burner grid
+      -- (53) and the captain's open book (68/69) are all drawn FROM
+      -- ABOVE, so they belong lying on the top face, not standing up as
+      -- cutouts.  59/60 doubles as the chest of drawers at the foot of
+      -- every cabin bunk; 12px puts it a hand above the mattress, which
+      -- is where a bedside chest belongs.
+      table = { 9, 10, 11, 12, 25, 26, 28, 44, 53, 59, 60, 64, 65, 68,
+                69, 80, 81 },
+      -- The cabin bunk: a mattress drawn from above, so its art stays on
+      -- the TOP face and it lies low.  70/71 the pillow, 86/87 the
+      -- mattress.  (Its drawer end is in `table` above.)
+      bed = { 70, 71, 86, 87 },
+      -- Seats, in the standee pool: the round stool that appears in
+      -- every cabin, the badge house and the captain's room (7/8 seat
+      -- over 23/24 legs), and the captain's own chair (66/67 seat over
+      -- the same 23/24 base, its back pinned into the wall above).
+      -- Seat height 8 keeps a character standing on the stool's
+      -- (walkable) cell sitting at seat height rather than floating.
+      -- The drawings have real floor margin on all four sides, so the
+      -- black-outline flood eats the checker around them and leaves the
+      -- seat whole.
+      stool = { 7, 8, 23, 24, 66, 67 },
+      -- The captain's storage rack: three shelf ranks (54 left, 43
+      -- right) drawn four tile rows tall against the wall.  TALL, not
+      -- deep -- the bookcase builder collapses it onto one cell of depth
+      -- at its drawn height, and adopts the row above (9/12, pinned
+      -- `table` as the tabletop corners they also are) as its cap.
+      -- Boxed by the detector it was a 16px stub with the wall beside it
+      -- towered to 24.
+      bookcase = { 43, 54 },
+      -- The galley barrels -- three down the kitchen's east wall, one in
+      -- the captain's room, one in each house.  A per-pixel cutout in
+      -- the THIN pool, the treatment Lt. Surge's trash cans get: 72/73
+      -- the lid, 88/89 the banded body.  72 is $48, the shore-set trap
+      -- that had each barrel resolving to water at -2.
+      prop = { 72, 73, 88, 89 },
+      -- The stairs, both flights, in every map that has them (1F, 2F,
+      -- 3F, B1F and the captain's room).  Same two drawings the whole
+      -- game uses, and the warp table says which is which: 41/42/57/58
+      -- is the light flight that always leads UP a deck, climbing east
+      -- the way its treads step; 39/40/55/56 is the dark stairwell that
+      -- always leads DOWN, sinking westward.  Both cells are walkable,
+      -- so unpinned both were flat floor and the decks did not connect.
+      stair_e = { 41, 42, 57, 58 },
+      stair_down_w = { 39, 40, 55, 56 },
+      -- Left to the derived default on purpose:
+      --   $01        pure black outside the hull -> void, flat darkness
+      --   $04 $23    deck planking and grating   -> walkable, ground
+      --   $0D $1D    cabin floor checker         -> walkable, ground
+      --   $4A        cabin door threshold        -> walkable, ground
+      --   $24 $34    the dark slab under the exit warp in the cabins and
+      --              the two houses: a threshold mat with no wall around
+      --              it, walkable, and flat is the honest reading
+      --   $14        the SEA around SS_ANNE_BOW.  It is the one tile id
+      --              the stale-cache water set names in every tileset,
+      --              and here that guess is simply RIGHT -- the bow deck
+      --              really does stand in open water, so it is the one
+      --              trap tile in this group that must NOT be pinned.
+    },
+
+    -- Vermilion Dock: the quay, the boarding gangway, and the S.S. Anne
+    -- herself moored alongside.  One map, and it is the only place in
+    -- the game where a whole VESSEL is drawn as map art rather than as a
+    -- building sprite.
+    --
+    -- The detector read the liner as a volume and raised her 48px --
+    -- three cells, taller than she is long is wide -- with her columns
+    -- stepping 48/40/24/0 across the hull, so the drawing was folded
+    -- UPRIGHT and smeared up a lumpy monolith.  Both ends of the hull
+    -- fell to 0 instead, and the port bow ($40/$41/$51) sat in a cell
+    -- whose bottom-left tile is open water, so rule 2 sank it to -2 and
+    -- the ship had a hole in her nose.
+    --
+    -- (This tileset is the one place the engine does NOT count $32 and
+    -- $48 as shore -- Map.lua's NO_SHORE_TILESETS -- because $32 IS the
+    -- gangway here.  So the usual shore trap does not apply, and $14 is
+    -- honest open water.  Nothing in this entry is dodging a water
+    -- fallback; the whole entry is about the ship.)
+    SHIP_PORT = {
+      -- The hull, every tile of her, as a `roof`: a box wearing its art
+      -- on the TOP face.  That is what the drawing IS -- the liner seen
+      -- from above and slightly astern, funnels and boats and deck rail
+      -- on the top rows, hull plating on the bottom two -- so folding it
+      -- upright was always going to smear.  28px of freeboard reads as a
+      -- liner beside a quay at 0 and water at -2 without towering, and
+      -- the side bands crop from each edge tile's own art, so the flank
+      -- the player faces wears the hull plating that is drawn there.
+      -- Rows north to south: bow rail and boat deck (0/2-7/9/11-15),
+      -- superstructure (16-31), midships (32-47), waterline strake
+      -- (48-53 and 61-63 in the stern), hull plating (64-69, 77-79) and
+      -- the boot topping (81-85, 90-93).
+      roof = { 0, 2, 3, 4, 5, 6, 7, 9, 11, 12, 13, 14, 15,
+               16, 17, 18, 19, 21, 22, 23, 24, 25, 28, 29, 30, 31,
+               32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 44, 45, 46, 47,
+               48, 51, 52, 53, 54, 55, 56, 57, 61, 62,
+               64, 65, 66, 67, 68, 69, 77, 78, 79,
+               81, 82, 83, 85, 90, 91, 93 },
+      -- The quayside crates, a 2x2-tile box each (86/87 lid, 1/80
+      -- body), stacked two cells deep in all four corners of the dock,
+      -- and the pallet stacks flanking the gangway head (49).  A crate
+      -- IS a 16px cube: one course, art folded up the face it shows.
+      -- Unpinned the corner stacks fused into one taller volume.
+      wall = { 1, 49, 80, 86, 87 },
+      -- The delivery van parked on the north quay: drawn face-on, four
+      -- tiles by two, with clear pavement all round it -- so it takes
+      -- the standing per-pixel cutout with a body (10 voxels), not a
+      -- rectangular block that would swallow the air above its cab.
+      -- 72/73/74/75 the cab and box, 88/89/60/76 the wheels and skirt.
+      billboard = { 60, 72, 73, 74, 75, 76, 88, 89 },
+      -- Left to the derived default on purpose:
+      --   $0A        the quay's paving -> walkable, ground
+      --   $32 $3B    the gangway planks -> walkable, ground, so the walk
+      --              from the quay to the warp stays flush at 0 and
+      --              meets the hull's flank rather than climbing it
+      --   $14        open water -> the tileset's own water, -2
+      --   $3A        the shaded strip along the quay's foot.  Its cell's
+      --              bottom-left tile is water, so rule 2 puts it at
+      --              water level -- which is correct: it is the dock's
+      --              shadow lying ON the water, and the 2px lip between
+      --              it and the paving is exactly the shoreline the
+      --              water class exists to draw.
+    },
+
+    -- The facilities: twenty-one maps off one 96-tile atlas -- Silph Co's
+    -- ten office floors, the four Rocket Hideout basements, the four
+    -- Pokemon Mansion floors, the Power Plant, and the Cinnabar and
+    -- Saffron gyms.  One pin therefore has to read right in a laboratory,
+    -- an open-plan office, a burnt mansion and a gym at once; where a
+    -- graphic genuinely means two things the note says which reading won.
+    -- The failures are the usual indoor ones, louder: the detector raised
+    -- whole wall COLUMNS to 48px, stood the lab consoles up as 32px
+    -- cabinets towering over the very band they are drawn INTO, fused
+    -- vertical runs of computer terminals into 48px monoliths, boxed the
+    -- potted-plant rows into one slab wearing leaves on its top face, and
+    -- left both staircases lying flat on the floor.  Silph Co's lobby
+    -- island is tile $14 -- the engine's stale-cache water id -- and sank
+    -- into a pond in the middle of the foyer.
+    FACILITY = {
+      -- The wall band stays ONE 16px face: the dark courses (42/58
+      -- horizontal, 43/44 vertical, 45/46 the top corners, 59/60 the
+      -- bottom caps) and Silph Co's own pale striped band (87/89).  A
+      -- north-south run of 43/44 is one continuous drawing, so unpinned
+      -- the detector measured the whole column and raised it to 48.
+      --
+      -- Everything DRAWN BUILT INTO that band is `wall` too, the
+      -- Center's-healing-console rule, so it reads as equipment jutting
+      -- from the band rather than a separate tower:
+      --   74/75 the machine's two dials over 76/77 its footed base -- one
+      --     graphic serving the Cinnabar Gym's quiz consoles, Silph Co's
+      --     and the Power Plant's equipment banks and the Mansion's lab
+      --     rigs.  Drawn three rows tall under a one-row wall cap, which
+      --     is why the detector called it 32
+      --   9/10 screen over 25/26 base: the computer terminal.  It is
+      --     ALSO the free-standing maze wall of Rocket Hideout B2F/B3F
+      --     and the terminal rows of the Power Plant hall, and 16 -- its
+      --     drawn height -- is right in every one of them
+      --   64/80 the Mansion 2F balustrade seen face-on, 65/81 its
+      --     north-south run.  65 repeats down a whole column, so it
+      --     towered exactly like the wall did
+      --   86/88 the lift doors of Silph Co: a walkable warp cell, but a
+      --     pin is look-only, so the doors stand in the wall band
+      --     instead of lying flat as a mat (the Center does the same
+      --     with its window/warp tile)
+      --   8/24 and 36/37 the shutters the card-key doors and the
+      --     Cinnabar Gym quiz gates stamp CLOSED at runtime
+      --     (field.cardKeyDoors' blocks $54/$5F/$2D).  They are in no
+      --     map's block list, so nothing but this line covers them; the
+      --     detector read them as an 8px stub lying in the doorway
+      wall = { 8, 9, 10, 24, 25, 26, 36, 37, 42, 43, 44, 45, 46,
+               58, 59, 60, 64, 65, 74, 75, 76, 77, 80, 81, 86,
+               87, 88, 89 },
+
+      -- The tall display cabinet of the Mansion and Silph 3F/8F/9F: cap
+      -- row 40/41 over two ranks of 56/57, one cell wide and drawn FOUR
+      -- rows tall.  A tall drawing, not a deep one, so it takes the
+      -- Mart's shelf-rack treatment and collapses onto a one-cell-deep
+      -- box at its full 32px -- as `wall` it flattened into a bench two
+      -- cells deep, which is the shape of its footprint, not the shape
+      -- of the thing.  Its base course is the computer terminal's own
+      -- 25/26, listed under `wall` above and therefore shared: that
+      -- stays a 16px block, and reads as the cabinet's plinth.
+      bookcase = { 40, 41, 56, 57 },
+
+      -- The grey slab family -- every desk, bench, worktop and service
+      -- counter in the tileset is cut from these seven pieces: 13/14 the
+      -- top corners, 2 the top edge between them, 29/30 the body's side
+      -- edges, 53 its fill, 68/69 the legs, 18 the counter's front panel
+      -- (the tileset's own counterTiles).
+      --
+      -- `counter` -- 8px, half a cell -- not `table` or `desk`, because
+      -- the drawing is a TOP surface seen from above with one row of
+      -- front elevation at its south end: one clean band folds exactly
+      -- that bottom row (68/69 legs, or 18) up as the front and rides
+      -- every row above it on the top face in drawn order, which is what
+      -- a seven-cell Silph Co bench actually looks like.  At 12 or 16
+      -- the same drawing reads as a wall stub, the failure the Center's
+      -- counters are pinned against.
+      --
+      -- 13/14 and 29/30 double as the CAP and body of the wall consoles
+      -- (blocks $60/$62/$64/$66/$7F).  The benches win the tie on count
+      -- -- 142 block placements across 18 maps against the consoles' 105
+      -- across 14 -- and the compromise costs the consoles nothing: the
+      -- capped rows sit NORTH of the 16px dial face, so an 8px ledge
+      -- behind a 16px machine is occluded from every southward camera.
+      counter = { 2, 13, 14, 18, 29, 30, 53, 68, 69 },
+
+      -- Plants, the thin standee pool, as in every other interior.  Two
+      -- drawings: the tall potted palm of Silph Co, the Hideout and the
+      -- Mansion (crown 5/6/21/22 over pot 7/15/23/31, a 1x2-cell
+      -- object), and the gym planter of Cinnabar, Saffron and the
+      -- Mansion (crown 39/47, bowl 55/63, box 61/62).  Unpinned the
+      -- detector fused a six-plant row into one box wearing the leaf
+      -- dither as a lid.  The crown's checker highlights share the
+      -- floor's shades so the mask drains some of them -- the same
+      -- accepted trade as the Center's bush.
+      prop = { 5, 6, 7, 15, 21, 22, 23, 31, 39, 47, 55, 61, 62, 63 },
+
+      -- Both flights UP, both climbing EAST.  3/4/19/78 is the one-cell
+      -- open staircase of the Mansion (1F->2F, 2F->3F) and the Hideout
+      -- (B1F->Game Corner): white treads whose risers step up toward the
+      -- upper right.  90/91 over 67/52 is Silph Co's own stairwell, set
+      -- into the north wall band on every floor -- courses of tread whose
+      -- east ends step back one notch at a time.  BOTH cells are
+      -- WALKABLE (19 and 67 are the tileset's warp tiles), so unpinned
+      -- they resolved to flat ground and the steps were painted on the
+      -- floor.  Silph's drawing is the one genuinely ambiguous flight in
+      -- the tileset -- read as a west rise it builds a ramp that leaves a
+      -- gap against the east jamb, so east it is, which also makes one
+      -- consistent story out of every up-stair in the group.
+      stair_e = { 3, 4, 19, 78, 52, 67, 90, 91 },
+      -- The staircase DOWN (11/12/27/28): three treads in a black
+      -- stairwell, shortening and darkening west to east, so the flight
+      -- descends EAST into the dark.  One graphic again, for every
+      -- down-stair in the group.  (Where the Mansion 3F variant hangs
+      -- directly under the wall band, block $73, the engine's door fold
+      -- claims the cell first -- 27 is one of the tileset's doorTiles --
+      -- and stands the art up in the band as a doorway.  That reads
+      -- fine, and the fold runs after this profile, so it is not
+      -- something a pin can or should undo.)
+      stair_down_e = { 11, 12, 27, 28 },
+
+      -- The rubble drifts of the Mansion and the Power Plant (83/84 over
+      -- 54/38): two black-outlined boulders per cell on a plain grey
+      -- ground, tiling wall-to-wall across whole rooms.  Drawn ROUND, so
+      -- they take the overworld canopy's archetype -- one voxel hull per
+      -- 16x16 cell carved from the darkest-pixel outline -- which is the
+      -- only class that keeps a repeating field as separate lumps: a
+      -- standee pool would cluster a whole drift into one giant flat
+      -- cutout, and the volume path gave 16px slabs with 48px towers
+      -- wherever a drift touched a wall.
+      cylinder = { 38, 54, 83, 84 },
+
+      -- Silph Co 1F's lobby island (tile $14), the cross-shaped dither
+      -- the reception terminals ring.  $14 is one of the three ids the
+      -- engine's stale-cache water set claims in EVERY tileset, and it
+      -- is not on this tileset's walkable list, so it fell straight to
+      -- `water` and opened a pond in the middle of the foyer.  It is a
+      -- floor-level mat drawn from above: flat.
+      ground = { 20 },
+
+      -- Left to the derived defaults on purpose, having been checked:
+      --   51, the Hideout's black fill, is all-black art, so the void
+      --     rule already flattens it -- which is what a room's interior
+      --     darkness should be
+      --   32/33/48/49 -- the four quarter-tiles the Hideout's spinner
+      --     arrows and the Saffron/Silph warp diamonds are assembled
+      --     from -- and 94, the Hideout's floor panel, are on the
+      --     tileset's walkable list and come out flat ground unaided
+      --   1 (the checker floor), 17 (the Mansion's upper-floor boards)
+      --     and 66/82 (the entrance carpet) likewise
+      --   the other two stale-cache water ids, $32 and $48, are never
+      --     placed by any of the twenty-one maps, so only $14 above
+      --     needed the guard
+    },
+
+    -- Pokemon Tower's seven floors and Agatha's room (one tileset).
+    -- Every floor is the same octagonal chamber: a ring of wall panels
+    -- ($09/$0A over $19/$1A) cut out of a mid-grey mass ($11), with a
+    -- field of gravestones inside it, and Agatha's room is that chamber
+    -- shrunk.  The ring and the mass the detector already reads as one
+    -- 16px course (probed) -- they are listed anyway so the answer is
+    -- authored rather than inferred from a repeat count, and so the
+    -- panels can never fuse into the gravestones that touch them.
+    -- What the detector got WRONG was everything else: the headstones
+    -- came out as 8px stubs with their arched tops dropped, both
+    -- stairwells were flattened by the walkable-cell rule, and the
+    -- potted palms lost their crowns to a 16px box.
+    -- (Nothing here needs pinning against the void rule: the tileset's
+    -- one all-black tile is $47, and no map in the group places it.)
+    CEMETERY = {
+      -- One 16px course: the chamber's wall ring ($09/$0A over
+      -- $19/$1A), the grey mass beyond it ($11) so the room reads as a
+      -- chamber cut into solid stock rather than a fence standing on a
+      -- plain, and Agatha's north band ($20 over $30).
+      wall = { 9, 10, 25, 26,
+               17,
+               32, 48 },
+      -- The reception counter of POKEMON_TOWER_1F -- the only counter in
+      -- the group, and the ROM's own counterTiles for this tileset name
+      -- $12 as exactly that.  It is an L that fences the receptionist
+      -- into the south-east corner: the east-west arm drawn face-on
+      -- ($02 the surface over $12 the front panel, eight cells of it)
+      -- meeting the north-south arm drawn from above ($1D/$1E, eight
+      -- tile rows, which the volume path would have towered to 64px).
+      -- The first pass put all four in `wall` and the barrier came out
+      -- a full-height partition with the receptionist hidden behind it
+      -- to the shoulders.  Half a cell is what a counter is: she leans
+      -- on it, the drawn surface ($02) rides the top face and the drawn
+      -- panel ($12) folds up the front, and both arms come out the same
+      -- height so the corner turns cleanly instead of stepping.  The
+      -- cells stay blocked either way -- pins are look-only.
+      counter = { 2, 18, 29, 30 },
+      -- The gravestones ($05/$06 over $15/$16): a headstone drawn
+      -- face-on, one per cell, 314 of them across the seven floors and
+      -- Agatha's room.  The volume path measured the drawing as its
+      -- bottom row alone and left an 8px stub -- the plinth without the
+      -- stone.  `post` is the per-CELL standee pool: each cell is
+      -- extracted on its own as a per-pixel cutout 6 voxels deep, so
+      -- the arched top comes back and a 4x2 block of graves stands as
+      -- eight separate stones instead of one 32px sheet with the back
+      -- row floating above the front (which is what one shared
+      -- billboard cluster would have made of them).  The stone's white
+      -- side margins let the background flood in; its own white checker
+      -- band is sealed by the black arch and survives.
+      post = { 5, 6, 21, 22 },
+      -- The flight UP to the next floor ($03/$04 over $13/$14): real
+      -- rising steps, climbing east the way the risers are drawn (short
+      -- at the west, tall at the east -- the same drawing idiom as Red's
+      -- house).  Its collision tile is $13, which IS in the tileset's
+      -- walkable list, so rule 3 had laid the whole flight flat; and its
+      -- south-east tile is $14, the water-fallback trap id -- harmless
+      -- only because the cell's own bottom-left is $13, and pinned here
+      -- so it can never matter.
+      stair_e = { 3, 4, 19, 20 },
+      -- The flight DOWN ($0B/$0C over $1B/$1C): a sunken stairwell.
+      -- The drawn step edges are high and lit at the WEST and fall away
+      -- dark to the east, so the flight descends eastward -- the mirror
+      -- of Red's bedroom stair.  Walkable ($1B) and flattened for the
+      -- same reason as the flight up.
+      stair_down_e = { 11, 12, 27, 28 },
+      -- The potted palm that flanks Mr. Fuji's shrine on 7F and stands
+      -- in Agatha's room ($27/$2F crown, $37/$3F fronds, $3D/$3E
+      -- planter): a plant, so the THIN standee pool, like every other
+      -- interior plant.  It is drawn 24px tall across THREE tile rows,
+      -- which is why the box path dropped its crown row entirely and
+      -- kept a 16px planter; a standee takes the whole drawing at its
+      -- real height.  It backs onto the wall ring, and a separate pool
+      -- keeps it from being absorbed into it.
+      prop = { 39, 47, 55, 63, 61, 62 },
+      -- (Nothing else needs an entry.  The tower's floor ($01) and 5F's
+      -- healing pad ($22) are walkable, so rule 3 lays them flat where
+      -- they are drawn; the mass, ring, graves, stairs and palm above
+      -- are every other tile the eight maps place.)
+    },
+
+    -- The two Underground Paths (Route 5<->6 north-south, Route 7<->8
+    -- west-east): one blockset, two maps, and the plainest geometry in
+    -- the game -- a tiled corridor cut out of black.  Most of it was
+    -- already right, because the black it is cut from ($10) is solid
+    -- black and the void rule flattens it (`10v00` over every border
+    -- block), and the lattice floor ($0B/$0C) with the diagonal shadow
+    -- strip along its west wall ($15/$18) are walkable and lie flat.
+    -- Two things were not.
+    --
+    -- The SOUTH rim.  The corridor's near wall is drawn as a single 8px
+    -- light line ($02) with black under it, so the volume builder
+    -- measured a one-row drawing and raised half a course -- an 8px
+    -- kerb (`02w08` along the whole bottom row of
+    -- UNDERGROUND_PATH_WEST_EAST) facing a proper 16px far wall
+    -- (`06w16`/`09w16`).  Pinned, the corridor closes with one band all
+    -- round.  The east and west rim lines ($16/$17) already read 16 --
+    -- their columns repeat -- and join the same authored course so the
+    -- whole enclosure is one decision.
+    --
+    -- The STAIRS.  $03/$04 over $13/$14 is a real flight drawn in
+    -- profile, treads climbing to the upper right, and it is the warp
+    -- back up to the surface at both ends of both corridors.  Its cell
+    -- is walkable, so it resolved to flat ground and the staircase was
+    -- a painting (`03g00 04g00 / 13g00 14g00`).  stair_e builds the
+    -- flight the drawing shows, rising east.  $14 is also the $14
+    -- WATER-FALLBACK id: the walkable cell was hiding the trap here
+    -- rather than dodging it, and the pin settles it either way.
+    UNDERGROUND = {
+      wall = { 6, 9,               -- $06 over $09, the far wall band
+               2,                  -- $02, the near wall's light line
+               22, 23 },           -- $16/$17, the east and west rims
+      stair_e = { 3, 4, 19, 20 },  -- $03/$04 over $13/$14
+      -- The blockset also carries the wall's unplaced corner variants
+      -- ($05/$08 north-west, $07/$0A north-east, $11 south-west, $12
+      -- south-east).  Neither map places them; they belong with the
+      -- wall band above if one ever does.
+    },
+
+    -- The approach to the Pokemon League: two maps, INDIGO_PLATEAU (the
+    -- forecourt the League itself stands on) and ROUTE_23 (the long
+    -- climb up to it, with its badge-check gates).  Everything this
+    -- blockset draws is one piece of architecture -- striated rock
+    -- walls, white pillars, and the bird STATUES that line both the
+    -- avenue and the plaza.  29 of its 73 blocks are never placed, so
+    -- every tile named below really is one of these two maps'.
+    --
+    -- A statue is built exactly like the badge gyms' (see GYM above):
+    -- one cell of FIGURE ($10/$12 over $28/$29) standing on one cell of
+    -- PLINTH ($15/$16 the cap over $30/$31 the plaque).  47 of them --
+    -- 12 on INDIGO_PLATEAU, six a side down the avenue, and 35 more
+    -- across ROUTE_23's plaza (blocks $42/$43; the $25/$26 twins that
+    -- stand the same statue on grass are never placed).
+    --
+    -- What the detector made of them is the bug this entry exists for.
+    -- On the avenue the statues stack with NO gap: the plinth's plaque
+    -- row is drawn directly above the next figure's head, so the
+    -- flood-fill joined all six of a column into ONE region 24 tile rows
+    -- tall, and the volume builder's repeat scan read 32px down one half
+    -- of the drawing and 24px down the other.  Each row came out as a
+    -- continuous stepped RIDGE of boxes wearing the statue art folded
+    -- onto its south face -- probed INDIGO_PLATEAU tiles (16,12)-(17,35)
+    -- at 32/24 and (22,12)-(23,35) mirrored.  ROUTE_23's plaza statues
+    -- stand alone and fared no better: 24px boxes with the figure's top
+    -- row skipped outright.
+    --
+    -- Pinned the gyms' way the ridge becomes statues.  The plinth is a
+    -- SOLID 16px `wall` block; the figure is a per-pixel cutout 5 voxels
+    -- deep (the thin `prop` pool) that rides the plinth's top face
+    -- through the authored-box support rule and collapses to the
+    -- plinth's SINGLE cell of footprint -- Structures' wall-support case,
+    -- so the base never marches backwards.
+    --
+    -- The one thing the gyms did not have to deal with: $28/$29 is
+    -- SHARED.  The same bird is drawn again at the foot of every white
+    -- pillar, framed there by the pillar's black edge ($25/$26 over that
+    -- same $28/$29, blocks $18/$1B) -- 80 of them, 76 down ROUTE_23 and
+    -- four on INDIGO_PLATEAU (its two outer corners and the pair
+    -- flanking the League's recess).  So $25/$26 joins the same pool:
+    -- pinning half a cell would have stood a half-height bird under a
+    -- wall.  That in turn is why the pillar itself is pinned -- see the
+    -- last paragraph of `wall`.
+    PLATEAU = {
+      -- ONE 16px course for every piece of masonry here.
+      --
+      -- $03 is the striated rock face, 2436 placements and the bulk of
+      -- both maps.  It already read 16 nearly everywhere, but in the
+      -- columns of INDIGO_PLATEAU's rim that stand over a corner pillar
+      -- the repeat scan came out 24 -- a stagger in the plateau's
+      -- skyline (probed `03w24` at tiles (8,0)-(9,2), (12,0)-(13,2) and
+      -- their two mirrors).  Authored, the rim is one course.
+      --
+      -- $0D/$0F/$0E are the League's outer wall -- top band, face and
+      -- base.  The same three tiles draw the Pokemon League's own
+      -- facade, the long walls flanking the avenue, and every
+      -- badge-check gate down ROUTE_23.
+      --
+      -- $15/$16 + $05/$06 + $30/$31 are the pilaster: cap, shaft, and
+      -- the plaque base.  $15/$16 over $30/$31 IS the statue's plinth --
+      -- the artist drew the same stone twice -- which is why one pin
+      -- serves the gate corners and the statues alike.
+      --
+      -- $2E/$2F the white pillar shaft and $20/$21 its cap change no
+      -- HEIGHT: they derive 16 already.  What the pin buys is
+      -- `authored`, which is exactly what the prop support rule tests.
+      -- Without it a pillar-foot bird finds no support, drops to ground
+      -- level, and leaves a hole punched clean through the pillar
+      -- (probed, shot, then fixed).
+      -- TWO courses (32px) for the masonry that ENCLOSES both maps -- the
+      -- plateau's rim and every wall around the terraces.  It is drawn two
+      -- cells tall, which is exactly the height of a statue on its plinth
+      -- (a 16px plinth under a 16px standee), and that is the read: you are
+      -- walking in a walled compound whose wall matches the statues lining
+      -- it, not a room with a 16px skirting.  At one course the rim was a
+      -- kerb you appeared to look over.
+      --
+      -- $03 the striated rock face, $0D/$0F/$0E the League's outer wall
+      -- (top band, face, base -- the same three tiles draw the League's
+      -- facade, the walls flanking the avenue and every badge-check gate
+      -- down ROUTE_23), and $2E/$2F the white pillar shaft with $20/$21 its
+      -- cap.  These four groups are the enclosure.
+      cliff = { 3, 13,
+                32, 33, 46, 47 },
+      -- THE GATE WALLS, stacked rather than laid out in depth.  $0D/$0F/$0E
+      -- (13/15/14 -- top band, face, base) draw the League's facade, the
+      -- walls flanking the avenue and every badge-check gate down ROUTE_23,
+      -- as FOUR tile rows: 13 / 15 / 15 / 14.  That is 32px of artwork
+      -- depicting one wall, and at one class per row it built four boxes
+      -- marching north, so the wall was 32px DEEP -- you saw the southmost
+      -- row's face and the rest hid behind it.
+      --
+      -- `bookcase` collapses the run onto a single one-cell-deep box at its
+      -- full drawn height: bands from the south are base, face, face, top
+      -- band, and the two rows behind are vacated.  Same mechanism the
+      -- Mart's back wall uses.
+      -- ...and the PILASTER stacks with it.  $05/$06 is its shaft, and it
+      -- is drawn only ever inside a pilaster, so it needs no rule.  Without
+      -- this the pale columns stood 16px against a 32px brown wall and
+      -- their top vertices sat a whole course below the wall's crown.
+      bookcase = { 14, 15, 5, 6 },
+      -- Tile 13 is DUAL-USE and needs resolving per position.  It is the
+      -- gate wall's TOP BAND (block $28's first row) and it is also the
+      -- BASE COURSE under a column of rock face (blocks $18/$1A/$1B, last
+      -- row).  Pinned `bookcase` outright the second use became a one-row
+      -- rank -- an 8px stub under the rock, 352 of them over both maps.
+      --
+      -- ABOVE cannot tell them apart, which is what `when_below` is for.
+      -- Scanned over both maps through the engine's own tileAt, the tile
+      -- above a 13 is the rock face $03 for 140 base courses AND for 64
+      -- gate bands -- so a rule on `above` misfires on those 64 (it did:
+      -- their runs came out 2 and 3 bands instead of 4).  BELOW splits it
+      -- exactly: the wall's own face $0F sits under the top band and under
+      -- nothing else, 336 against 352.  So 13 defaults to `cliff` and is
+      -- promoted where the face is drawn beneath it.
+      --
+      -- 14 and 15 need no rule: 14 only ever sits under 15, 15 only ever
+      -- under 13 or 15.
+      when_below = {
+        [13] = { { below = { 15 }, class = "bookcase" } },
+        -- The pilaster's CAP ($15/$16) is the same stone as the statue's
+        -- plinth top -- the artist drew it twice -- so it too resolves per
+        -- position.  Scanned over both maps: a cap with the shaft $05/$06
+        -- beneath it is a pilaster (76 of them) and one with the plaque
+        -- base $30/$31 beneath it is a statue's plinth (47).  Default
+        -- `wall`, promoted here, so the plinth keeps its single course and
+        -- the statue standing on it still totals the 32px the wall is.
+        [21] = { { below = { 5 }, class = "bookcase" } },
+        [22] = { { below = { 6 }, class = "bookcase" } },
+      },
+      -- The other two ends of the same pair of drawings, keyed the other
+      -- way round.  A pilaster is capped at BOTH ends, so its lower cap has
+      -- the shaft ABOVE it (8 placements); and the plaque base $30/$31 is a
+      -- pilaster's foot when the shaft is above it (68) but a statue's
+      -- plinth bottom when the cap $15/$16 is (47).
+      when_above = {
+        [21] = { { above = { 5 }, class = "bookcase" } },
+        [22] = { { above = { 6 }, class = "bookcase" } },
+        [48] = { { above = { 5 }, class = "bookcase" } },
+        [49] = { { above = { 6 }, class = "bookcase" } },
+      },
+      -- The vacated rows behind a collapsed wall take the cell ABOVE the
+      -- run rather than the default hidden floor: here that is more rock
+      -- face on ROUTE_23 and the plateau's paving or grass on INDIGO_
+      -- PLATEAU, so the wall reads as set INTO the terrace instead of
+      -- standing in front of a trench of synthesized ground.
+      bookcase_backfill = "above",
+      -- ONE course, and it must stay one: $15/$16 + $05/$06 + $30/$31 is
+      -- the pilaster -- cap, shaft, plaque base -- and $15/$16 over $30/$31
+      -- IS the statue's plinth, the artist having drawn the same stone
+      -- twice.  Raising it would carry every statue standee up to 48px and
+      -- break the very match the cliff height was chosen for.
+      -- $05/$06 is NOT here: it moved to `bookcase` above, and a tile
+      -- listed in two groups resolves by whichever `pairs` order wins --
+      -- half the pilasters kept the shaft as `wall`, which broke the run
+      -- and left their caps as isolated 8px stubs.  One group per tile.
+      wall = { 21, 22, 48, 49 },
+      -- The statues, and the same bird at the pillar feet.  Black-outline
+      -- segmented: the outline and everything it encloses stay, the sky
+      -- and the paving around them flood away.
+      prop = { 16, 18, 40, 41, 37, 38 },
+      -- Round drawings, one voxel ball per 16x16 cell -- the treatment
+      -- the overworld's canopies and Celadon's hedge take.
+      --
+      -- $07/$08 over $17/$18: the seven canopies planted on pillar tops
+      -- along ROUTE_23 (blocks $44/$45; the $0F block that tiles four of
+      -- them together is never placed).  Boxed, the canopy art smeared
+      -- down the whole pillar column beneath it.
+      --
+      -- $2A/$2B over $22/$1D: the boulders strewn across ROUTE_23's
+      -- middle terrace (blocks $02/$13/$16), one per cell and NOT
+      -- walkable.  As boxes they sat flat enough to look painted onto
+      -- the path; as balls they read as the obstacles they are.
+      cylinder = { 7, 8, 23, 24,
+                   29, 34, 42, 43 },
+      -- The Route 23 sign, one cell, block $48's only placement.
+      -- Unpinned it probed `09w00 0Aw00 / 19w08 1Aw08` -- an 8px stub
+      -- with its board skipped.  Same thin plate on a stick every other
+      -- outdoor sign gets.
+      signpost = { 9, 10, 25, 26 },
+      -- The Route 22 gate's roof, drawn from ABOVE and filling
+      -- ROUTE_23's last two block rows ($3D the tiling, $3E/$44 its
+      -- edges, $40/$41 the corners).  Art on the TOP face -- the way
+      -- SHIP_PORT's hull is pinned -- rather than folded up a 16px kerb.
+      -- It stands past the map's last walkable row (you warp to
+      -- ROUTE_22_GATE before you reach it), so this is a tidy-up rather
+      -- than a fix.
+      roof = { 61, 62, 64, 65, 68 },
+      -- The ground painted where a pinned figure's cell used to be:
+      -- $23, the pale paving both maps are floored with.  It is also the
+      -- white the pillars are drawn in, so the cell a pillar-foot bird
+      -- vacates reads as more pillar -- where the neighbour vote left a
+      -- BLACK hole, having nothing to elect (all four neighbours of that
+      -- cell are wall).  On the avenue and the plaza the statues' own
+      -- cells simply keep the paving they stand on.
+      prop_ground = { [16] = 35, [18] = 35, [40] = 35, [41] = 35,
+                      [37] = 35, [38] = 35 },
+      -- Deliberately NOT pinned:
+      --
+      -- $14, the water -- 1446 placements, the pond on ROUTE_23's middle
+      -- terrace -- and its bank shading $32/$33/$1F.  $14 and $32 are
+      -- two of the three stale-cache water ids the trap is named for,
+      -- but here they are honestly water: TILEANIM_WATER animates $14,
+      -- the pond is real, and $32/$33/$1F are drawn in the TOP half of
+      -- water cells as the waterline itself, so the cell rule dropping
+      -- them to -2 is what the art means.  Left to fall through to the
+      -- engine's water set.  ($48, the third trap id, is not in this
+      -- atlas at all -- it stops at $45.)
+      --
+      -- $0B/$0C over $1B/$1C, the barred doors: the Pokemon League's two
+      -- and Victory Road's two.  They are the tileset's own doorTiles,
+      -- so the door fold already stands them upright in the facade;
+      -- probed 16px identically before and after this entry.
+      --
+      -- $23/$2C/$2D are in the walkable list outright, and $45 is the
+      -- tileset's grassTile, which derives its own standing-tuft pin.
+      --
+      -- The Victory Road entrance is a `buildings` template
+      -- (victory_road_gate, at the bottom of this file): 36x6 tiles at
+      -- ROUTE_23 (0,58), and its ends are built out of $25/$26/$28/$29
+      -- and $15/$16/$05/$06.  Buildings claim their tiles before any of
+      -- the above can reach them -- probed `b` class over all 216 of
+      -- them, unchanged by this entry.
+    },
+  },
+
+  -- Buildings whose whole sprite is voxelized band by band (lib/Buildings.lua,
+  -- the pipeline in assets/docs/buidling_to_voxel/).  A building is matched by its
+  -- exact tile grid -- the drawings are catalogued in assets/docs/buildings/ -- so
+  -- every map that places the same art gets the same model: one entry
+  -- voxelizes Red's house, Blue's house, Bill's, the Copycat's and the two
+  -- Fuchsia houses alike.
+  --
+  -- Only the BAND TABLE is authored here, because only it needs a human to
+  -- read the drawing.  Everything measurable is measured off the pixels:
+  -- the silhouette, the taper rate (which IS the roof's slope), the eave
+  -- height, and every window and doorway (a non-black region its own black
+  -- frame seals off).  Fields:
+  --
+  --   tiles      the tile-id grid that identifies the building, rows of the
+  --              8px tile atlas, north row first
+  --   roofRows   how many rows off the top are drawn as TOP-FACING roof;
+  --              the rest of the drawing is the facade, seen face-on
+  --   roofBack   rows laid along the north rim, one row per voxel of depth
+  --   roofFront  rows laid along the south rim (the fascia and eave course)
+  --   roofCycle  the row run the middle depth cycles; its length must be
+  --              the roof texture's period or the courses will not line up
+  --   slab       roof thickness in voxels
+  --   frontEave  how far the roof overhangs the facade
+  --   ledge      a band that juts two voxels past the walls (an awning),
+  --              or nil
+  --   seal       sides the drawing runs off rather than closing with its
+  --              own outline, as a string of n/s/e/w; the silhouette
+  --              flood does not seed there. Only needed by a drawing
+  --              trimmed flush to its art -- one whose base course is a
+  --              row of brick rather than the black threshold every other
+  --              building stands on. Omit it unless the fill says
+  --              otherwise: sealing a side the drawing does NOT run off
+  --              swallows the terrain beside it.
+  --
+  -- Nothing here describes the roof's SHAPE, because nothing needs to: the
+  -- topmost drawn row of each column is the elevation profile, so a drawn
+  -- taper becomes a slope and a roof drawn from straight above comes out
+  -- level.  That is why the flat-roofed civic block and its sixteen
+  -- relatives -- every Center and Mart, the gyms and gates, the department
+  -- store and Silph Co -- share one band table below, differing only in
+  -- their tile grids.  The sloped ones fall into three groups just as
+  -- cleanly, by the depth of the roof band: 16 rows (Red's house), 32
+  -- (Oak's lab) or 64 (the museum).  Before authoring a new one, check
+  -- whether its roof band is already pixel for pixel one of those.
+  --
+  -- assets/docs/buildings/B26 is deliberately absent.  Its drawing has no
+  -- black base course -- it ends on a row of light brick -- so the
+  -- silhouette flood, which comes in from the border through light pixels,
+  -- climbs up through the wall and hollows it out.  Every other building
+  -- is sealed by a black threshold row.  Reading it would mean changing
+  -- the flood itself, which every model here depends on, for one scenery
+  -- placement.
+  buildings = {
+    OVERWORLD = {
+      -- assets/docs/buildings/B30: the POKEMON TOWER -- the one drawing
+      -- in the catalogue that STRADDLES A MAP BOUNDARY.  Twelve of its
+      -- twenty rows stand in ROUTE_10's last rows (the 64px purple roof
+      -- band plus two window courses); the other eight -- five more
+      -- courses and the base with the door -- are on LAVENDER_TOWN,
+      -- where the tower begins at tile row 0.  Modelled per map it came
+      -- out as two buildings, one per half.
+      --
+      -- `topRows` composites ROUTE_10's twelve rows ABOVE the matched
+      -- grid, so the model is built from the COMPLETE twenty-row drawing
+      -- -- 96px of facade under the real 64px roof -- while placement
+      -- still matches only the eight Lavender rows.  Its `claimOnly`
+      -- twin below claims the ROUTE_10 rows and stamps nothing, so the
+      -- roof half does not also stand as its own building.
+      --
+      -- BOTH COME FIRST IN THIS LIST ON PURPOSE.  The tower's upper
+      -- twelve rows are `gabled_block_6x6` tile for tile -- the artist
+      -- drew the top of the tower as an ordinary six-cell block -- so
+      -- that template matches at ROUTE_10 (24,132) too.  Placement is
+      -- first-claim-wins (see Buildings.build), so claiming here before
+      -- the generic block reaches it is what keeps the second tower from
+      -- being stamped behind this one.
+      --
+      -- The 13-id last row is kept from the first attempt: the bare
+      -- 12-wide body grid is B14's lower two-thirds tile for tile, and
+      -- the extra id stops this template stamping inside
+      -- `flat_block_6x6`'s three placements (`matches` walks a row to
+      -- its own length, while `read` composites only #tiles[1] columns,
+      -- so a 13th id constrains placement without entering the drawing).
+      {
+        id = "pokemon_tower",
+        topRows = {
+          {  5,  6, 83, 83, 83, 83, 83, 83, 83, 83,  8,  9 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 22, 23, 23, 23, 23, 23, 23, 23, 23, 24, 25 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 22, 23, 23, 23, 23, 23, 23, 23, 23, 24, 25 },
+          { 37, 38, 34, 34, 34, 34, 34, 34, 34, 34, 40, 41 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+        },
+        tiles = {
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 78, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 79, 17 },
+        },
+        roofRows = 64, roofBack = 8, roofFront = 8, roofCycle = { 8, 31 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+      -- the tower's roof half, where it actually stands on ROUTE_10:
+      -- claimed flat so the drawing does not ALSO fold up as a building
+      -- behind the modelled tower (see topRows above)
+      {
+        id = "pokemon_tower_top",
+        claimOnly = true,
+        tiles = {
+          {  5,  6, 83, 83, 83, 83, 83, 83, 83, 83,  8,  9 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 22, 23, 23, 23, 23, 23, 23, 23, 23, 24, 25 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 22, 23, 23, 23, 23, 23, 23, 23, 23, 24, 25 },
+          { 37, 38, 34, 34, 34, 34, 34, 34, 34, 34, 40, 41 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+        },
+      },
+      -- assets/docs/buildings/B07: the two-storey gabled house.  Coursed cap over
+      -- a gable wall, an awning with its double black underline, then the
+      -- ground floor with the door.  7 placements, Red's and Blue's among
+      -- them.  Course rhythm: a dark line every 4 rows.
+      {
+        id = "gabled_house",
+        tiles = {
+          {  5,  6,  7,  7,  7,  7,  8,  9 },
+          { 21, 22, 23, 23, 23, 23, 24, 25 },
+          { 37, 38, 10, 34, 10, 10, 40, 41 },
+          { 92, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 34, 11, 12, 10, 10, 34, 31 },
+          { 78, 26, 27, 28, 26, 26, 26, 79 },
+        },
+        roofRows = 16, roofBack = 7, roofFront = 9, roofCycle = { 5, 8 },
+        slab = 4, frontEave = 4, ledge = { 24, 31 },
+      },
+
+      -- assets/docs/buildings/B31: Oak's lab.  The same architecture with a roof
+      -- band twice as deep -- the extra rows are DEPTH, not height, so the
+      -- lab is a bigger footprint under the same storey.  Its cross-hatch
+      -- roof texture repeats every 8 rows, and it has no awning: the band
+      -- that would be one is the roof's own eave course.
+      {
+        id = "oaks_lab",
+        tiles = {
+          {  5,  6, 83, 83, 83, 83, 83, 83, 83, 83,  8,  9 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 22, 23, 23, 23, 23, 23, 23, 23, 23, 24, 25 },
+          { 37, 38, 10, 10, 10, 75, 75, 10, 10, 10, 40, 41 },
+          { 15, 34, 34, 34, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 11, 12, 10, 10, 10, 10, 10, 31 },
+          { 78, 26, 26, 26, 27, 28, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B03: the flat-roofed commercial block --
+      -- Celadon's diner, hotel, chief's house and prize room, the Bike
+      -- Shop, the Fan Club, Mr. Psychic's, the Underground Path entrances.
+      -- 15 placements, the most of any voxelized drawing.  The lattice
+      -- field is drawn from straight above, so the measured taper is flat
+      -- and the whole band is depth under one level roof; the eave course
+      -- is the roof's own south rim, lab-style, no awning.  Lattice period
+      -- 8, the lab's rhythm again.
+      {
+        id = "flat_commercial",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 11, 12, 75, 75, 75, 31 },
+          { 78, 26, 27, 28, 26, 26, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B05: every Pokemon Center in the game
+      -- (Celadon, Cerulean, Cinnabar, Fuchsia, Lavender, Pewter,
+      -- Saffron, Vermilion, Viridian, Mt Moon, Rock Tunnel). B03's
+      -- block with the POKe sign hung beside the door; the sign is
+      -- too wide to be a pane, so it stays flush.
+      {
+        id = "pokecenter",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 11, 12, 66, 67, 75, 31 },
+          { 78, 26, 27, 28, 74, 74, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B06: every Poke Mart (Cerulean,
+      -- Cinnabar, Fuchsia, Lavender, Pewter, Saffron, Vermilion,
+      -- Viridian). The Center's twin, MART on the sign.
+      {
+        id = "pokemart",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 11, 12, 68, 69, 75, 31 },
+          { 78, 26, 27, 28, 74, 74, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B02: the plain 4x4 block: one window
+      -- course over blank brick and no door. 15 placements, scenery
+      -- in every city bar the Celadon Mart roof stair.
+      {
+        id = "flat_block_4x4",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 31 },
+          { 78, 26, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B08: the same block two cells deeper,
+      -- 6 placements, all scenery.
+      {
+        id = "flat_block_4x6",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 31 },
+          { 78, 26, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B13: the 6x4 scenery block, 4
+      -- placements.
+      {
+        id = "flat_block_6x4",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 78, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B14: the 6x6 scenery block, 3
+      -- placements.
+      {
+        id = "flat_block_6x6",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 78, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B27: the 8x4 scenery block, one
+      -- placement on Route 11.
+      {
+        id = "flat_block_8x4",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 78, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B09: the wide storefront: Celadon's
+      -- Game Corner, the Pokemon Mansion, Cinnabar Lab, the Safari
+      -- Zone gate and Fuchsia's meeting room.
+      {
+        id = "game_corner",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 10, 75, 75, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 75, 75, 11, 12, 10, 10, 75, 75, 75, 31 },
+          { 78, 26, 26, 26, 27, 28, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B15: Celadon Mansion and the Route 6
+      -- and Route 12 gates.
+      {
+        id = "celadon_mansion",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 75, 75, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 75, 75, 11, 12, 10, 10, 75, 75, 75, 31 },
+          { 78, 26, 26, 26, 27, 28, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B18: the Route 2 gate, and the museum's
+      -- east entrance beside it in Pewter.  The museum HALL itself is
+      -- B24 below, a different drawing with a sloped roof.
+      {
+        id = "route_2_gate",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 11, 12, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 78, 26, 27, 28, 26, 26, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B29: Fuchsia Gym, the block with GYM
+      -- on the sign.
+      {
+        id = "fuchsia_gym",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 34, 47, 63, 34, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 34, 34, 34, 34, 75, 75, 75, 31 },
+          { 15, 75, 11, 12, 10, 10, 10, 10, 75, 75, 75, 31 },
+          { 78, 26, 27, 28, 26, 26, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B28: the Route 5 underground-path
+      -- gate.
+      {
+        id = "route_5_gate",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 75, 75, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 11, 12, 10, 10, 75, 75, 75, 31 },
+          { 78, 26, 26, 26, 26, 26, 26, 26, 27, 28, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B21: the Route 22 league gate, the
+      -- widest of the family at 12 cells.
+      {
+        id = "route_22_gate",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 75, 75, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 11, 12, 10, 10, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 78, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 27, 28, 26, 26, 26, 26, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B25: the Power Plant.
+      {
+        id = "power_plant",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 75, 75, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 11, 12, 10, 10, 75, 75, 75, 31 },
+          { 78, 26, 26, 26, 26, 26, 26, 26, 27, 28, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B22: Celadon's department store: six
+      -- window courses over the MART sign.
+      {
+        id = "celadon_mart",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 75, 75, 10, 10, 75, 75, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 75, 75, 11, 12, 10, 10, 11, 12, 10, 10, 68, 69, 75, 31 },
+          { 78, 26, 26, 26, 27, 28, 26, 26, 27, 28, 26, 26, 74, 74, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B20: Silph Co. Twelve cells of plot
+      -- and ten courses of windows under the same roof band, so it
+      -- stands as the tallest thing in Kanto.
+      {
+        id = "silph_co",
+        tiles = {
+          { 76, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 77 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 90 },
+          { 92, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 93 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 75, 75, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 75, 75, 11, 12, 10, 10, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 78, 26, 26, 26, 27, 28, 26, 26, 26, 26, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B24: the Pewter museum's hall, and the only
+      -- building in the family with a SLOPED roof: the same 2:1 taper the
+      -- lab and Red's house are drawn with, over a roof band twice the
+      -- lab's depth.  The drawing repeats its whole lattice-and-course
+      -- motif -- rows 8..31 again at 32..55 -- which is what fixes the
+      -- cycle at 24 rather than the bare lattice's 8: the drawing proves
+      -- the period.  The last band (rows 56..63) is the roof's fascia,
+      -- wider than the wall it covers, so it stays in the roof band and
+      -- lands on the south rim.
+      {
+        id = "museum",
+        tiles = {
+          {  5,  6, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83,  8,  9 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 22, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 24, 25 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 22, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 24, 25 },
+          { 37, 38, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 40, 41 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 75, 75, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 11, 12, 10, 10, 75, 75, 75, 31 },
+          { 78, 26, 26, 26, 26, 26, 26, 26, 27, 28, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 64, roofBack = 8, roofFront = 8, roofCycle = { 8, 31 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B10: the gym. Cinnabar, Pewter,
+      -- Vermilion and Viridian wear this drawing, and so does the
+      -- Fighting Dojo next door to Saffron's. Oak's lab's roof band
+      -- exactly, tile for tile, over a facade with GYM on the sign.
+      {
+        id = "gym",
+        tiles = {
+          {  5,  6, 83, 83, 83, 83, 83, 83, 83, 83,  8,  9 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 22, 23, 23, 23, 23, 23, 23, 23, 23, 24, 25 },
+          { 37, 38, 10, 10, 34, 47, 63, 34, 10, 10, 40, 41 },
+          { 15, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 11, 12, 10, 31 },
+          { 78, 26, 26, 26, 26, 26, 26, 26, 27, 28, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B16: the big-city gym: Celadon,
+      -- Cerulean and Saffron. Two cells wider than the standard
+      -- gym, and it carries the GYM sign twice.
+      {
+        id = "gym_large",
+        tiles = {
+          {  5,  6, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83,  8,  9 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 22, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 24, 25 },
+          { 37, 38, 10, 10, 34, 47, 63, 34, 34, 47, 63, 34, 10, 10, 40, 41 },
+          { 15, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 12, 10, 31 },
+          { 78, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 27, 28, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B01: the commonest drawing in the
+      -- game at 19 placements, and every one of them scenery: a
+      -- gabled block with two window courses and no door. Red's
+      -- house's roof band, tile for tile, but no awning under it.
+      {
+        id = "gabled_block_4x3",
+        tiles = {
+          {  5,  6,  7,  7,  7,  7,  8,  9 },
+          { 21, 22, 23, 23, 23, 23, 24, 25 },
+          { 37, 38, 10, 10, 10, 10, 40, 41 },
+          { 15, 34, 34, 34, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 31 },
+          { 78, 26, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 16, roofBack = 7, roofFront = 9, roofCycle = { 5, 8 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B04: the little 4x2 cottage, 12
+      -- placements and nearly all of them somebody's home: Mr
+      -- Fuji's, the Cubone house, Bill's grandpa's, the Name
+      -- Rater's, the Viridian school house, the Route 8 underground
+      -- path.
+      {
+        id = "gabled_cottage",
+        tiles = {
+          {  5,  6,  7,  7,  7,  7,  8,  9 },
+          { 21, 22, 23, 23, 23, 23, 24, 25 },
+          { 37, 38, 11, 12, 10, 10, 40, 41 },
+          { 78, 26, 27, 28, 26, 26, 26, 79 },
+        },
+        roofRows = 16, roofBack = 7, roofFront = 9, roofCycle = { 5, 8 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B17: the wide 6x2 house: Cerulean's
+      -- badge, trade and trashed houses.
+      {
+        id = "gabled_house_wide",
+        tiles = {
+          {  5,  6,  7,  7,  7,  7,  7,  7,  7,  7,  8,  9 },
+          { 21, 22, 23, 23, 23, 23, 23, 23, 23, 23, 24, 25 },
+          { 37, 38, 11, 12, 35, 10, 10, 35, 10, 10, 40, 41 },
+          { 78, 26, 27, 28, 26, 26, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 16, roofBack = 7, roofFront = 9, roofCycle = { 5, 8 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B11: the 6x2 scenery block, 5
+      -- placements, no door.
+      {
+        id = "gabled_block_6x2",
+        tiles = {
+          {  5,  6,  7,  7,  7,  7,  7,  7,  7,  7,  8,  9 },
+          { 21, 22, 23, 23, 23, 23, 23, 23, 23, 23, 24, 25 },
+          { 37, 38, 10, 34, 35, 10, 10, 35, 10, 10, 40, 41 },
+          { 78, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 16, roofBack = 7, roofFront = 9, roofCycle = { 5, 8 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B34: the 4x2 scenery block, one
+      -- placement in Fuchsia.
+      {
+        id = "gabled_block_4x2",
+        tiles = {
+          {  5,  6,  7,  7,  7,  7,  8,  9 },
+          { 21, 22, 23, 23, 23, 23, 24, 25 },
+          { 37, 38, 10, 34, 10, 10, 40, 41 },
+          { 78, 26, 26, 26, 26, 26, 26, 79 },
+        },
+        roofRows = 16, roofBack = 7, roofFront = 9, roofCycle = { 5, 8 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B33: the Route 5 day care.
+      {
+        id = "daycare",
+        tiles = {
+          {  5,  6, 83, 83, 83, 83,  8,  9 },
+          { 21, 56, 18, 18, 18, 18, 56, 25 },
+          { 21, 56, 18, 18, 18, 18, 56, 25 },
+          { 21, 22, 23, 23, 23, 23, 24, 25 },
+          { 37, 38, 10, 10, 10, 10, 40, 41 },
+          { 15, 34, 34, 34, 34, 34, 34, 31 },
+          { 15, 10, 10, 10, 11, 12, 10, 31 },
+          { 78, 26, 26, 26, 27, 28, 26, 79 },
+        },
+        roofRows = 32, roofBack = 7, roofFront = 8, roofCycle = { 5, 12 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+
+      -- assets/docs/buildings/B26: the Route 10 scenery block,
+      -- structurally the museum's twin -- Oak's lab's roof band,
+      -- and its rows 8..31 repeat at 32..55 exactly as the museum's
+      -- do. It needs `seal` because its drawing has no black base
+      -- course: it ends on a row of light brick, and unsealed the
+      -- flood climbs in from the south border through the mortar
+      -- and hollows the wall out (72% of the sprite survives
+      -- instead of 95%, in 65 pieces instead of 1).
+      {
+        id = "gabled_block_6x6",
+        tiles = {
+          {  5,  6, 83, 83, 83, 83, 83, 83, 83, 83,  8,  9 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 22, 23, 23, 23, 23, 23, 23, 23, 23, 24, 25 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 56, 18, 18, 18, 18, 18, 18, 18, 18, 56, 25 },
+          { 21, 22, 23, 23, 23, 23, 23, 23, 23, 23, 24, 25 },
+          { 37, 38, 34, 34, 34, 34, 34, 34, 34, 34, 40, 41 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+          { 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 31 },
+          { 15, 75, 75, 75, 75, 75, 75, 75, 75, 75, 75, 31 },
+        },
+        roofRows = 64, roofBack = 8, roofFront = 8, roofCycle = { 8, 31 },
+        slab = 4, frontEave = 4, ledge = nil, seal = "s",
+      },
+    },
+
+    FOREST = {
+      -- assets/docs/buildings/B12: the Safari Zone rest houses --
+      -- Center, East, North, West and the Secret House. A
+      -- corrugated roof over a plank facade; its stripe repeats
+      -- every 5 rows, not the OVERWORLD lattice's 8.
+      {
+        id = "safari_rest_house",
+        tiles = {
+          {  8,  9,  9,  9,  9,  9,  9, 12 },
+          { 24, 25, 25, 25, 25, 25, 25, 28 },
+          { 40, 41, 42, 43,  1,  1, 41, 44 },
+          { 56, 41, 58, 59, 41, 41, 41, 60 },
+        },
+        roofRows = 17, roofBack = 5, roofFront = 3, roofCycle = { 5, 9 },
+        slab = 4, frontEave = 4, ledge = nil,
+      },
+    },
+  },
+}

--- a/mods/dramatic_shape/lib/BattleArena.lua
+++ b/mods/dramatic_shape/lib/BattleArena.lua
@@ -1,0 +1,360 @@
+-- Overworld battles: where the fight is staged.
+--
+-- A battle in this mod happens ON THE MAP, so it needs a patch of ground
+-- clear enough to stand two Pokemon on and point a camera down. This module
+-- finds it: the nearest patch of open cells, in the shape below.
+--
+--     x x x
+--     x O x        O   the enemy's mon
+--     x x x
+--     x x x
+--     x P x        P   the player's mon
+--     x x x
+--
+-- Every `x` is an OPEN cell -- one with no obstruction, i.e. one the player
+-- could walk onto. The two mons stand three cells apart down the middle
+-- column, with a one-cell apron all round so the camera looks across floor
+-- rather than into a wall.
+--
+-- When no map has room for that -- a corridor, a cave, a shop floor -- the
+-- search relaxes to the narrow shape, which is the same three-cell gap with
+-- the apron given up:
+--
+--     O
+--     x
+--     x
+--     P
+--
+-- and if even that will not fit, the caller gets nil and the battle draws
+-- the way it always did. A mod that cannot find a stage does not invent
+-- one.
+--
+-- Nothing here MOVES anybody: the arena is where the CAMERA goes and where
+-- the two mons are staged for the shot. The player's own cell, the party,
+-- every script and flag are exactly where the battle left them, which is
+-- what keeps a trainer's post-battle dialogue talking to someone still
+-- standing in front of them.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local BattleArena = {}
+
+-- ------- the authored spot
+--
+-- Every map gets ONE place its battles happen, chosen once and written down
+-- in data/battle_arenas.lua, rather than whatever clearing happens to be
+-- nearest to wherever the fight started. Two reasons.
+--
+-- A fight should look the same every time it happens somewhere. Picking the
+-- nearest patch means Route 1 has a dozen different battle scenes depending
+-- on which step of the grass you were on, some of them behind a tree.
+--
+-- And "open ground" is not the same question as "you can SEE the two of
+-- them". The camera is low and a long way back, so a hedge, a ledge lip or a
+-- building corner anywhere along that line hides a mon completely while the
+-- cells it stands on are perfectly walkable. That is what `clearance` below
+-- measures, and it is what the authored list is chosen against.
+--
+-- A map with no entry falls back to the search, so a mod that adds maps, or
+-- an entry that goes stale, degrades to the old behaviour rather than to no
+-- battle.
+-- An entry may also name ANOTHER MAP to stage on:
+--
+--   ["MT_MOON_B2F"] = { map = "MT_MOON_1F", x = 12, y = 8, shape = "wide" }
+--
+-- because some maps simply have nowhere to put a fight. A cave's lower floor
+-- can be nothing but two-cell-wide corridors between rock walls; a gym is a
+-- room full of furniture. Rather than stage a battle there badly -- both
+-- Pokemon behind a boulder -- the fight is shot on a floor of the SAME cave,
+-- or a floor of the same building, that does have the room for it. It is the
+-- same place, and no worse a fiction than a battle happening on ground the
+-- player is not standing on, which is what every one of these already is.
+local authored = nil
+local overrides = {}
+
+local function authoredFor(mapId)
+  -- `~= nil`, not truthiness: `false` is a meaningful entry here (an
+  -- authored refusal), so it has to reach the caller rather than read as
+  -- "nothing set" and fall through to the data file
+  local forced = overrides[mapId]
+  if forced ~= nil then return forced end
+  if authored == nil then
+    local ok, list = pcall(V.data, "battle_arenas")
+    authored = (ok and type(list) == "table") and list or false
+  end
+  if not authored then return nil end
+  return authored[mapId]
+end
+
+BattleArena.authoredFor = authoredFor
+
+-- Force one map's entry at runtime, ahead of the data file. The authoring
+-- tool's handle: it is how a spot chosen by eye is staged and photographed
+-- before it is written down, and the only way to check a cross-floor entry
+-- without editing the shipped list first. Pass nil to drop it again.
+function BattleArena.setOverride(mapId, entry)
+  overrides[mapId] = entry
+end
+
+-- Cell size in world pixels, the unit every coordinate here is in when it
+-- crosses into the renderer (Map's walk grid is 16px cells).
+local CELL = 16
+
+-- The two shapes, in preference order. `w`/`h` are in cells; `enemy` and
+-- `player` are the offsets, from the shape's north-west corner, of the two
+-- cells a mon stands on.
+BattleArena.SHAPES = {
+  { id = "wide",   w = 3, h = 6, enemy = { 1, 1 }, player = { 1, 4 } },
+  { id = "narrow", w = 1, h = 4, enemy = { 0, 0 }, player = { 0, 3 } },
+}
+
+-- Whether a cell is open ground for the purpose above.
+--
+-- "Open" is the walk test the player themselves answer to, so an arena can
+-- never be laid over a wall, a counter, a tree or a ledge face. Water counts
+-- only for a surfer, which is the one case where the player is standing on
+-- it too -- a sea battle staged on the beach half a route away would read as
+-- a teleport.
+--
+-- Warp cells are excluded on top of that. They are walkable by definition
+-- (they are the doormat), and a fight framed in a doorway both looks wrong
+-- and puts the camera inside the building's geometry.
+--
+-- And TALL GRASS is excluded, which is the surprising one, because grass is
+-- where wild battles come from and standing in it is the obvious place to
+-- have one. It does not survive contact with the camera. Grass is real
+-- geometry in this mode -- a row of tufts about knee height on a Pokemon --
+-- drawn with the same camera-ward bias that lets it overdraw a walking
+-- character's feet in the free-roam world. From a camera nearly level with
+-- the floor that bias stops being feet-deep: the tufts on and around a mon's
+-- own tile stand between it and the lens and eat most of the sprite.
+--
+-- So the arena is laid on bare ground -- the whole footprint, not just the
+-- two cells a mon stands on, because the apron south of the near mon is
+-- exactly the row whose grass would cover it. Grass FURTHER back toward the
+-- camera is fine and stays: it is far enough forward to project low and wide
+-- across the bottom of the frame, where it reads as a field rather than as
+-- something in the way.
+local function openCell(map, cx, cy, surfing)
+  if not map:inBounds(cx, cy) then return false end
+  if map:warpAtCell(cx, cy) then return false end
+  if map:isWarpTileCell(cx, cy) then return false end
+  if map.isGrassCell and map:isGrassCell(cx, cy) then return false end
+  if map:isWalkableCell(cx, cy) then return true end
+  return (surfing and map:isWaterCell(cx, cy)) or false
+end
+
+BattleArena.openCell = openCell
+
+-- The map's open cells as one flat boolean grid, so the rectangle test
+-- below is a lookup rather than a tileset walk per cell. Built once per
+-- search; a battle asks for one.
+local function openGrid(map, surfing)
+  local w, h = map.widthCells, map.heightCells
+  local grid = {}
+  for cy = 0, h - 1 do
+    local row = cy * w
+    for cx = 0, w - 1 do
+      grid[row + cx] = openCell(map, cx, cy, surfing)
+    end
+  end
+  return grid, w, h
+end
+
+local function fits(grid, gw, x, y, w, h)
+  for cy = y, y + h - 1 do
+    local row = cy * gw
+    for cx = x, x + w - 1 do
+      if not grid[row + cx] then return false end
+    end
+  end
+  return true
+end
+
+-- Build the record the renderer reads: the two mons' cells and, in world
+-- pixels, the centre of each and of the pair.
+local function place(shape, x, y)
+  local ex, ey = x + shape.enemy[1], y + shape.enemy[2]
+  local px, py = x + shape.player[1], y + shape.player[2]
+  local arena = {
+    shape = shape.id,
+    x = x, y = y, w = shape.w, h = shape.h,
+    enemyCell = { ex, ey },
+    playerCell = { px, py },
+    -- world-pixel centres of the two cells a mon stands on
+    enemy = { ex * CELL + CELL / 2, ey * CELL + CELL / 2 },
+    player = { px * CELL + CELL / 2, py * CELL + CELL / 2 },
+  }
+  arena.mid = { (arena.enemy[1] + arena.player[1]) / 2,
+                (arena.enemy[2] + arena.player[2]) / 2 }
+  return arena
+end
+
+-- ------- can the two of them actually be SEEN there
+--
+-- The camera sits low and far back on one side, so what hides a mon is not
+-- what is on its own tile -- it is anything TALL between the camera and it.
+-- A tree two cells to the south-east blocks the near mon completely while
+-- every cell of the arena is open ground.
+--
+-- So the line from the eye to each mon is walked in short steps and the
+-- terrain height under each step is compared with how high the line is
+-- there. Three lines per mon -- to its feet, its middle and its head --
+-- because a hedge that clears the head still cuts the body in half.
+--
+-- Grass and flowers are deliberately not obstacles: they stand at ankle
+-- height, they are what a field looks like, and a mon standing in them
+-- reads as standing in a field rather than as being hidden by one.
+BattleArena.SAMPLE_STEP = 4      -- world pixels along the line
+BattleArena.MON_H = 16           -- how tall a mon stands, in world pixels
+BattleArena.CLEAR_EPS = 1.5      -- slack, so a flush kerb is not an obstacle
+
+local function heightAt(map, wx, wz)
+  local cx, cy = math.floor(wx / CELL), math.floor(wz / CELL)
+  if not map:inBounds(cx, cy) then
+    -- off the map the border ring is drawn, and on most outdoor maps that
+    -- ring is trees; treat it as solid so an arena is never framed through it
+    return 32
+  end
+  local ok, h = pcall(V.require("VoxelScene").groundAt, map, cx, cy)
+  return (ok and h) or 0
+end
+
+-- Whether the segment from `eye` to (tx, ty, tz) clears the terrain.
+local function lineClear(map, eye, tx, ty, tz)
+  local dx, dy, dz = tx - eye[1], ty - eye[2], tz - eye[3]
+  local len = math.sqrt(dx * dx + dy * dy + dz * dz)
+  if len <= 1 then return true end
+  local steps = math.ceil(len / BattleArena.SAMPLE_STEP)
+  -- skip the ends: the eye is in open air by construction and the last step
+  -- is the mon's own tile, which it is standing on
+  for i = 1, steps - 1 do
+    local t = i / steps
+    local wx = eye[1] + dx * t
+    local wy = eye[2] + dy * t
+    local wz = eye[3] + dz * t
+    if heightAt(map, wx, wz) > wy + BattleArena.CLEAR_EPS then return false end
+  end
+  return true
+end
+
+-- Whether both mons would be in plain view from the battle camera.
+function BattleArena.clearance(map, arena)
+  local BattleCam = V.require("BattleCam")
+  local ok, rig = pcall(BattleCam.rig, arena, 0)
+  if not (ok and rig and rig.eye) then return true end
+  local eye = rig.eye
+  local H = BattleArena.MON_H
+  for _, mark in ipairs({ arena.player, arena.enemy }) do
+    for _, hy in ipairs({ 1, H * 0.5, H }) do
+      if not lineClear(map, eye, mark[1], hy, mark[2]) then return false end
+    end
+  end
+  return true
+end
+
+-- The nearest arena to (fromX, fromY) -- the player's cell -- or nil when
+-- the map has room for neither shape.
+--
+-- Distance is measured from the player to the arena's MIDPOINT, so "nearest"
+-- means the fight is staged as close to where it was triggered as the ground
+-- allows, rather than merely having a corner nearby.
+--
+-- Both shapes are searched over the whole map before the next one is tried:
+-- a wide arena on the far side of a route still beats a narrow one
+-- underfoot, because the wide one is the shot this mode is framed for.
+function BattleArena.find(map, fromX, fromY, surfing)
+  if not (map and map.widthCells) then return nil end
+
+  -- the authored spot wins outright when the map has one and it still holds
+  local pick = authoredFor(map.id)
+  -- `false` is an authored REFUSAL: a map looked at and found to have nowhere
+  -- a fight can be seen, with no other floor to borrow. Declining is the
+  -- honest answer -- the battle draws on the plain screen -- and it has to be
+  -- said explicitly, because the fallback search below would otherwise go and
+  -- find one of the bad spots that were already rejected by eye.
+  if pick == false then return nil end
+  if pick then
+    local shape = nil
+    for _, s in ipairs(BattleArena.SHAPES) do
+      if s.id == (pick.shape or "wide") then shape = s end
+    end
+    -- an entry may point at another floor of the same cave or building; the
+    -- arena is then measured against THAT map, and carries it
+    local host = map
+    if shape and pick.map and pick.map ~= map.id then
+      local ok, other = pcall(function()
+        local Game = require("src.core.Game")
+        return require("src.world.MapLoader").load(Game.data, pick.map)
+      end)
+      host = (ok and other) or nil
+    end
+    if shape and host then
+      -- An authored spot is checked with WATER COUNTING AS GROUND, whatever
+      -- the player is doing. The surfing test exists to stop the automatic
+      -- search staging a walker's fight out at sea; an authored entry was
+      -- chosen and looked at by a person, so if it is on water that is the
+      -- point of it -- the surf routes fight in the middle of their own
+      -- ocean rather than on a scrap of beach at the edge of the map. Land
+      -- entries are unaffected: land passes the test either way.
+      local grid, gw = openGrid(host, true)
+      if fits(grid, gw, pick.x, pick.y, shape.w, shape.h) then
+        local arena = place(shape, pick.x, pick.y)
+        arena.map = host
+        -- which camera rig this spot is framed for; nil is the default long
+        -- lens, "close" the short one small rooms need (see BattleCam)
+        arena.cam = pick.cam
+        return arena
+      end
+    end
+  end
+
+  local found = BattleArena.search(map, fromX, fromY, surfing)
+  if found then found.map = map end
+  return found
+end
+
+-- The arena at a given north-west corner, whatever the map says about it.
+-- The authoring tool's manual override: a spot chosen by eye rather than by
+-- the search, so it can be photographed and judged before it is written down.
+function BattleArena.at(x, y, shapeId)
+  for _, shape in ipairs(BattleArena.SHAPES) do
+    if shape.id == (shapeId or "wide") then return place(shape, x, y) end
+  end
+  return nil
+end
+
+-- The nearest arena the map can offer, preferring one the pair can be SEEN
+-- in. Two passes rather than one score: a clear arena on the far side of a
+-- route beats an obstructed one underfoot, because being able to see the
+-- fight is the point, but an obstructed one still beats no battle at all.
+function BattleArena.search(map, fromX, fromY, surfing, wantClear)
+  local grid, gw, gh = openGrid(map, surfing)
+  for _, shape in ipairs(BattleArena.SHAPES) do
+    for _, needClear in ipairs({ true, false }) do
+      local best, bestD = nil, nil
+      for y = 0, gh - shape.h do
+        for x = 0, gw - shape.w do
+          if fits(grid, gw, x, y, shape.w, shape.h) then
+            local mx = x + (shape.w - 1) / 2
+            local my = y + (shape.h - 1) / 2
+            local dx, dy = mx - fromX, my - fromY
+            local d = dx * dx + dy * dy
+            if not bestD or d < bestD then
+              local cand = place(shape, x, y)
+              if not needClear or BattleArena.clearance(map, cand) then
+                best, bestD = cand, d
+              end
+            end
+          end
+        end
+      end
+      if best then return best end
+      if wantClear and needClear then return nil end
+    end
+  end
+  return nil
+end
+
+return BattleArena

--- a/mods/dramatic_shape/lib/BattleBillboard.lua
+++ b/mods/dramatic_shape/lib/BattleBillboard.lua
@@ -1,0 +1,137 @@
+-- Overworld battles: the two mons, as geometry standing on the map.
+--
+-- Not pics composited over a picture of the world -- quads INSIDE it, drawn
+-- in the same 3D pass as the terrain, from the same camera, through the same
+-- shader. Which means they get everything the world gets and nothing has to
+-- be faked for them: the depth buffer decides what is in front of what, the
+-- sun pass sees them and throws their real silhouettes across the ground,
+-- and their size on screen is whatever standing on that tile at that
+-- distance actually looks like.
+--
+-- One quad, standing upright with its feet on the cell and yawed to face the
+-- camera. Upright rather than leaned back, unlike the free-roam mode's
+-- character cards: those lean because that camera looks DOWN and a standing
+-- card would foreshorten to nothing, and this one looks along the ground
+-- from about a foot above it, where a card standing up is simply correct.
+--
+-- The shader's alpha discard cuts the mon's exact outline out of the quad,
+-- so a Pokemon is its own silhouette against the world with no matte, no
+-- billboard edge and no sorting to get wrong.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local Mat4 = V.require("Mat4")
+local Voxel3D = V.require("Voxel3D")
+
+local BattleBillboard = {}
+
+-- How wide a full-size (7x7 tile) mon stands, in world pixels. One overworld
+-- square, so a Pokemon covers the tile it is on and no more; a species whose
+-- pic is smaller than the full buffer comes out proportionally smaller,
+-- which is how the artwork's own size differences survive the trip.
+BattleBillboard.FULL_W = 16
+BattleBillboard.FULL_PIC = 56     -- the pic size FULL_W refers to
+
+-- A hair of camera-ward bias, so a card standing ON the ground plane wins
+-- the depth test against it instead of z-fighting the tile it is rooted to.
+BattleBillboard.PULL = 1.5
+
+local quad = nil                  -- nil = untried, false = unavailable
+
+-- The unit card: x in -0.5..0.5, y in 0..1, z = 0, UV over the whole
+-- texture. Feet on the model origin, so the model matrix only has to say
+-- where the mon is standing and how big it is.
+--
+-- Which puts this card OFF the voxel grid, alone among the meshes in this
+-- mode: the rest are built one unit per voxel in their own model space --
+-- terrain in world pixels, a character's card in the sprite's own pixels --
+-- and the wireframe is the integer planes of that space (see VoxelGrid).
+-- One unit here is the whole card, so the only integer plane inside it is
+-- x = 0, which is the pic's centre column: a single stray line straight
+-- down the middle of every Pokemon and no seams anywhere else.
+--
+-- The card stays a unit card, because a mon's size on screen is decided by
+-- the artwork's own dimensions and the distance it is standing at, and a
+-- unit card is what lets one matrix say both. Whoever draws it turns the
+-- wireframe off instead (Voxel3D.seams) -- a mesh that is not on the voxel
+-- grid does not get a voxel grid drawn on it.
+local function unitQuad()
+  if quad ~= nil then return quad or nil end
+  local verts = {
+    { -0.5, 0, 0, 0, 1, 1 },
+    { 0.5, 0, 0, 1, 1, 1 },
+    { 0.5, 1, 0, 1, 0, 1 },
+    { -0.5, 1, 0, 0, 0, 1 },
+  }
+  local indices = {}
+  Voxel3D.pushQuad(indices, 0)
+  local mesh = Voxel3D.newMesh(verts, indices)
+  quad = mesh or false
+  return quad or nil
+end
+
+BattleBillboard.mesh = unitQuad
+
+-- The yaw that turns the card's face toward the eye. The quad's normal is
+-- +Z before rotation, so this is just the bearing from the mon to the
+-- camera -- flattened to the horizontal, because a card that also tipped to
+-- face a camera above it would lift its feet off the floor.
+function BattleBillboard.yawToward(x, z, eye)
+  if not eye then return 0 end
+  return math.atan2(eye[1] - x, eye[3] - z)
+end
+
+-- Stand a `w` x `h` card with its feet centred on world (x, y, z).
+function BattleBillboard.matrix(x, y, z, w, h, yaw)
+  return Mat4.mul(Mat4.mul(Mat4.translate(x, y, z), Mat4.rotateY(yaw)),
+                  Mat4.scale(w, h, 1))
+end
+
+-- The world size a pic of `pw` x `ph` texture pixels stands at.
+function BattleBillboard.sizeFor(pw, ph)
+  if not (pw and ph and pw > 0 and ph > 0) then return 0, 0 end
+  local scale = BattleBillboard.FULL_W / BattleBillboard.FULL_PIC
+  return pw * scale, ph * scale
+end
+
+-- Draw one mon. `tex` is the pic already rendered to a texture (see
+-- OverworldBattle, which lets the engine's own battler draw produce it, so
+-- every faint slide, blink and squish comes along), `grow` the send-out
+-- animation's scale or nil.
+function BattleBillboard.draw(tex, x, y, z, grow)
+  local mesh = unitQuad()
+  if not (mesh and tex) then return false end
+  local pw, ph = tex:getDimensions()
+  local w, h = BattleBillboard.sizeFor(pw, ph)
+  if grow then w, h = w * grow, h * grow end
+  if w <= 0 or h <= 0 then return false end
+  local yaw = BattleBillboard.yawToward(x, z, Voxel3D.eye)
+  -- off the voxel grid, so no wireframe on it (see unitQuad)
+  Voxel3D.seams(false)
+  Voxel3D.draw(mesh, tex, BattleBillboard.matrix(x, y, z, w, h, yaw),
+               BattleBillboard.PULL)
+  Voxel3D.seams(true)
+  return true
+end
+
+-- The same card, as the SUN sees it: no camera-ward pull (that is a trick
+-- for the view's own depth buffer and would drag the shadow off its owner)
+-- and no draw call of its own, because the shadow pass has its own.
+function BattleBillboard.caster(shadowMap, tex, x, y, z, grow)
+  local mesh = unitQuad()
+  if not (mesh and tex) then return false end
+  local pw, ph = tex:getDimensions()
+  local w, h = BattleBillboard.sizeFor(pw, ph)
+  if grow then w, h = w * grow, h * grow end
+  if w <= 0 or h <= 0 then return false end
+  local yaw = BattleBillboard.yawToward(x, z, Voxel3D.eye)
+  shadowMap.draw(mesh, tex, BattleBillboard.matrix(x, y, z, w, h, yaw))
+  return true
+end
+
+function BattleBillboard.invalidate()
+  quad = nil
+end
+
+return BattleBillboard

--- a/mods/dramatic_shape/lib/BattleCam.lua
+++ b/mods/dramatic_shape/lib/BattleCam.lua
@@ -1,0 +1,193 @@
+-- Overworld battles: the over-the-shoulder camera and its parallax drift.
+--
+-- The two mons are PINNED to their cells: each pic is drawn wherever its
+-- patch of ground projects to, not at a fixed screen slot. So the camera is
+-- not decoration -- it is the thing that decides where the fight appears,
+-- and it has to put those two patches of ground exactly where the battle
+-- screen wants its two pics:
+--
+--     the player's mon   (26, 96)    back pic, feet on the text box, well left
+--     the enemy's mon   (124, 56)    front pic, bottom of the 7x7 slot
+--
+-- Four screen coordinates, so four equations. The rig below is the solution:
+-- SIDE / BACK / HEIGHT place the eye relative to the arena's midpoint, LOOK
+-- aims it, and FRAME_H sets the lens, and together they land both marks
+-- within a thousandth of a pixel of the targets. They are not hand-picked
+-- numbers that looked about right -- they came out of a solver, and the
+-- suite reprojects them so a future edit either still lands or says so.
+--
+-- East is what decides which mon is on which side. The arena axis runs north
+-- (the enemy) to south (the player's mon), and a camera east of that axis
+-- sees the near end swing LEFT and the far end RIGHT -- the layout arrived
+-- at by standing in the right place rather than by mirroring anything.
+--
+-- ------- and two more equations, from the pixels
+--
+-- The pics are pixel art and their size on screen is not something the mod
+-- gets to choose: 56 pixels for a front pic, 64 for a back one. And a mon has
+-- to stand in ONE OVERWORLD SQUARE, or it towers over the houses and gives
+-- away that the world behind it is a picture. Together those say the square
+-- each mon stands on must project to about the width of its own pic, which is
+-- two more equations for the same six unknowns -- and they are what set the
+-- distance.
+--
+-- The answer is a LONG LENS FROM A LOW STANCE: twelve degrees above the
+-- floor, twelve degrees wide, from five blocks back. Not a stylistic choice
+-- -- it is what a 56-pixel sprite standing on a 16-pixel tile forces on a
+-- 160-pixel screen. Roughly three tiles fit across the frame, so the camera
+-- has to be far away and zoomed in rather than near and wide. That is the
+-- DEFAULT rig, and every map that can take it gets it.
+--
+-- ------- the exception: rooms too small to stand back from
+--
+-- Five blocks back is further than some rooms are wide. A gym is about ten
+-- cells across, so on one the eye lands OUTSIDE the map, where the border
+-- ring the engine draws round every map -- extruded into a cliff by this mode
+-- -- crosses the near Pokemon wherever it stands. Three gyms could not be
+-- staged anywhere at all for that reason.
+--
+-- So there is a second rig, and an arena asks for it by name (cam = "wide"
+-- in data/battle_arenas.lua). It comes in to about four cells with the lens
+-- opened up to match: an ordinary 44-degree shot that fits inside the room.
+-- The mons render smaller for it -- a bit over half a tile rather than a
+-- whole one -- which is the price. Both rigs are solved against the SAME four
+-- anchors, so the composition is identical either way; only the lens and the
+-- distance differ, which is what makes it safe to pick per map.
+--
+-- Rooms too small for the long lens are the reason it exists, but it is not
+-- only for them: an area that simply reads better with more of itself in
+-- shot can ask for it too.
+--
+-- Purely presentational, like everything else in this mod: the camera looks
+-- at the map, and nothing it does reaches collision, movement or scripts.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local BattleCam = {}
+
+-- ------- the rig, in world pixels (a map cell is 16, a block 32)
+--
+-- Solved against the four anchors and two spans above, with the two mons 48
+-- world pixels (three cells) apart -- BattleArena.SHAPES is where that gap is
+-- set, and changing it invalidates these.
+
+-- `frameH` is how much world the frame is tall enough to hold at the aim
+-- distance, which together with that distance is the lens.
+-- Named for the LENS, because that is what an author is choosing between
+-- when they look at a shot and decide it wants more room in it.
+BattleCam.RIGS = {
+  -- the default: a long 11.5-degree lens from five blocks back, which is
+  -- what makes one tile big enough to stand a 56-pixel mon on
+  tele = {
+    side = 78.79, back = 144.96, height = 37.88,
+    lookX = -0.26, lookY = 0.34, frameH = 34.11,
+  },
+  -- 44 degrees from four cells: fits inside a room the long lens cannot
+  -- stand back from, and shows more of anywhere else, at the cost of a
+  -- smaller pair
+  wide = {
+    side = 41.98, back = 41.16, height = 28.48,
+    lookX = -3.24, lookY = -1.35, frameH = 55.62,
+  },
+}
+
+BattleCam.DEFAULT_RIG = "tele"
+
+-- The rig an arena asks for, falling back to the default for anything that
+-- does not ask (and for a name that is not one of the two).
+function BattleCam.rigFor(arena)
+  local want = arena and arena.cam
+  return BattleCam.RIGS[want] or BattleCam.RIGS[BattleCam.DEFAULT_RIG]
+end
+
+-- ------- the drift
+--
+-- A slow orbit about the arena's vertical axis. Rotating about a point
+-- BETWEEN the two mons is what makes it parallax rather than a pan: the mons
+-- are pinned to the ground, so the near one slides one way across the frame
+-- and the far one slides the OTHER, by the amount their difference in
+-- distance implies. Over a full swing that is about eight pixels of relative
+-- movement -- plainly visible as depth, far too slow to fight the fight.
+-- The angle is small because the lens is long: two degrees of orbit is seven
+-- pixels of travel through an eleven-degree field of view.
+--
+-- Under it, a much smaller breath in and out along the same line, on an
+-- unrelated period, so the pair never returns to the same pose on any cycle
+-- a battle is long enough to show. A DOLLY rather than a pan of the aim:
+-- moving the aim point would slide both mons the same way, which with pinned
+-- pics is just the whole picture walking sideways. Changing the DISTANCE
+-- moves them apart and back together about the frame's centre, which is the
+-- same depth cue the orbit gives, from the other axis.
+BattleCam.PAN_YAW = math.rad(2)   -- half-angle of the orbit
+BattleCam.PAN_PERIOD = 26         -- seconds for one there-and-back
+BattleCam.PAN_DOLLY = 0.02        -- how far the eye breathes, as a fraction
+BattleCam.DOLLY_PERIOD = 37
+
+BattleCam.t = 0
+
+function BattleCam.reset()
+  BattleCam.t = 0
+end
+
+-- Real frame time, like every other presentational tween in this mod: a
+-- fast-forwarded battle must not spin the camera.
+function BattleCam.update(dt)
+  BattleCam.t = BattleCam.t + (dt or 0)
+  -- keep the phase small forever rather than letting a long session lose
+  -- float precision in the sines below
+  local wrap = BattleCam.PAN_PERIOD * BattleCam.DOLLY_PERIOD
+  if BattleCam.t > wrap then BattleCam.t = BattleCam.t - wrap end
+end
+
+local function phase(t, period)
+  return math.sin(2 * math.pi * t / period)
+end
+
+-- The camera for `arena` this instant: the record Voxel3D.camera takes, plus
+-- the pitch the pull and the sun frustum want (measured from straight down,
+-- the same convention Voxel.angle uses).
+--
+-- `fov` here frames the GB's 160x144. A caller rendering at window
+-- resolution widens it for the extra picture around that frame -- see
+-- BattleScene.letterboxFov, which is what keeps the pins exact at any window
+-- size.
+--
+-- `groundY` is the height of the arena floor, so a fight staged on a ledge
+-- or a raised walkway is shot from above THAT rather than from inside it.
+function BattleCam.rig(arena, groundY)
+  groundY = groundY or 0
+  local R = BattleCam.rigFor(arena)
+  local mx, mz = arena.mid[1], arena.mid[2]
+
+  local yaw = BattleCam.PAN_YAW * phase(BattleCam.t, BattleCam.PAN_PERIOD)
+  local c, s = math.cos(yaw), math.sin(yaw)
+  -- the breath scales the whole offset, height included, so the eye moves
+  -- along its own line to the arena and the pitch of the shot never changes
+  local k = 1 + BattleCam.PAN_DOLLY
+              * phase(BattleCam.t, BattleCam.DOLLY_PERIOD)
+  local dx = (R.side * c - R.back * s) * k
+  local dz = (R.side * s + R.back * c) * k
+
+  local eye = { mx + dx, groundY + R.height * k, mz + dz }
+  local focus = { mx + R.lookX, groundY + R.lookY, mz }
+
+  local ex = eye[1] - focus[1]
+  local ey = eye[2] - focus[2]
+  local ez = eye[3] - focus[3]
+  local dist = math.max(1, math.sqrt(ex * ex + ey * ey + ez * ez))
+  local horiz = math.sqrt(ex * ex + ez * ez)
+
+  return {
+    eye = eye,
+    focus = focus,
+    fov = 2 * math.atan((R.frameH / 2) / dist),
+    -- the world curve is a free-roam flourish that bends the horizon away
+    -- from the player; a fixed camera on a staged shot has no player to bend
+    -- around, and the bend would tip the arena floor out from under the mons
+    -- the pics are pinned to
+    curve = 0,
+  }, math.atan2(horiz, math.max(1e-3, ey))
+end
+
+return BattleCam

--- a/mods/dramatic_shape/lib/BattleDOF.lua
+++ b/mods/dramatic_shape/lib/BattleDOF.lua
@@ -1,0 +1,187 @@
+-- Overworld battles: the depth-of-field pass over the arena.
+--
+-- A photographic lens focused on two subjects three cells apart holds a
+-- narrow slab of the world sharp and loses everything in front of and
+-- behind it. On this shot that slab is a BAND ACROSS THE FRAME, because the
+-- camera is fixed and looking down at a floor: distance from the lens runs
+-- monotonically up the picture, so screen height IS depth, and a band of
+-- rows is a slab of world. The floor the mons stand on stays sharp, the
+-- middle distance and the horizon soften, and the foreground the camera is
+-- leaning over softens the other way.
+--
+-- BOTH MONS ARE IN FOCUS, and not by tuning: they are drawn as the battle
+-- screen's own pics AFTER this runs, so they are never blurred at all. This
+-- pass only ever touches the world behind them -- which is exactly the
+-- separation a real shot of two subjects at the same distance would have.
+--
+-- Two separable gaussian passes over a 160x144 image: two full-frame draws
+-- of 23,040 pixels, which is nothing, and it buys the one cue that stops a
+-- 3D backdrop reading as wallpaper.
+
+local BattleDOF = {}
+
+-- Switched off for now. The pass is kept whole -- band maths, shader,
+-- canvases -- because the reason to have it has not gone away: it is the one
+-- cue that separates the pair from the ground behind them. It is off because
+-- the mons are geometry in the scene now rather than pics over it, and a blur
+-- that softens their own tile softens THEM, which the pinned-pic version
+-- never had to answer for. Turning it back on means solving that first.
+BattleDOF.ENABLED = false
+
+-- Fallbacks for the band, in canvas uv. The caller normally measures it off
+-- the two ground marks -- the whole point is that the slab in focus is the
+-- one the mons are standing in -- and these are what a caller that cannot
+-- gets instead.
+BattleDOF.FOCUS_Y = 0.52
+BattleDOF.BAND = 0.16
+BattleDOF.RANGE = 0.32
+
+-- How much floor either side of the two marks stays sharp, as a fraction of
+-- the gap between them: a mon is taller than the patch it stands on, and the
+-- ground just in front of and behind it belongs to the same slab.
+BattleDOF.BAND_MARGIN = 0.55
+
+-- How far past the band it takes to reach full blur, in the same units as
+-- the band itself.
+BattleDOF.RANGE_SCALE = 2.0
+
+-- Tap spacing at full blur, as a fraction of the canvas height, so the blur
+-- is the same depth of field in a window and fullscreen. The gaussian's
+-- reach is four taps and the two passes compound, so a little goes a long
+-- way.
+BattleDOF.SPACING = 0.0095
+
+-- A touch of saturation on the way out, the same trick the tilt-shift pass
+-- uses: a blurred background reads as further away when it is also a
+-- little richer than the sharp subject in front of it.
+BattleDOF.SATURATION = 1.12
+
+local SHADER = [[
+  uniform vec2 dir;        // one texel step along the axis being blurred
+  uniform float focusY;
+  uniform float band;
+  uniform float range;
+  uniform float spacing;
+  uniform float boost;     // 0 = plain blur pass, 1 = final pass (colour pop)
+  uniform float saturation;
+  vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+    float d = abs(tc.y - focusY) - band;
+    float s = clamp(d / range, 0.0, 1.0);
+    s = s * s;             // ease in, so the band edge has no visible seam
+    vec2 o = dir * (s * spacing);
+    vec4 sum = Texel(tex, tc) * 0.2270270270;
+    sum += (Texel(tex, tc + o) + Texel(tex, tc - o)) * 0.1945945946;
+    sum += (Texel(tex, tc + 2.0 * o) + Texel(tex, tc - 2.0 * o)) * 0.1216216216;
+    sum += (Texel(tex, tc + 3.0 * o) + Texel(tex, tc - 3.0 * o)) * 0.0540540541;
+    sum += (Texel(tex, tc + 4.0 * o) + Texel(tex, tc - 4.0 * o)) * 0.0162162162;
+    if (boost > 0.5) {
+      float luma = dot(sum.rgb, vec3(0.299, 0.587, 0.114));
+      sum.rgb = mix(vec3(luma), sum.rgb, saturation);
+    }
+    return sum * color;
+  }
+]]
+
+local shader = nil            -- nil = untried, false = unavailable
+local ping, pong, cw, ch = nil, nil, 0, 0
+
+local function getShader()
+  if shader == nil then
+    local ok, sh = pcall(love.graphics.newShader, SHADER)
+    shader = (ok and sh) or false
+  end
+  return shader or nil
+end
+
+-- Its own pair of canvases rather than the tilt-shift pass's: those are
+-- sized to the window and this is sized to the GB frame, and sharing them
+-- would reallocate both every time a battle started or ended.
+local function getCanvases(w, h)
+  if not ping or cw ~= w or ch ~= h then
+    local ok, a = pcall(love.graphics.newCanvas, w, h)
+    if not ok then return nil end
+    local okB, b = pcall(love.graphics.newCanvas, w, h)
+    if not okB then return nil end
+    -- the gaussian's fractional tap offsets need linear filtering
+    a:setFilter("linear", "linear")
+    b:setFilter("linear", "linear")
+    ping, pong, cw, ch = a, b, w, h
+  end
+  return ping, pong
+end
+
+-- The sharp band for a shot whose two ground marks land at canvas rows
+-- `y1` and `y2`, as (focusY, band, range) in uv. This is the depth of field
+-- proper: the band is the slab of world the two mons occupy, and everything
+-- nearer or further softens away from it.
+function BattleDOF.bandFor(y1, y2, h)
+  if not (y1 and y2 and h and h > 0) then
+    return BattleDOF.FOCUS_Y, BattleDOF.BAND, BattleDOF.RANGE
+  end
+  local mid = (y1 + y2) / 2 / h
+  local half = math.abs(y1 - y2) / 2 / h
+  local band = half * (1 + BattleDOF.BAND_MARGIN)
+  return math.min(1, math.max(0, mid)),
+         band,
+         math.max(1e-3, band * BattleDOF.RANGE_SCALE)
+end
+
+-- Run the pass over `canvas` and return the result, or the input unchanged
+-- when it cannot run (headless, no shader support) -- so the caller always
+-- has something to composite. `focusY`, `band` and `range` are in canvas uv;
+-- omit them for the fixed fallback band.
+function BattleDOF.apply(canvas, focusY, band, range)
+  if not (canvas and BattleDOF.ENABLED) then return canvas end
+  local sh = getShader()
+  if not sh then return canvas end
+  local w, h = canvas:getDimensions()
+  local a, b = getCanvases(w, h)
+  if not a then return canvas end
+  focusY = focusY or BattleDOF.FOCUS_Y
+  band = band or BattleDOF.BAND
+  range = range or BattleDOF.RANGE
+
+  local prevBlend, prevAlpha = love.graphics.getBlendMode()
+  local prevCanvas = love.graphics.getCanvas()
+
+  -- the scene canvas filters nearest for its 1:1 blit; the taps need linear,
+  -- restored below so the composite sees what it expects
+  canvas:setFilter("linear", "linear")
+  love.graphics.setShader(sh)
+  love.graphics.setColor(1, 1, 1, 1)
+  -- replace, not alpha-blend: these are image-processing copies
+  love.graphics.setBlendMode("replace", "premultiplied")
+  pcall(sh.send, sh, "focusY", focusY)
+  pcall(sh.send, sh, "band", band)
+  pcall(sh.send, sh, "range", range)
+  pcall(sh.send, sh, "spacing", math.max(0.75, h * BattleDOF.SPACING))
+  pcall(sh.send, sh, "saturation", BattleDOF.SATURATION)
+
+  local ok = pcall(function()
+    love.graphics.setCanvas(a)
+    pcall(sh.send, sh, "dir", { 1 / w, 0 })
+    pcall(sh.send, sh, "boost", 0)
+    love.graphics.draw(canvas)
+    love.graphics.setCanvas(b)
+    pcall(sh.send, sh, "dir", { 0, 1 / h })
+    pcall(sh.send, sh, "boost", 1)
+    love.graphics.draw(a)
+  end)
+
+  if prevCanvas then
+    love.graphics.setCanvas(prevCanvas)
+  else
+    love.graphics.setCanvas()
+  end
+  love.graphics.setShader()
+  love.graphics.setBlendMode(prevBlend or "alpha", prevAlpha)
+  canvas:setFilter("nearest", "nearest")
+  return ok and b or canvas
+end
+
+-- Drop the GPU objects (window resize, hot reload).
+function BattleDOF.invalidate()
+  ping, pong, cw, ch = nil, nil, 0, 0
+end
+
+return BattleDOF

--- a/mods/dramatic_shape/lib/BattleExit.lua
+++ b/mods/dramatic_shape/lib/BattleExit.lua
@@ -1,0 +1,201 @@
+-- Leaving a battle: the fade the way back to the map never had.
+--
+-- Going IN is a whole production -- one of the original's eight wipes, picked by
+-- three bits, over a flash (src/render/BattleTransition.lua). Coming OUT was a
+-- hard cut: BattleState:finish pops itself and the map is simply THERE on the
+-- next frame. On the flat battle screen that is a cut between a white field and
+-- a tile map, which the original got away with. In this mode it is a cut between
+-- a placed camera looking across an arena and a diorama looking down on a
+-- walking player, and a jump that big reads as a glitch rather than as an edit.
+--
+-- So the battle fades out, closes behind the black, and the map fades up out of
+-- it. The timing is a transitions record this mod registers rather than a
+-- constant in here, so it is retunable in data like the engine's own eight.
+--
+-- WHEN. Only while voxel mode is on: this is the diorama's own exit, and a
+-- vanilla battle keeps the cut it always had. While the mode IS on, every battle
+-- gets it -- including one that found no arena and drew on the flat battle
+-- screen -- because what is being smoothed over is the return to the MAP, and
+-- the map is a diorama either way.
+--
+-- HOW IT IS DRAWN, which is the part worth reading. Not by this state: it draws
+-- nothing at all. It owns a NUMBER, and one black rectangle over the FINISHED
+-- composite in a wrap around Renderer:endFrame paints it -- after the world
+-- blit, after the letterbox, after the UI blit, which is the only point where a
+-- single rect covers everything on screen at once.
+--
+-- The renderer's own fade (worldFadeAlpha, which the warp fade uses) is painted
+-- BETWEEN the world and the UI, because a warp has no UI over it. A fade that
+-- borrowed it would darken the arena and leave the battle's text box sitting
+-- bright on top of the black -- and the letterbox bars of a flat battle screen,
+-- painted by the renderer's clear before any state draws, would not darken at
+-- all.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local BattleExit = {}
+BattleExit.__index = BattleExit
+
+-- The battle underneath keeps drawing while this is up -- what fades is its own
+-- last live frame, camera drift, HUD and all. Only the top state UPDATES, so
+-- nothing the battle does can outrun the fade either.
+BattleExit.isOpaque = false
+
+-- The registered record's id, and the fallback timing if it is missing (a
+-- headless caller, or a total conversion that dropped the namespace). Per HALF,
+-- matching the engine's warp fade, so the whole edit is 24 frames.
+BattleExit.ID = "voxel_battle_exit"
+BattleExit.FRAMES = 12
+
+-- The fade in progress, or nil. Kept here rather than on the state so the
+-- endFrame wrap has one place to look and nothing can go stale the frame after
+-- the state leaves the stack.
+local live = nil
+
+-- How black the composite is this frame: 0 on the battle's last live frame, 1 at
+-- the cut, 0 again once the map is up. nil when no fade is running, which is
+-- every other frame the game ever draws.
+function BattleExit.veil()
+  if not live then return nil end
+  -- A fade can be taken off the stack by something that is not the fade: a
+  -- script or a shot driver popping down to the overworld, a state teardown.
+  -- Then it is not running, whatever its counter says -- and a veil left behind
+  -- would black the game out for good, because nothing is going to fade it back
+  -- in. Checked here rather than trusted, because this is the one place the
+  -- answer is used. The walk only happens while a fade is live.
+  local stack = live.game and live.game.stack
+  local states = stack and stack.states
+  local onStack = false
+  for i = #(states or {}), 1, -1 do
+    if states[i] == live then onStack = true break end
+  end
+  if not onStack then live = nil; return nil end
+  local a = live.t / live.frames
+  if live.phase == "in" then a = 1 - a end
+  return math.max(0, math.min(1, a))
+end
+
+local function framesFor(game)
+  local records = game and game.data and game.data.transitions
+  local record = records and records[BattleExit.ID]
+  local frames = record and record.frames
+  if type(frames) == "number" and frames > 0 then return frames end
+  return BattleExit.FRAMES
+end
+
+function BattleExit.new(game, battle, onMidpoint)
+  return setmetatable({ game = game, battle = battle, onMidpoint = onMidpoint,
+                        frames = framesFor(game), t = 0, phase = "out" },
+                      BattleExit)
+end
+
+-- Push the fade over the battle it is closing.
+function BattleExit.start(battle, onMidpoint)
+  local game = battle.game
+  local self = BattleExit.new(game, battle, onMidpoint)
+  live = self
+  game.stack:push(self)
+  return self
+end
+
+function BattleExit:update()
+  self.t = self.t + 1
+  if self.t < self.frames then return end
+  self.t = 0
+
+  if self.phase == "in" then
+    live = nil
+    self.game.stack:pop()
+    return
+  end
+
+  -- ------- the cut, at full black
+  --
+  -- Off the stack FIRST. BattleState:finish pops whatever is on TOP, and while
+  -- this fade is up that is the fade -- so a fade that stayed would eat the
+  -- battle's own pop and leave the battle running underneath, finished but
+  -- still on the stack. Popping ourselves hands the top back to the battle so
+  -- its pop lands on itself.
+  self.phase = "in"
+  local stack = self.game.stack
+  stack:pop()
+  if self.onMidpoint then self.onMidpoint() end
+  if stack:top() == self.game.overworld then
+    stack:push(self)                       -- and the map comes up out of it
+    return
+  end
+
+  -- We are not going back to the map after all. Either the battle did not
+  -- actually leave -- finish() can be a false start, and wanted() mirrors the
+  -- one the engine has today -- or something else took the screen on the way
+  -- out: a blackout's own warp fade, an evolution prompt. Whatever it is owns
+  -- the transition from here, so this one ends at the cut instead of fading in
+  -- over the top of it. The flag goes back too, so a second finish() that does
+  -- leave gets its own fade.
+  live = nil
+  if self.battle then self.battle.dramaticShapeLeaving = nil end
+end
+
+-- "Voxel mode is on", as the ENGINE answers it: switched on, not retired by a
+-- fault, and runnable on this machine. A function on the table rather than an
+-- inline call so a driver or a headless test can pin it -- the test harness has
+-- no depth buffer, where the honest answer is no on every rung.
+function BattleExit.modeOn()
+  return require("src.render.Pipelines").eligible("voxel") and true or false
+end
+
+-- Whether this ending gets the fade.
+function BattleExit.wanted(battle)
+  local game = battle and battle.game
+  if not (game and game.stack) then return false end
+  -- finish() is not always the end: an unpaid PAY DAY prints its takings and
+  -- comes back through here a moment later (BattleState:finish's first branch).
+  -- Mirrored read-only, so the fade starts on the call that really leaves rather
+  -- than fading to black and snapping back for one more message.
+  if battle.payDay and battle.result == "win" then return false end
+  return BattleExit.modeOn()
+end
+
+-- ------- engine seams
+--
+-- Two wraps, each idempotent so a hot reload cannot stack them.
+function BattleExit.install()
+  local BattleState = require("src.battle.BattleState")
+  if not BattleState.dramaticShapeExitHook then
+    local inner = BattleState.finish
+    -- The one place a battle ends. Wrapped rather than listened for: the
+    -- battle.ended event is emitted AFTER the pop, and by then the battle
+    -- screen is gone and there is nothing left to fade out.
+    function BattleState:finish()
+      if self.dramaticShapeLeaving or not BattleExit.wanted(self) then
+        return inner(self)
+      end
+      self.dramaticShapeLeaving = true
+      BattleExit.start(self, function() inner(self) end)
+    end
+    BattleState.dramaticShapeExitHook = true
+  end
+
+  local Renderer = require("src.render.Renderer")
+  if not Renderer.dramaticShapeExitHook then
+    local inner = Renderer.endFrame
+    function Renderer:endFrame(zones, worldZones)
+      inner(self, zones, worldZones)
+      local a = BattleExit.veil()
+      if not a or a <= 0 then return end
+      -- The composite is on the screen by now, in LOVE units, so one rect over
+      -- the window darkens the world, the letterbox bars, the text box and
+      -- anything a present pass put on top, all by the same amount. Left to
+      -- last on purpose: this is a shutter closing on the finished frame, not a
+      -- layer inside it.
+      local w, h = love.graphics.getDimensions()
+      love.graphics.setColor(0, 0, 0, a)
+      love.graphics.rectangle("fill", 0, 0, w, h)
+      love.graphics.setColor(1, 1, 1, 1)
+    end
+    Renderer.dramaticShapeExitHook = true
+  end
+end
+
+return BattleExit

--- a/mods/dramatic_shape/lib/BattleHud.lua
+++ b/mods/dramatic_shape/lib/BattleHud.lua
@@ -1,0 +1,408 @@
+-- Overworld battles: the HUD's footing on a world that is not white.
+--
+-- Gen 1 draws its battle HUDs as black glyphs and bar tiles straight onto
+-- the white field, with no box around them -- the field IS the backing. Take
+-- the field away and put a route underneath and the name, the level and the
+-- HP numbers are black on grass, which is not readable.
+--
+-- So each HUD block gets a panel: the world behind it, blurred to frosted
+-- glass and laid back down translucent, with a tint that pushes it away from
+-- whatever colour the text is about to be. Frosted rather than opaque
+-- because the point of the mode is that you can see where you are standing,
+-- and an opaque slab in the corner of the frame is the white field back
+-- again by another name.
+--
+-- And the text flips. A panel over a sunlit meadow is bright and wants black
+-- glyphs; the same panel over a cave floor or a dark roof is not, and wants
+-- white ones. So the panel's average brightness is measured and the glyphs
+-- follow it, with hysteresis so a slow camera drift across the threshold
+-- cannot strobe them.
+--
+-- The measurement is a one-pixel readback, which is a GPU stall, so it runs
+-- a few times a second rather than every frame. The camera drifts at about
+-- a pixel a second; brightness cannot outrun that.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local BattleHud = {}
+
+-- How solid the frost is over the world behind it, and how far the tint
+-- pushes it toward the far end from the text.
+--
+-- Both deliberately light. The panel is there to make glyphs legible, not to
+-- put a slab in the corner of the frame: at these values the sharp world
+-- still reads through it and the blur registers as a pane of glass rather
+-- than as a second background.
+BattleHud.FROST = 0.55
+BattleHud.TINT = 0.26
+
+-- The luminance the glyphs flip at, with a dead band so a drift across it
+-- settles rather than strobes.
+BattleHud.DARK_ENTER = 0.44   -- below this, the panel is dark: white glyphs
+BattleHud.DARK_LEAVE = 0.56   -- above this, back to black ones
+
+-- Frames between brightness readbacks.
+BattleHud.SAMPLE_EVERY = 12
+
+-- The frost buffer's height; width follows the source's aspect. Small on
+-- purpose: the downscale is most of the blur, and what is read back for the
+-- brightness is one pixel of it.
+BattleHud.FROST_H = 72
+
+local frost, frostW, frostH = nil, 0, 0
+local blurA, blurB = nil, nil
+local probe = nil
+local frame = 0
+local luma = {}      -- panel key -> { value, dark, at }
+
+local SHADER = [[
+  uniform vec2 dir;
+  vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+    vec4 sum = Texel(tex, tc) * 0.2270270270;
+    sum += (Texel(tex, tc + dir) + Texel(tex, tc - dir)) * 0.1945945946;
+    sum += (Texel(tex, tc + 2.0 * dir) + Texel(tex, tc - 2.0 * dir)) * 0.1216216216;
+    sum += (Texel(tex, tc + 3.0 * dir) + Texel(tex, tc - 3.0 * dir)) * 0.0540540541;
+    sum += (Texel(tex, tc + 4.0 * dir) + Texel(tex, tc - 4.0 * dir)) * 0.0162162162;
+    return sum * color;
+  }
+]]
+
+local shader = nil            -- nil = untried, false = unavailable
+
+local function getShader()
+  if shader == nil then
+    local ok, sh = pcall(love.graphics.newShader, SHADER)
+    shader = (ok and sh) or false
+  end
+  return shader or nil
+end
+
+local function canvasOf(w, h, filter)
+  local ok, c = pcall(love.graphics.newCanvas, w, h)
+  if not ok then return nil end
+  c:setFilter(filter or "linear", filter or "linear")
+  return c
+end
+
+-- Build (or rebuild) the frosted copy of `src` for this frame.
+--
+-- Two steps, because one is not enough: the downscale to a 72-row buffer
+-- averages the world down to something that no longer reads as terrain, and
+-- the separable gaussian over that turns the remaining structure into
+-- frosted glass rather than a mosaic of the tiles it came from.
+function BattleHud.build(src)
+  if not src then return nil end
+  local blur = getShader()
+  local sw, sh = src:getDimensions()
+  if sw <= 0 or sh <= 0 then return nil end
+  local h = BattleHud.FROST_H
+  local w = math.max(1, math.floor(sw * h / sh + 0.5))
+  if not frost or frostW ~= w or frostH ~= h then
+    frost = canvasOf(w, h)
+    blurA = canvasOf(w, h)
+    blurB = canvasOf(w, h)
+    probe = probe or canvasOf(1, 1)
+    if not (frost and blurA and blurB) then
+      frost, blurA, blurB, frostW, frostH = nil, nil, nil, 0, 0
+      return nil
+    end
+    frostW, frostH = w, h
+  end
+
+  local prevCanvas = love.graphics.getCanvas()
+  local prevBlend, prevAlpha = love.graphics.getBlendMode()
+  local prevFilter = { src:getFilter() }
+  src:setFilter("linear", "linear")
+  love.graphics.setColor(1, 1, 1, 1)
+  love.graphics.setBlendMode("replace", "premultiplied")
+
+  local ok = pcall(function()
+    love.graphics.setCanvas(frost)
+    love.graphics.draw(src, 0, 0, 0, w / sw, h / sh)
+    if blur then
+      love.graphics.setShader(blur)
+      love.graphics.setCanvas(blurA)
+      pcall(blur.send, blur, "dir", { 2.5 / w, 0 })
+      love.graphics.draw(frost)
+      love.graphics.setCanvas(blurB)
+      pcall(blur.send, blur, "dir", { 0, 2.5 / h })
+      love.graphics.draw(blurA)
+      love.graphics.setShader()
+      frost, blurB = blurB, frost   -- the blurred one is the frost now
+    end
+  end)
+
+  love.graphics.setShader()
+  if prevCanvas then
+    love.graphics.setCanvas(prevCanvas)
+  else
+    love.graphics.setCanvas()
+  end
+  love.graphics.setBlendMode(prevBlend or "alpha", prevAlpha)
+  src:setFilter(prevFilter[1] or "nearest", prevFilter[2] or "nearest")
+  frame = frame + 1
+  return ok and frost or nil
+end
+
+function BattleHud.frame()
+  return frame
+end
+
+-- Average luminance of the frost under `key`'s rect, in frost-canvas pixels.
+--
+-- Averaged by letting the GPU do it: the rect is drawn into a one-pixel
+-- canvas, which IS the mean, and that one pixel is read back. Cached for
+-- SAMPLE_EVERY frames because the readback synchronises the pipeline and
+-- nothing it measures moves faster than that.
+local function sampleLuma(key, fx, fy, fw, fh)
+  local hit = luma[key]
+  if hit and (frame - hit.at) < BattleHud.SAMPLE_EVERY then return hit.value end
+  if not (frost and probe and frostW > 0) then return hit and hit.value end
+  if fw <= 0 or fh <= 0 then return hit and hit.value end
+
+  local prevCanvas = love.graphics.getCanvas()
+  local prevBlend, prevAlpha = love.graphics.getBlendMode()
+  local value = hit and hit.value or 1
+  local ok = pcall(function()
+    love.graphics.setCanvas(probe)
+    love.graphics.setBlendMode("replace", "premultiplied")
+    love.graphics.setColor(1, 1, 1, 1)
+    local quad = love.graphics.newQuad(fx, fy, fw, fh, frostW, frostH)
+    love.graphics.draw(frost, quad, 0, 0, 0, 1 / fw, 1 / fh)
+    love.graphics.setCanvas()
+    local data = probe:newImageData()
+    local r, g, b = data:getPixel(0, 0)
+    if data.release then pcall(data.release, data) end
+    value = 0.299 * r + 0.587 * g + 0.114 * b
+  end)
+
+  if prevCanvas then
+    love.graphics.setCanvas(prevCanvas)
+  else
+    love.graphics.setCanvas()
+  end
+  love.graphics.setBlendMode(prevBlend or "alpha", prevAlpha)
+  if not ok then return hit and hit.value end
+
+  luma[key] = { value = value, at = frame }
+  return value
+end
+
+-- Map a GB-frame rect onto the frost canvas, given where the letterbox sits
+-- in the source the frost was built from.
+local function frostRect(rect, box)
+  local kx = frostW / box.pw
+  local ky = frostH / box.ph
+  local fx = (box.lx + rect[1] * box.scale) * kx
+  local fy = (box.ly + rect[2] * box.scale) * ky
+  local fw = rect[3] * box.scale * kx
+  local fh = rect[4] * box.scale * ky
+  return fx, fy, math.max(1, fw), math.max(1, fh)
+end
+
+-- The same map for a rect that is ALREADY in world-canvas pixels. A HUD
+-- snapped out to the window's edge has left the GB frame, so it has no GB
+-- coordinates to be placed from -- see OverworldBattle.snapRects.
+local function frostRectWorld(rect, box)
+  local kx = frostW / box.pw
+  local ky = frostH / box.ph
+  return rect[1] * kx, rect[2] * ky,
+         math.max(1, rect[3] * kx), math.max(1, rect[4] * ky)
+end
+
+-- Which of the two the caller's rects are in. One frost buffer, one panel
+-- draw, two coordinate spaces: the GB frame (rects land in the 160x144 UI
+-- canvas) or world pixels (rects land in the window-resolution world image).
+local function mapper(world)
+  return world and frostRectWorld or frostRect
+end
+
+-- ------- the verdict
+--
+-- ONE answer for the whole frame, not one per panel. Both HUDs draw in a
+-- single pass and there is only one glyph colour to be had out of it -- and
+-- a frame with a black-lettered HUD in one corner and a white-lettered one
+-- in the other would read as a bug rather than as adaptation. The DARKER
+-- panel decides, because it is the one that cannot afford to be wrong, and
+-- the tint below then commits both panels to that reading.
+local wasDark = false
+
+function BattleHud.verdict(rects, box, world)
+  if not (frost and box and box.scale and box.scale > 0) then return false end
+  local toFrost = mapper(world)
+  local darkest = nil
+  for key, rect in pairs(rects) do
+    local fx, fy, fw, fh = toFrost(rect, box)
+    local v = sampleLuma(key, fx, fy, fw, fh)
+    if v and (not darkest or v < darkest) then darkest = v end
+  end
+  if not darkest then return wasDark end
+  -- hysteresis: it takes a clear move past the far threshold to flip back,
+  -- so a camera drifting across the boundary settles instead of strobing
+  if wasDark then
+    wasDark = darkest < BattleHud.DARK_LEAVE
+  else
+    wasDark = darkest < BattleHud.DARK_ENTER
+  end
+  return wasDark
+end
+
+-- Draw one HUD panel into the current target, in that target's own
+-- coordinates: GB ones for the 160x144 UI canvas, world pixels (world = true)
+-- for a panel laid straight onto the world image.
+--
+-- The tint always pushes AWAY from the glyph colour that is about to be
+-- used, so the contrast is guaranteed rather than hoped for: a dark panel
+-- gets darker under white text, a bright one brighter under black text.
+function BattleHud.panel(rect, box, dark, world)
+  if not (frost and box and box.scale and box.scale > 0) then return false end
+  local fx, fy, fw, fh = mapper(world)(rect, box)
+  local ok = pcall(function()
+    local quad = love.graphics.newQuad(fx, fy, fw, fh, frostW, frostH)
+    love.graphics.setColor(1, 1, 1, BattleHud.FROST)
+    love.graphics.draw(frost, quad, rect[1], rect[2], 0,
+                       rect[3] / fw, rect[4] / fh)
+    local shade = dark and 0 or 1
+    love.graphics.setColor(shade, shade, shade, BattleHud.TINT)
+    love.graphics.rectangle("fill", rect[1], rect[2], rect[3], rect[4])
+    love.graphics.setColor(1, 1, 1, 1)
+  end)
+  return ok
+end
+
+-- ------- flipping the glyphs
+--
+-- Over a dark panel the HUD's black text has to go white, and it cannot be
+-- done by setting a draw colour: LOVE MULTIPLIES by it, and a black glyph
+-- times white is still black. The colour channel has to be REPLACED.
+--
+-- So the HUD is drawn into a scratch layer and that layer is composited back
+-- through a shader that whitens whatever is nearly black and leaves the rest
+-- alone. "Nearly black" is the text, the tick marks and the bar's outline --
+-- everything the HUD draws as ink -- while the HP bar's own greens and reds
+-- are well clear of the threshold and come through untouched.
+--
+-- Composited back into whatever the caller had bound, which is what makes it
+-- work in both pipelines without knowing which one it is in: in the colorized
+-- one that target is the grayscale BG canvas, where white IS shade 0 and the
+-- zone pass then colours the flipped glyphs like every other lightest-shade
+-- surface; in the flat fallback it is the screen, where white is white.
+local INK = 0.35   -- luminance at or under which a pixel counts as ink
+
+local FLIP = [[
+  uniform float ink;
+  vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+    vec4 p = Texel(tex, tc);
+    float luma = dot(p.rgb, vec3(0.299, 0.587, 0.114));
+    if (p.a > 0.0 && luma <= ink * p.a) p.rgb = vec3(p.a);
+    return p * color;
+  }
+]]
+
+local flipShader = nil
+local layer = nil
+
+local function getFlip()
+  if flipShader == nil then
+    local ok, sh = pcall(love.graphics.newShader, FLIP)
+    flipShader = (ok and sh) or false
+  end
+  return flipShader or nil
+end
+
+-- Whether the flip pass can run at all, for the shot driver's log.
+function BattleHud.flipReady()
+  return getFlip() ~= nil
+end
+
+-- Run `fn` with its ink whitened. Falls back to running it plainly when the
+-- scratch layer or the shader is unavailable, so a driver that cannot do
+-- either gets the vanilla black HUD rather than no HUD.
+function BattleHud.flipGlyphs(w, h, fn)
+  local sh = getFlip()
+  if not sh then return fn() end
+  if not layer or layer:getWidth() ~= w or layer:getHeight() ~= h then
+    layer = canvasOf(w, h, "nearest")
+    if not layer then return fn() end
+  end
+
+  local prevCanvas = love.graphics.getCanvas()
+  local prevBlend, prevAlpha = love.graphics.getBlendMode()
+  local ok, err = pcall(function()
+    love.graphics.setCanvas(layer)
+    love.graphics.clear(0, 0, 0, 0)
+    love.graphics.setBlendMode("alpha")
+    fn()
+  end)
+  if prevCanvas then
+    love.graphics.setCanvas(prevCanvas)
+  else
+    love.graphics.setCanvas()
+  end
+  love.graphics.setBlendMode(prevBlend or "alpha", prevAlpha)
+  if not ok then error(err, 0) end
+
+  love.graphics.setShader(sh)
+  pcall(sh.send, sh, "ink", INK)
+  love.graphics.setColor(1, 1, 1, 1)
+  love.graphics.draw(layer, 0, 0)
+  love.graphics.setShader()
+end
+
+-- ------- the whole HUD layer as a texture
+--
+-- The two blocks do not sit in the same place any more: each is snapped to its
+-- own side of the WINDOW, which is outside the 160x144 canvas the engine draws
+-- them in (see OverworldBattle.snapRects). A draw cannot be aimed at two
+-- places at once, so the layer is rendered ONCE into a GB-sized canvas and
+-- each block is then blitted out of it as a quad.
+--
+-- `dark` runs the ink through the same flip the in-frame HUD uses, here baked
+-- into the texture rather than composited into the caller's target -- the world
+-- image the quads land on is a colour canvas, and a flip pass over it would
+-- whiten the terrain behind the glyphs along with them.
+local hudLayer = nil
+
+function BattleHud.layerTexture(w, h, dark, fn)
+  if not hudLayer or hudLayer:getWidth() ~= w or hudLayer:getHeight() ~= h then
+    hudLayer = canvasOf(w, h, "nearest")
+    if not hudLayer then return nil end
+  end
+  local g = love.graphics
+  local prevCanvas = g.getCanvas()
+  local prevBlend, prevAlpha = g.getBlendMode()
+  local ok, err = pcall(function()
+    g.setCanvas(hudLayer)
+    g.clear(0, 0, 0, 0)
+    g.setBlendMode("alpha")
+    g.setColor(1, 1, 1, 1)
+    -- flipGlyphs renders fn into its own scratch layer and composites the
+    -- whitened result into whatever is bound, which is this canvas
+    if dark then BattleHud.flipGlyphs(w, h, fn) else fn() end
+  end)
+  if prevCanvas then g.setCanvas(prevCanvas) else g.setCanvas() end
+  g.setBlendMode(prevBlend or "alpha", prevAlpha)
+  g.setColor(1, 1, 1, 1)
+  if not ok then error(err, 0) end
+  return hudLayer
+end
+
+-- The last luminance measured, for the shot driver's log.
+function BattleHud.lastLuma()
+  local best = nil
+  for _, hit in pairs(luma) do
+    if not best or hit.value < best then best = hit.value end
+  end
+  return best
+end
+
+function BattleHud.invalidate()
+  frost, blurA, blurB, probe = nil, nil, nil, nil
+  frostW, frostH = 0, 0
+  luma = {}
+  wasDark = false
+  layer, hudLayer = nil, nil
+end
+
+return BattleHud

--- a/mods/dramatic_shape/lib/BattlePics.lua
+++ b/mods/dramatic_shape/lib/BattlePics.lua
@@ -1,0 +1,157 @@
+-- Overworld battles: giving a battle pic its paper back.
+--
+-- Gen 1 battle pics are two-bit art whose lightest shade is WHITE, and the
+-- engine's decoded PNGs key that shade to alpha 0 -- which was free, because
+-- the field behind them was white too. A transparent belly on a white page
+-- is a white belly.
+--
+-- Put a route behind it and the belly is grass. Charizard's chest, the whites
+-- of every eye, the highlight down a Pikachu's cheek: all of it turns into a
+-- hole with the world showing through, and the mon reads as a stencil.
+--
+-- So the paper is put back, and only where the paper was: the pic is read
+-- back once, the transparent region OUTSIDE the figure is flood-filled from
+-- the border, and every transparent pixel the flood could not reach -- every
+-- hole enclosed by the artwork -- is filled opaque white. The silhouette is
+-- untouched, so the mon still cuts cleanly against the world; only its
+-- insides stop being see-through.
+--
+-- Read back off the GPU rather than off the asset, deliberately. What comes
+-- back is the pic the engine actually decided to draw -- species palette,
+-- forced-mono rebuild, shiny recolour, a mod's replacement art -- so this
+-- needs to know nothing about how any of that was arrived at. Once per pic
+-- per session, cached on the image itself.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local BattlePics = {}
+
+-- Cached by the image the engine handed over. Weak keys, so a pic that goes
+-- out of scope takes its filled twin with it rather than pinning a texture
+-- for the session.
+local cache = setmetatable({}, { __mode = "k" })
+
+-- What an enclosed hole is filled with. White, because white is what the
+-- battle field was: this restores the pixel the artist drew and the engine
+-- then keyed away, it does not invent a new one.
+BattlePics.FILL = { 1, 1, 1, 1 }
+
+-- Anything at or under this alpha counts as keyed-out rather than drawn.
+local CUT = 0.5
+
+-- Read the pixels the engine would actually blit. A LOVE Image does not hand
+-- its data back, so it is drawn into a canvas of its own size and the canvas
+-- is read -- which is also what makes this work for every path that produces
+-- a pic, without knowing which one produced this one.
+local function readBack(img)
+  local w, h = img:getDimensions()
+  if w <= 0 or h <= 0 then return nil end
+  local prevCanvas = love.graphics.getCanvas()
+  local prevBlend, prevAlpha = love.graphics.getBlendMode()
+  local prevR, prevG, prevB, prevA = love.graphics.getColor()
+  local data = nil
+  local ok = pcall(function()
+    local canvas = love.graphics.newCanvas(w, h)
+    love.graphics.setCanvas(canvas)
+    love.graphics.clear(0, 0, 0, 0)
+    love.graphics.setBlendMode("replace", "premultiplied")
+    love.graphics.setColor(1, 1, 1, 1)
+    love.graphics.draw(img, 0, 0)
+    love.graphics.setCanvas()
+    data = canvas:newImageData()
+    if canvas.release then pcall(canvas.release, canvas) end
+  end)
+  if prevCanvas then
+    love.graphics.setCanvas(prevCanvas)
+  else
+    love.graphics.setCanvas()
+  end
+  love.graphics.setBlendMode(prevBlend or "alpha", prevAlpha)
+  love.graphics.setColor(prevR or 1, prevG or 1, prevB or 1, prevA or 1)
+  return ok and data or nil
+end
+
+-- Mark every transparent pixel reachable from the border. That set is the
+-- OUTSIDE; everything transparent it does not reach is an enclosed hole.
+--
+-- An explicit stack rather than recursion: a 56x56 pic is three thousand
+-- pixels and a keyed-out background is most of them, which is a deeper call
+-- chain than is worth risking for no gain.
+local function markOutside(data, w, h)
+  local outside = {}
+  local stack, top = {}, 0
+  local function push(x, y)
+    if x < 0 or y < 0 or x >= w or y >= h then return end
+    local key = y * w + x
+    if outside[key] then return end
+    local _, _, _, a = data:getPixel(x, y)
+    if a > CUT then return end
+    outside[key] = true
+    top = top + 1
+    stack[top] = key
+  end
+  for x = 0, w - 1 do
+    push(x, 0)
+    push(x, h - 1)
+  end
+  for y = 0, h - 1 do
+    push(0, y)
+    push(w - 1, y)
+  end
+  while top > 0 do
+    local key = stack[top]
+    top = top - 1
+    local x, y = key % w, math.floor(key / w)
+    push(x - 1, y)
+    push(x + 1, y)
+    push(x, y - 1)
+    push(x, y + 1)
+  end
+  return outside
+end
+
+-- The pic with its enclosed holes filled, or the pic itself when that could
+-- not be done (no pixel access, a driver that refused the readback). Never
+-- nil for a non-nil argument: a caller must always have something to draw.
+function BattlePics.filled(img)
+  if not img then return img end
+  local hit = cache[img]
+  if hit ~= nil then return hit or img end
+
+  local made = nil
+  local ok = pcall(function()
+    local data = readBack(img)
+    if not data then return end
+    local w, h = data:getDimensions()
+    local outside = markOutside(data, w, h)
+    local fill = BattlePics.FILL
+    local changed = false
+    for y = 0, h - 1 do
+      local row = y * w
+      for x = 0, w - 1 do
+        if not outside[row + x] then
+          local _, _, _, a = data:getPixel(x, y)
+          if a <= CUT then
+            data:setPixel(x, y, fill[1], fill[2], fill[3], fill[4])
+            changed = true
+          end
+        end
+      end
+    end
+    -- nothing enclosed: hand the original back rather than a copy of it
+    if not changed then return end
+    local out = love.graphics.newImage(data)
+    out:setFilter("nearest", "nearest")
+    made = out
+  end)
+
+  cache[img] = (ok and made) or false
+  return made or img
+end
+
+function BattlePics.invalidate()
+  cache = setmetatable({}, { __mode = "k" })
+end
+
+return BattlePics

--- a/mods/dramatic_shape/lib/BattleScene.lua
+++ b/mods/dramatic_shape/lib/BattleScene.lua
@@ -1,0 +1,494 @@
+﻿-- Overworld battles: one frame of the arena, as geometry.
+--
+-- The same world the free-roam mode draws, from a placed camera instead of
+-- the orbit, at the WINDOW's own pixel resolution -- not the GB's. The
+-- backdrop reaches the screen through Renderer's worldOverride, the seam a
+-- render pipeline's finished world image already composites through, which
+-- is drawn one canvas pixel to one screen pixel; the 160x144 battle screen
+-- then blits over it in the classic letterbox. So the world is as crisp as
+-- the free-roam diorama and the pics, HUDs and text box stay exactly the
+-- chunky GB art they are.
+--
+-- Rendering the whole window rather than just the letterbox means the
+-- framing has to be split in two. The RIG frames the GB's 160x144 (see
+-- BattleCam, which is solved against coordinates in that frame); this
+-- module widens the lens by exactly the ratio the window bears to the
+-- letterbox, so the letterbox sub-rectangle of what gets rendered is
+-- bit-for-bit the framing the rig asked for, and everything outside it is
+-- extra picture. That is what lets the two mons be PINNED: their cells
+-- project to the same GB coordinates at any window size or zoom.
+--
+-- Characters are deliberately absent. The overworld cast is culled for the
+-- length of the battle (see OverworldBattle), so this pass has terrain,
+-- grass and flowers and nothing that walks -- the arena is empty, which is
+-- what makes it an arena.
+--
+-- Everything expensive is shared with the free-roam mode rather than
+-- duplicated: the same chunk meshes out of ChunkMesher, the same palette
+-- atlas out of TerrainAtlas, the same sun out of ShadowMap. A battle on a
+-- map already meshed for walking around costs the frame it draws and
+-- nothing else.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local Mat4 = V.require("Mat4")
+local Voxel3D = V.require("Voxel3D")
+local ShadowMap = V.require("ShadowMap")
+local ChunkMesher = V.require("ChunkMesher")
+local TerrainAtlas = V.require("TerrainAtlas")
+local VoxelScene = V.require("VoxelScene")
+local BattleCam = V.require("BattleCam")
+local BattleBillboard = V.require("BattleBillboard")
+local VoxelGrid = V.require("VoxelGrid")
+local DayNight = V.require("DayNight")
+local PaletteFX = require("src.render.PaletteFX")
+local Map = require("src.world.Map")
+
+local BattleScene = {}
+
+-- The GB frame the battle screen is drawn in, and the frame BattleCam's rig
+-- is solved against.
+BattleScene.GB_W = 160
+BattleScene.GB_H = 144
+
+-- A map cell in world pixels: the overworld square a mon stands on, which is
+-- both what the arena is measured in and what a mon is sized to.
+BattleScene.CELL = 16
+
+-- How far into black a shadow goes in the arena, against the free-roam
+-- mode's own lighter setting.
+--
+-- Darker on purpose, and only here. Walking around, a shadow is scenery and
+-- wants to stay out of the way of reading the map. In a battle it is doing
+-- one specific job: the two mons are flat cards, and the ONLY thing telling
+-- the eye they are standing on that floor rather than hanging in front of it
+-- is the shadow they put on it. A faint one leaves them floating.
+BattleScene.SHADOW_ALPHA = 0.68
+
+-- Which rung of the sky ramp an indoor void is painted with. A room has no
+-- sky, but it does have somewhere the geometry stops, and leaving that
+-- transparent would show the letterbox clear through the gaps.
+local INDOOR_SHADE = 4
+
+-- ------- where the GB frame sits inside the window
+--
+-- Renderer blits worldOverride one canvas pixel to one screen pixel and then
+-- blits the 160x144 UI canvas into a centred, integer-scaled letterbox. So
+-- these have to agree with Renderer:endFrame exactly, or the pins land off
+-- the mons by however much they disagree.
+function BattleScene.letterbox()
+  local Renderer = require("src.render.Renderer")
+  local pw, ph = BattleScene.pixelSize()
+  local s = Renderer:fitScale()
+  return math.floor((pw - BattleScene.GB_W * s) / 2),
+         math.floor((ph - BattleScene.GB_H * s) / 2),
+         s, pw, ph
+end
+
+-- The window in FRAMEBUFFER pixels, which is what the override blit works
+-- in. love.graphics.getDimensions is in LOVE units and differs from this by
+-- the display density on mobile.
+function BattleScene.pixelSize()
+  if love.graphics.getPixelDimensions then
+    local pw, ph = love.graphics.getPixelDimensions()
+    if pw and ph and pw > 0 and ph > 0 then return pw, ph end
+  end
+  return love.graphics.getDimensions()
+end
+
+-- Widen the rig's vertical field of view from the GB frame to the whole
+-- window, so the letterbox rows show exactly what the rig framed.
+--
+-- The horizontal falls out of it: at aspect pw/ph the window's half-width is
+-- tan(fov/2) * pw/ph, and the letterbox is 160*s of those pw pixels, which
+-- works back out to the GB frame's own 160/144. So one scale on the vertical
+-- pins both axes.
+function BattleScene.letterboxFov(fovGB, ph, s)
+  local span = BattleScene.GB_H * s
+  if span <= 0 then return fovGB end
+  return 2 * math.atan(math.tan(fovGB / 2) * ph / span)
+end
+
+-- ------- palette
+--
+-- The world palette a map draws under, in the shape VoxelScene's colour
+-- helpers take. Rebuilt per frame from the overworld state, which is where
+-- the engine's own pipeline context gets it too (OverworldController's
+-- ctx.paletteFor).
+local function paletteFor(state, home)
+  return function(map)
+    return PaletteFX.pal(require("src.core.Game").data,
+                         state:paletteNameFor(map or home))
+  end
+end
+
+-- ------- the map the fight is staged on
+--
+-- Normally the one the player is standing on. An authored arena may name
+-- another floor of the same cave or building (see BattleArena), and then the
+-- scene is THAT map: its terrain, its palette, its sky. Nothing else in the
+-- battle changes -- the fight, the party, the player's own position are all
+-- exactly where they were.
+--
+-- A foreign floor is meshed alone, with no connected neighbours: connections
+-- are the player's neighbourhood, and the map the camera has gone to visit is
+-- not standing in it. Both maps are kept live so neither the arena's mesh nor
+-- the one waiting to be walked back onto is evicted mid-battle.
+local function prefetchArena(state, host)
+  if host == state.map then return VoxelScene.prefetch(state) end
+  local live = { [host.id] = true, [state.map.id] = true }
+  for _, nb in ipairs(state.neighbors or {}) do live[nb.map.id] = true end
+  ChunkMesher.setLive(live)
+  TerrainAtlas.setLive(live)
+  local terrain = ChunkMesher.request(host, false, nil, true)
+                  or ChunkMesher.peek(host, true)
+  return terrain, {}
+end
+
+-- ------- the sun
+--
+-- Only has to be drawn once per battle: the arena does not move, and neither
+-- does the light. So the signature is the map, the arena and the meshes --
+-- not the camera, which is the one thing that IS moving and the one thing
+-- the sun does not care about.
+-- ------- the two mons, hung on their cells
+--
+-- The billboard texture is the battle screen's own 160x144 pics layer with
+-- one side rendered into it (see OverworldBattle.sideTexture), so the quad is
+-- that whole frame stood up on the map -- which is what carries every pic
+-- effect the engine applies without any of them being reimplemented here.
+--
+-- Its size follows from one number: a full 7x7-tile mon covers one overworld
+-- square, so a canvas pixel is FULL_W / FULL_PIC world pixels and the card is
+-- the canvas at that scale. Its placement follows from the anchor the
+-- texture reports -- the column the pic was centred on and the row its feet
+-- were put on -- which is translated onto the cell before the card is stood
+-- up, so a mon of any size in any pose has its feet on the ground.
+-- `mirror` flips the card about its own anchor column. Both mons wear their
+-- FRONT pic, which is drawn facing out of the screen -- so dropped into the
+-- world unaltered the pair stand back to back, both looking the same way past
+-- each other. Mirroring the near one turns it to face the far one, which is
+-- what a fight looks like; and because it is a flip about the pic's own
+-- centre the feet do not move off the tile.
+--
+-- The player's TRAINER pic is the exception, and it is exempted below. That
+-- one is a BACK view -- the player seen from behind, already turned to face
+-- up the field -- so it arrives pointing the right way and mirroring it would
+-- turn it around to face the camera it is standing in front of.
+local function monMatrix(tex, x, groundY, z, mirror)
+  local k = BattleBillboard.FULL_W / BattleBillboard.FULL_PIC
+  local w = BattleScene.GB_W * k
+  local h = BattleScene.GB_H * k
+  local ox = -((tex.ax / BattleScene.GB_W) - 0.5) * w
+  local oy = -((BattleScene.GB_H - tex.ay) / BattleScene.GB_H) * h
+  local yaw = BattleBillboard.yawToward(x, z, Voxel3D.eye)
+  local card = Mat4.mul(Mat4.translate(ox, oy, 0), Mat4.scale(w, h, 1))
+  if mirror then card = Mat4.mul(Mat4.scale(-1, 1, 1), card) end
+  return Mat4.mul(Mat4.mul(Mat4.translate(x, groundY, z), Mat4.rotateY(yaw)),
+                  card)
+end
+
+-- Every mon that has something to show this frame, as (texture, matrix).
+local function monCards(arena, groundY, textures)
+  local out = {}
+  if not textures then return out end
+  for _, side in ipairs({ "enemy", "player" }) do
+    local tex = textures[side]
+    local cell = (side == "player") and arena.player or arena.enemy
+    if tex and tex.canvas and cell then
+      local mirror = (side == "player") and not tex.trainer
+      out[#out + 1] = { tex = tex.canvas,
+                        model = monMatrix(tex, cell[1], groundY, cell[2],
+                                          mirror) }
+    end
+  end
+  return out
+end
+
+BattleScene.monCards = monCards
+
+-- The sun has to see the mons too, or they stand on the ground without
+-- putting anything on it. They are the one thing in this scene that MOVES,
+-- so `token` -- a counter the caller bumps whenever a pic could have changed
+-- -- goes in the signature; the terrain half of the answer would otherwise
+-- keep a stale pass alive and freeze the shadows in whatever pose they were
+-- first drawn in.
+local function shadowSignature(state, arena, terrain, nbMesh, token)
+  local host = arena.map or state.map
+  local parts = { "battle", host.id, arena.x, arena.y, arena.shape,
+                  tostring(terrain), tostring(token or 0),
+                  -- the cycle keeps running through a fight, and an arena lit
+                  -- from somewhere new must be re-cast from there
+                  math.floor(ShadowMap.KX * 128),
+                  math.floor(ShadowMap.KZ * 128) }
+  for i = 1, #nbMesh do parts[#parts + 1] = tostring(nbMesh[i]) end
+  return table.concat(parts, ",")
+end
+
+local function castShadows(state, arena, terrain, nbMesh, cx, cy, vw, vh,
+                           atlasFor, cards, token, host, neighbors)
+  if not ShadowMap.available() then return end
+  local sig = shadowSignature(state, arena, terrain, nbMesh, token)
+  if not ShadowMap.stale(sig) then return end
+  if not ShadowMap.begin(cx, cy, vw, vh) then return end
+
+  ShadowMap.draw(terrain, atlasFor(host), nil)
+  for i, nb in ipairs(neighbors) do
+    ShadowMap.draw(nbMesh[i], atlasFor(nb.map), Mat4.translate(nb.ox, 0, nb.oy))
+  end
+  -- thin cards are snugged toward the sun (ShadowMap.snug) so their shadows
+  -- keep contact with their bases instead of starting a bias-width away
+  ShadowMap.draw(ChunkMesher.flowers(host), atlasFor(host),
+                 ShadowMap.snug(nil))
+  for _, nb in ipairs(neighbors) do
+    ShadowMap.draw(ChunkMesher.flowers(nb.map), atlasFor(nb.map),
+                   ShadowMap.snug(Mat4.translate(nb.ox, 0, nb.oy)))
+  end
+
+  -- the mons themselves, as the same cards the camera will see. Their alpha
+  -- is the silhouette, so what lands on the ground is the shape of the
+  -- Pokemon rather than a blob standing in for one.
+  for _, card in ipairs(cards or {}) do
+    ShadowMap.draw(BattleBillboard.mesh(), card.tex,
+                   ShadowMap.snug(card.model))
+  end
+
+  ShadowMap.finish(sig)
+end
+
+-- The height of the arena floor: the ground the two mons stand on. Both
+-- cells are open, so they are normally the same; take the player's, which is
+-- the one nearer the camera and therefore the one a mismatch would show up
+-- against.
+function BattleScene.groundY(map, arena)
+  local ok, h = pcall(VoxelScene.groundAt, map,
+                      arena.playerCell[1], arena.playerCell[2])
+  return (ok and h) or 0
+end
+
+-- Where a world point lands in GB frame coordinates under `vp`, or nil when
+-- it is behind the camera. This is the function the pins are built on: it
+-- takes the window-resolution clip position and divides the letterbox back
+-- out of it, so the answer is in the same 160x144 space the battle screen
+-- draws its pics in.
+function BattleScene.toGB(vp, wx, wy, wz, lx, ly, s, pw, ph)
+  local cx = vp[1] * wx + vp[2] * wy + vp[3] * wz + vp[4]
+  local cy = vp[5] * wx + vp[6] * wy + vp[7] * wz + vp[8]
+  local cw = vp[13] * wx + vp[14] * wy + vp[15] * wz + vp[16]
+  if cw <= 1e-6 then return nil end
+  -- viewProjection already flipped clip Y into LOVE's Y-down convention
+  local px = (cx / cw * 0.5 + 0.5) * pw
+  local py = (cy / cw * 0.5 + 0.5) * ph
+  return (px - lx) / s, (py - ly) / s
+end
+
+-- Render the arena and hand back { canvas, player = {x,y}, enemy = {x,y} },
+-- the two marks in GB coordinates -- or nil when there is nothing to draw
+-- yet (the terrain mesh is still building, the driver has no depth support).
+-- nil is not a failure: the caller simply leaves the battle screen as the
+-- engine drew it for that frame.
+-- White, for the hit flash, and how far toward it the card goes.
+--
+-- The shader replaces the card's colour rather than multiplying it, so at
+-- full strength this is the sprite turned into a solid white silhouette --
+-- which is what the effect is on a flat GB screen and far too much on a
+-- sprite standing in a lit world. Held well short of 1, the mon's own
+-- shading still reads through the flash: it looks struck rather than
+-- deleted.
+BattleScene.FLASH_COLOR = { 1, 1, 1 }
+BattleScene.FLASH_STRENGTH = 0.5
+
+function BattleScene.render(state, arena, textures, token)
+  if not (state and state.map and arena) then return nil end
+  if not Voxel3D.available() then return nil end
+
+  -- the floor the fight is staged on: normally the player's own, sometimes
+  -- another floor of the same cave or building (see BattleArena)
+  local host = arena.map or state.map
+  local neighbors = (host == state.map) and (state.neighbors or {}) or {}
+
+  -- the hour's light reaches the arena exactly as it reaches free-roam: the
+  -- shared rig follows the clock on an outdoor floor and stays at noon on an
+  -- indoor one, and the same tint multiplies the staged shot -- with the
+  -- same window glass on whatever buildings stand in the background
+  local outdoor = host.def and Map.isOutdoor(host.def) or false
+  DayNight.applyRig(outdoor)
+  -- a canopy floor (Viridian Forest) fights under the hour's tint too,
+  -- with the rig and the void exactly as they were
+  Voxel3D.tint = DayNight.tint(outdoor or DayNight.isCanopy(host))
+  local GlassMask = V.require("GlassMask")
+  Voxel3D.glassMask = outdoor and GlassMask.texture(host.tileset) or nil
+  Voxel3D.glassNight = outdoor and DayNight.windowLight() or 0
+  -- no glint in the arena: the drift is the shot breathing, not the player
+  -- moving, and a shimmer on background windows would fight the mons
+  Voxel3D.glassGlint = 0
+
+  -- shares the free-roam mode's request/evict bookkeeping, so a battle warms
+  -- exactly the meshes walking around would have and nothing extra
+  local terrain, nbMesh = prefetchArena(state, host)
+  if not terrain then return nil end
+
+  local lx, ly, s, pw, ph = BattleScene.letterbox()
+  if not (pw > 0 and ph > 0 and s > 0) then return nil end
+
+  local palette = paletteFor(state, host)
+  local function atlasFor(map)
+    return TerrainAtlas.forMap(map, VoxelScene._modeColors(palette, map))
+  end
+
+  local groundY = BattleScene.groundY(host, arena)
+  local cam, pitch = BattleCam.rig(arena, groundY)
+  cam.fov = BattleScene.letterboxFov(cam.fov, ph, s)
+
+  local cx, cy = arena.mid[1], arena.mid[2]
+  -- the world extents the sun frustum is fitted to; the camera itself is
+  -- framed by cam.fov, so these only have to describe the ground in shot
+  local vh = BattleCam.rigFor(arena).frameH * ph / (BattleScene.GB_H * s)
+  local vw = vh * pw / ph
+
+  -- the cards need the camera's eye to face it, so the rig has to be live
+  -- before they are built; Voxel3D.eye is set by viewProjection, which
+  -- beginScene calls -- so a provisional one is taken here for the sun pass
+  -- and the real one is rebuilt inside the scene below.
+  Voxel3D.camera = cam
+  Voxel3D.viewProjection(cx, cy, vw, vh)
+  local cards = monCards(arena, groundY, textures)
+  Voxel3D.camera = nil
+  castShadows(state, arena, terrain, nbMesh, cx, cy, vw, vh, atlasFor,
+              cards, token, host, neighbors)
+
+  -- An opaque void either way. Outdoors the camera is low enough that the
+  -- horizon is genuinely in frame, so it is sky; indoors it is the dark end
+  -- of the same ramp, which is a room's "past the wall". Transparent -- the
+  -- free-roam default -- would let the letterbox clear through wherever the
+  -- geometry stops.
+  local sky = VoxelScene.skyColor(host, 1)
+             or VoxelScene.skyShade(INDOOR_SHADE, 1)
+
+  Voxel3D.camera = cam
+  -- the sun is turned up for the arena and put back afterwards, so the
+  -- free-roam world it shares this module with keeps its own weight -- and
+  -- the hour still has the last word: a sunset fades the arena's shadows
+  -- out and the moon presses more softly, exactly as it does outside
+  local sunWas = Voxel3D.SHADOW_ALPHA
+  Voxel3D.SHADOW_ALPHA = BattleScene.SHADOW_ALPHA
+                         * DayNight.shadowScale(outdoor)
+  -- and the wireframe is ON for a battle whatever the V-GRID row says. The
+  -- arena is a staged shot rather than the world being walked through, and
+  -- the seams are what make it read as built rather than photographed. Forced
+  -- through the override so the player's own row is never written to.
+  local gridWas = VoxelGrid.override
+  VoxelGrid.override = true
+  local out = nil
+  local ok, err = pcall(function()
+    -- its own canvas slot: this renders at the window's pixel size and the
+    -- free-roam pass does too, but the two are alive at different moments
+    -- and a shared slot would reallocate on every battle entry and exit
+    if not Voxel3D.beginScene(pw, ph, cx, cy, vw, vh, sky, "battle") then
+      return
+    end
+    Voxel3D.draw(terrain, atlasFor(host), nil)
+    for i, nb in ipairs(neighbors) do
+      Voxel3D.draw(nbMesh[i], atlasFor(nb.map),
+                   Mat4.translate(nb.ox, 0, nb.oy))
+    end
+    -- The mons, standing on their tiles. Depth-tested like everything else,
+    -- so a ledge or a tree between the camera and a Pokemon really is in
+    -- front of it, and the alpha discard cuts the sprite's own outline out of
+    -- the card. A small camera-ward pull keeps a card rooted to the ground
+    -- plane from z-fighting the tile it is standing on.
+    -- The engine's hit flash is a full-screen white rectangle, which on a
+    -- white battle field is a flash and over a world is a whiteout of the
+    -- map, the HUD and the text box alike. It is dropped on the way past
+    -- (see OverworldBattle) and put back HERE, on the two things it was ever
+    -- about: the mons themselves go solid white for those frames.
+    local flashing = textures and textures.flash
+    if flashing then
+      Voxel3D.flatten(BattleScene.FLASH_COLOR, BattleScene.FLASH_STRENGTH)
+    end
+    -- and no voxel wireframe on the pair. Everything else in this frame is
+    -- built a unit per voxel and wears the seams that fall out of that; a
+    -- mon's card is one quad wearing the battle screen (see
+    -- BattleBillboard), so it is off the grid and has no seams to draw.
+    Voxel3D.seams(false)
+    -- and no glass either: the cards wear the battle screen, not the
+    -- tileset atlas, so the mask's coordinates mean nothing on them
+    Voxel3D.glass(false)
+    for _, card in ipairs(monCards(arena, groundY, textures)) do
+      -- the sun stored this card snugged (castShadows), so its own shadow
+      -- lookup must read the same snugged transform -- see ShadowMap.snug
+      Voxel3D.draw(BattleBillboard.mesh(), card.tex, card.model,
+                   BattleBillboard.PULL, ShadowMap.snug(card.model))
+    end
+    Voxel3D.glass(true)
+    Voxel3D.seams(true)
+    if flashing then Voxel3D.flatten(nil) end
+    -- grass and flowers ride the same camera-ward pull the free-roam pass
+    -- gives them, measured against THIS camera's pitch rather than the
+    -- orbit's -- there is no character here for them to overdraw, but the
+    -- pull is also what keeps a tuft from z-fighting the floor it stands on
+    local pull = VoxelScene.pull(math.max(pitch, 0.05))
+    Voxel3D.draw(ChunkMesher.grass(host), atlasFor(host), nil, pull)
+    for _, nb in ipairs(neighbors) do
+      Voxel3D.draw(ChunkMesher.grass(nb.map), atlasFor(nb.map),
+                   Mat4.translate(nb.ox, 0, nb.oy), pull)
+    end
+    local fpull = math.max(0, pull - 8 * math.sin(math.max(pitch, 0.05)))
+    Voxel3D.draw(ChunkMesher.flowers(host), atlasFor(host), nil, fpull,
+                 ShadowMap.snug(nil))
+    for _, nb in ipairs(neighbors) do
+      Voxel3D.draw(ChunkMesher.flowers(nb.map), atlasFor(nb.map),
+                   Mat4.translate(nb.ox, 0, nb.oy), fpull,
+                   ShadowMap.snug(Mat4.translate(nb.ox, 0, nb.oy)))
+    end
+    local canvas = Voxel3D.endScene()
+    if not canvas then return end
+
+    local vp = Voxel3D.vp
+    local pmx, pmy = BattleScene.toGB(vp, arena.player[1], groundY,
+                                      arena.player[2], lx, ly, s, pw, ph)
+    local emx, emy = BattleScene.toGB(vp, arena.enemy[1], groundY,
+                                      arena.enemy[2], lx, ly, s, pw, ph)
+    if not (pmx and emx) then return end
+    -- How wide one overworld square is on screen where each mon stands, in
+    -- GB pixels. This is what the pics are scaled to: a mon covers its own
+    -- square and no more, at whatever the drift has done to the distance.
+    local half = BattleScene.CELL / 2
+    local pl = BattleScene.toGB(vp, arena.player[1] - half, groundY,
+                                arena.player[2], lx, ly, s, pw, ph)
+    local pr = BattleScene.toGB(vp, arena.player[1] + half, groundY,
+                                arena.player[2], lx, ly, s, pw, ph)
+    local el = BattleScene.toGB(vp, arena.enemy[1] - half, groundY,
+                                arena.enemy[2], lx, ly, s, pw, ph)
+    local er = BattleScene.toGB(vp, arena.enemy[1] + half, groundY,
+                                arena.enemy[2], lx, ly, s, pw, ph)
+    if not (pl and pr and el and er) then return end
+    out = {
+      canvas = canvas,
+      player = { pmx, pmy },
+      enemy = { emx, emy },
+      playerSpan = math.abs(pr - pl),
+      enemySpan = math.abs(er - el),
+      -- the letterbox, so the depth-of-field pass can put its sharp band on
+      -- the two marks rather than on a fraction of the window
+      lx = lx, ly = ly, scale = s, pw = pw, ph = ph,
+    }
+  end)
+  -- the placed camera is ours for exactly this pass; anything else that
+  -- renders (the free-roam pipeline, next frame) must find the orbit back
+  Voxel3D.camera = nil
+  Voxel3D.SHADOW_ALPHA = sunWas
+  VoxelGrid.override = gridWas
+  if not ok then
+    -- endScene never ran, so the canvas is still bound and the shader still
+    -- set; put the frame back the way it was found before rethrowing
+    pcall(love.graphics.setShader)
+    pcall(love.graphics.setDepthMode)
+    pcall(love.graphics.setCanvas)
+    error(err, 0)
+  end
+  return out
+end
+
+return BattleScene

--- a/mods/dramatic_shape/lib/BuildBudget.lua
+++ b/mods/dramatic_shape/lib/BuildBudget.lua
@@ -1,0 +1,61 @@
+-- Voxel world mode: the cooperative build budget.
+--
+-- Mesh building runs inside a plain coroutine that ChunkMesher pumps for
+-- a few milliseconds a frame (there is no worker thread: LOVE's graphics
+-- objects are main-thread only, and the build is pure Lua that slices
+-- cleanly). The long loops in Structures and ChunkMesher call tick() as
+-- they go; when the frame's slice is spent, tick() suspends the build
+-- coroutine and the frame carries on rendering whatever is already
+-- cached.
+--
+-- tick() is deliberately safe to call from ANY context: outside the pump
+-- (headless tests, the pure geometry API, a driver poking a build
+-- function directly) it recognises it is not inside the build coroutine
+-- and does nothing, so synchronous callers keep their synchronous
+-- behavior.
+
+local B = { n = 0 }
+
+local clock = (love and love.timer and love.timer.getTime) or os.clock
+
+local deadline = math.huge
+local buildCo = nil
+
+-- Enter/leave a pumped slice. `co` is the coroutine being resumed, so
+-- tick() can tell the build apart from any other coroutine the engine
+-- happens to be running (drivers are coroutines too).
+function B.begin(co, seconds)
+  buildCo = co
+  deadline = clock() + seconds
+end
+
+function B.finish()
+  buildCo = nil
+  deadline = math.huge
+end
+
+function B.expired()
+  return clock() > deadline
+end
+
+-- Cheap enough to sprinkle through inner loops: one modulo most calls,
+-- a clock read every 32nd.
+function B.tick()
+  local n = B.n + 1
+  B.n = n
+  if n % 32 ~= 0 then return end
+  if buildCo and coroutine.running() == buildCo and clock() > deadline then
+    coroutine.yield("budget")
+  end
+end
+
+-- Like tick() but consults the clock every call -- for coarse loops
+-- whose single iteration already costs milliseconds (mesh upload
+-- slices), where tick()'s 1-in-32 sampling would never fire.
+function B.check()
+  if buildCo and coroutine.running() == buildCo and clock() > deadline then
+    coroutine.yield("budget")
+  end
+end
+
+return B

--- a/mods/dramatic_shape/lib/Buildings.lua
+++ b/mods/dramatic_shape/lib/Buildings.lua
@@ -1,0 +1,751 @@
+-- Voxel world mode: a building voxelized from its own sprite.
+--
+-- A Game Boy overworld building is a fake-3D projection that packs several
+-- different 3D facings into one flat drawing: the roof is drawn as if seen
+-- from above, the facade as if seen face-on, and the sloped ends as
+-- diagonal silhouettes. Raising the whole footprint as one box (what the
+-- generic volume path does) folds all three into a wall, so a house comes
+-- out as a cube wearing its own elevation.
+--
+-- This module does the other thing: it classifies each BAND of the drawing
+-- by the surface it depicts and applies the matching operation per band --
+-- the pipeline written up in assets/docs/buidling_to_voxel/. Two rules govern it:
+--
+--   1. Every visible voxel colour is a real texel of the drawing. Nothing
+--      is invented but the geometry the sprite implies and never paints
+--      (undersides, the depth behind the facade), and those wear the
+--      drawing's own four shades.
+--   2. The sprite is ground truth, not the tile grid. The silhouette, the
+--      taper rate, the eave height and every window are MEASURED off the
+--      pixels; the profile only says which rows are roof and which are
+--      facade.
+--
+-- The pipeline, per template (see data/voxel_heights.lua `buildings`):
+--
+--   read     composite the building out of the atlas and flood its
+--            silhouette in from the border through light pixels only --
+--            the black outline and the #555 shading together are the
+--            boundary, and a "not black" test eats the shaded flanks.
+--   measure  the topmost drawn row of each column IS the roof's elevation
+--            profile (the drawn taper is the slope); the facade's panes
+--            are the non-black regions its black frames seal off.
+--   build    facade rows extrude straight back over the footprint, the
+--            awning band juts past them, panes sink one voxel, and the
+--            roof lays the top-facing rows flat -- level over the
+--            plateau, stepping down the drawn taper at the ends -- then
+--            overwrites the walls it intersects.
+--   emit     cull to the shell and merge runs of texel-adjacent faces into
+--            single quads, so a 90k-voxel house ships as ~2k quads.
+--
+-- One model is built per template and stamped at every placement: Red's
+-- and Blue's houses are the same seven-placement drawing, so they cost one
+-- build between them. mods/DRAMATIC_SHAPE/tools/building_voxels.py is the
+-- reference implementation of the same algorithm and prints the voxel and
+-- shell counts this one must agree with.
+--
+-- Purely presentational, like everything else in the mod: the tiles a
+-- building claims keep the collision, warps and triggers they always had.
+
+-- the mod namespace (see main.lua): V.data loads a shipped data file
+local V = ...
+
+local Budget = V.require("BuildBudget")
+
+local Buildings = {}
+
+-- The four GB shades, lightest first (same cutoffs as Structures.shadeClass,
+-- which reasons about the same art).
+local WHITE, GREY, DARK, BLACK = 0, 1, 2, 3
+
+-- A pane is a window or a doorway: a non-black region the drawing seals
+-- off behind its own black frame. Anything wider or taller than this is a
+-- band of the facade itself -- a siding course, the awning's grey field --
+-- and must stay flush.
+local RECESS_MAX = 24
+
+-- Face shades, matching the rest of the mod's objects: the south face is
+-- the drawing itself and draws at full brightness.
+local SHADE = { top = 0.95, south = 1.0, north = 0.68,
+                side = 0.78, bottom = 0.5 }
+
+local function keyOf(tx, ty)
+  return (ty + 64) * 4096 + (tx + 64)
+end
+
+local function shadeOf(r, g, b, a)
+  if a == 0 then return WHITE end
+  local v = math.min(r, g, b)
+  if v <= 0.25 then return BLACK end
+  if v <= 0.55 then return DARK end
+  if v <= 0.85 then return GREY end
+  return WHITE
+end
+
+-- The shape profile ships with the mod; absent or broken simply means no
+-- building templates, and every building falls back to the volume path.
+local spec = nil
+local function profile()
+  if spec == nil then
+    local ok, s = pcall(V.data, "voxel_heights")
+    spec = (ok and type(s) == "table") and s or false
+  end
+  return spec or nil
+end
+
+local models = {}          -- "<tileset>:<index>" -> prebuilt local quads
+
+-- ------------------------------------------------------------------ read --
+
+-- Composite the template out of the atlas and flood the silhouette in from
+-- the border. Returns flat arrays indexed y * W + x.
+--
+-- `topRows`, when a template carries it, is extra drawing rows composited
+-- ABOVE the matched grid: rows of the same drawing that are not on the
+-- map this template places on. The Pokemon Tower is the case that needs
+-- it -- the drawing straddles the LAVENDER_TOWN / ROUTE_10 boundary, its
+-- roof band and top window courses standing in the route's last rows, so
+-- no single map's grid holds the whole building. The matcher never sees
+-- topRows (placement is still by `tiles` alone); they exist so the MODEL
+-- is built from the complete drawing and the tower rises to its real
+-- height instead of folding as two half-buildings.
+local function read(t, data, perRow)
+  local tiles = t.tiles
+  if t.topRows then
+    tiles = {}
+    for _, row in ipairs(t.topRows) do tiles[#tiles + 1] = row end
+    for _, row in ipairs(t.tiles) do tiles[#tiles + 1] = row end
+  end
+  local bh, bw = #tiles, #t.tiles[1]
+  local W, H = bw * 8, bh * 8
+  local col, ax, ay = {}, {}, {}
+  for sy = 0, H - 1 do
+    Budget.tick()
+    local row = tiles[math.floor(sy / 8) + 1]
+    for sx = 0, W - 1 do
+      local tile = row[math.floor(sx / 8) + 1]
+      local px = (tile % perRow) * 8 + sx % 8
+      local py = math.floor(tile / perRow) * 8 + sy % 8
+      local i = sy * W + sx
+      ax[i], ay[i] = px, py
+      local r, g, b, a = data:getPixel(px, py)
+      col[i] = shadeOf(r, g, b, a)
+    end
+  end
+
+  local outside = {}
+  local queue, n = {}, 0
+  local function seed(x, y)
+    local i = y * W + x
+    if not outside[i] and col[i] <= GREY then
+      outside[i] = true
+      n = n + 1
+      queue[n] = i
+    end
+  end
+  -- The flood comes in from the border, which assumes the drawing is
+  -- bounded by its own outline on every side. A drawing trimmed flush to
+  -- its art -- one whose base course is a row of brick rather than the
+  -- black threshold every other building stands on -- names the sides it
+  -- runs off in `seal`, and the flood does not seed there. Without it the
+  -- flood climbs in through the light mortar and hollows the wall out.
+  local seal = t.seal or ""
+  local function sealed(side) return string.find(seal, side, 1, true) ~= nil end
+  for x = 0, W - 1 do
+    if not sealed("n") then seed(x, 0) end
+    if not sealed("s") then seed(x, H - 1) end
+  end
+  for y = 0, H - 1 do
+    if not sealed("w") then seed(0, y) end
+    if not sealed("e") then seed(W - 1, y) end
+  end
+  while n > 0 do
+    local i = queue[n]
+    n = n - 1
+    local x, y = i % W, math.floor(i / W)
+    if x + 1 < W then seed(x + 1, y) end
+    if x > 0 then seed(x - 1, y) end
+    if y + 1 < H then seed(x, y + 1) end
+    if y > 0 then seed(x, y - 1) end
+  end
+
+  local inside = {}
+  for i = 0, W * H - 1 do inside[i] = not outside[i] end
+  return { W = W, H = H, col = col, ax = ax, ay = ay, inside = inside }
+end
+
+-- --------------------------------------------------------------- measure --
+
+local function measure(sp, t)
+  local W, H = sp.W, sp.H
+  local roofRows = t.roofRows
+
+  -- The drawn taper IS the slope: the first drawn row of a column is how
+  -- far the roof has stepped down by the time it reaches that column.
+  local top = {}
+  for x = 0, W - 1 do
+    local r = roofRows
+    for y = 0, roofRows - 1 do
+      if sp.inside[y * W + x] then r = y break end
+    end
+    top[x] = r
+  end
+
+  local wallH = H - roofRows
+  local ytop = wallH - 1 + t.slab
+
+  -- Side faces must not come out as slabs of outline black: where the
+  -- drawing's own pixel is the outline, walk inward for the first painted
+  -- colour, which is what the flanks of the real thing would show.
+  local interior = {}
+  for sy = roofRows, H - 1 do
+    for sx = 0, W - 1 do
+      local i = sy * W + sx
+      local src = i
+      if sp.inside[i] and sp.col[i] == BLACK then
+        local step = sx < W / 2 and 1 or -1
+        for d = 1, 3 do
+          local nx = sx + step * d
+          if nx >= 0 and nx < W then
+            local ni = sy * W + nx
+            if sp.inside[ni] and sp.col[ni] ~= BLACK then
+              src = ni
+              break
+            end
+          end
+        end
+      end
+      interior[i] = src
+    end
+  end
+
+  -- Panes: the facade's non-black pixels split into regions across the
+  -- black frames, and a region small enough to be a window or a doorway
+  -- sinks a voxel. Frames stay proud, so the pane behind them reads as
+  -- glass set into the wall -- and a nested frame (the door's own little
+  -- window) layers for free.
+  local recess, seen = {}, {}
+  for sy = roofRows, H - 1 do
+    for sx = 0, W - 1 do
+      local i0 = sy * W + sx
+      if not seen[i0] and sp.inside[i0] and sp.col[i0] ~= BLACK then
+        local cells, stack = {}, { i0 }
+        seen[i0] = true
+        local x0, x1, y0, y1 = sx, sx, sy, sy
+        local function step(nx, ny)
+          if nx < 0 or nx >= W or ny < roofRows or ny >= H then return end
+          local ni = ny * W + nx
+          if not seen[ni] and sp.inside[ni] and sp.col[ni] ~= BLACK then
+            seen[ni] = true
+            stack[#stack + 1] = ni
+          end
+        end
+        while #stack > 0 do
+          local i = table.remove(stack)
+          cells[#cells + 1] = i
+          local cx, cy = i % W, math.floor(i / W)
+          if cx < x0 then x0 = cx end
+          if cx > x1 then x1 = cx end
+          if cy < y0 then y0 = cy end
+          if cy > y1 then y1 = cy end
+          step(cx + 1, cy)
+          step(cx - 1, cy)
+          step(cx, cy + 1)
+          step(cx, cy - 1)
+        end
+        if x1 - x0 < RECESS_MAX and y1 - y0 < RECESS_MAX then
+          for _, i in ipairs(cells) do recess[i] = true end
+        end
+      end
+    end
+  end
+
+  -- One representative texel per shade, taken from the building's own art:
+  -- the roof's fascia and its undersides are geometry the drawing implies
+  -- but never paints, and they must still wear its palette (and pick up
+  -- whatever SGB recolouring the atlas carries).
+  local shadeTexel = {}
+  for i = 0, sp.W * sp.H - 1 do
+    if sp.inside[i] and not shadeTexel[sp.col[i]] then
+      shadeTexel[sp.col[i]] = i
+    end
+  end
+  for s = WHITE, BLACK do
+    shadeTexel[s] = shadeTexel[s] or shadeTexel[BLACK] or 0
+  end
+
+  -- Depth is the MATCHED footprint, not the sprite height. The two are
+  -- the same number for every whole-drawing template (the sprite is
+  -- built from `tiles` alone), but a template with `topRows` has a
+  -- sprite taller than its footprint -- the tower's 16-row drawing
+  -- stands on the 8 rows of it that are actually on the map, and D = H
+  -- would have pushed its body 64px south into the town plaza.
+  return { top = top, ytop = ytop, D = #t.tiles * 8,
+           recess = recess, interior = interior, shadeTexel = shadeTexel }
+end
+
+-- ----------------------------------------------------------------- build --
+
+-- The voxel model as a lookup: `at(x, y, z)` is the index of the sprite
+-- pixel that voxel wears, or nil. Build ORDER is expressed as lookup
+-- order -- roof first, so it overwrites the walls it intersects, and walls
+-- are trimmed to its underside so nothing pokes through the surface.
+local function model(sp, pr, t)
+  local W, H, D = sp.W, sp.H, pr.D
+  local slab, roofRows = t.slab, t.roofRows
+  local top, ytop = pr.top, pr.ytop
+
+  -- The roof's drawn span. A sprite inset from its box (B03) leaves outer
+  -- columns undrawn in the roof band; they carry no roof at all, and the
+  -- rim treatment belongs to the outermost drawn columns instead of the
+  -- box edge.
+  local x0d, x1d
+  for x = 0, W - 1 do
+    if top[x] < roofRows then
+      x0d = x0d or x
+      x1d = x
+    end
+  end
+  local ledge0, ledge1 = nil, nil
+  if t.ledge then ledge0, ledge1 = t.ledge[1], t.ledge[2] end
+
+  local rz0, rz1 = 0, D - 1 + (t.frontEave or 0)
+  local back, front = t.roofBack, t.roofFront
+  local cyc0, cyc1 = t.roofCycle[1], t.roofCycle[2]
+  local cycN = cyc1 - cyc0 + 1
+
+  -- Which drawn row lies at depth z. The drawing looks at the roof from
+  -- the north, so its top rows ARE the far edge and its bottom rows the
+  -- eave over the facade. The band is shallower than the building, so the
+  -- rims map one row per voxel and the middle cycles a run whose period is
+  -- the course rhythm -- picked up where the north rim left off, which
+  -- continues both the course lines and the roof texture seamlessly.
+  local roofSy = {}
+  for z = rz0, rz1 do
+    local df, db = z - rz0, rz1 - z          -- from the north / south edge
+    if df < back then
+      roofSy[z] = df
+    elseif db < front then
+      roofSy[z] = roofRows - 1 - db
+    else
+      roofSy[z] = cyc0 + (df - cyc0) % cycN
+    end
+  end
+
+  local T = {}
+  for x = 0, W - 1 do T[x] = ytop - top[x] end
+
+  local function at(x, y, z)
+    if x < 0 or x >= W then return nil end
+    local tx = T[x]
+
+    -- roof: a solid of constant thickness following the elevation profile
+    if top[x] < roofRows
+        and y > tx - slab and y <= tx and z >= rz0 and z <= rz1 then
+      if y == tx and x > x0d and x < x1d and z > rz0 and z < rz1 then
+        -- the surface itself. Clamping the row into the column's first
+        -- drawn row keeps the flank battens running down the slope
+        -- instead of falling off the silhouette.
+        local sy = roofSy[z]
+        if sy < top[x] then sy = top[x] end
+        return sy * W + x
+      end
+      -- The rim reproduces the eave the drawing itself paints under the
+      -- roof: a black outline, a shaded fascia, closed by the outline
+      -- again. (A GREY fascia band -- what the first cut had -- comes out
+      -- WHITE once the atlas is recoloured and turns every sloped end
+      -- into a black-and-white zip.) Under the surface it is all shadow.
+      local outer = x == x0d or x == x1d or z == rz0 or z == rz1
+      if not outer then return pr.shadeTexel[DARK] end
+      if y == tx or y == tx - slab + 1 then return pr.shadeTexel[BLACK] end
+      return pr.shadeTexel[DARK]
+    end
+
+    -- trimmed: under the slope. A column with no roof over it has no
+    -- underside to trim to, and must not be cut away by a profile the
+    -- drawing never set.
+    if top[x] < roofRows and y > tx - slab then return nil end
+
+    -- the awning: the band juts two voxels past the walls, front and back
+    if ledge0 and (z == -2 or z == -1 or z == D or z == D + 1) then
+      local sy = H - 1 - y
+      if sy >= ledge0 and sy <= ledge1 and sp.inside[sy * W + x] then
+        return sy * W + x
+      end
+      return nil
+    end
+
+    -- the facade, extruded straight back over the footprint
+    if z < 0 or z >= D then return nil end
+    local sy = H - 1 - y
+    local i = sy * W + x
+    if y == 0 and not sp.inside[i] and sy > 0 and sp.inside[i - W] then
+      -- the drawing's last row is the ground the building stands on, so
+      -- its base course is one row up; without this the walls float a
+      -- voxel over their own plot
+      sy, i = sy - 1, i - W
+    end
+    if not sp.inside[i] then return nil end
+    if z == D - 1 then
+      if pr.recess[i] then return nil end
+      return i
+    end
+    if z == 0 then return i end
+    return pr.interior[i]
+  end
+
+  return { at = at, W = W, ytop = ytop,
+           zmin = ledge0 and -2 or 0,
+           zmax = math.max(rz1, ledge0 and (D + 1) or 0) }
+end
+
+-- ------------------------------------------------------------------ emit --
+
+-- Cull to the shell and merge. A run of faces collapses into one quad when
+-- its texels are the SAME (a flat-coloured strip, which is most of a side
+-- face) or ADJACENT IN THE ATLAS along the run (the drawing continuing
+-- across the face, which is most of a front face or a roof top). Both keep
+-- every texel exactly where the sprite put it.
+local function emit(m, sp, atlasW, atlasH)
+  local W = m.W
+  local quads = { voxels = 0, shell = 0 }
+  local cell = {}                        -- (y, z, x) -> sprite pixel index
+
+  local zmin, zmax, ytop = m.zmin, m.zmax, m.ytop
+  local zn = zmax - zmin + 1
+  local function ci(x, y, z)
+    if x < 0 or x >= W or y < 0 or y > ytop or z < zmin or z > zmax then
+      return nil
+    end
+    return cell[(y * zn + (z - zmin)) * W + x]
+  end
+  for y = 0, ytop do
+    Budget.tick()
+    for z = zmin, zmax do
+      local base = (y * zn + (z - zmin)) * W
+      for x = 0, W - 1 do
+        local v = m.at(x, y, z)
+        cell[base + x] = v
+        if v then quads.voxels = quads.voxels + 1 end
+      end
+    end
+  end
+  -- the shell: what survives hidden-face culling. Counted here rather than
+  -- derived from the quads because it is the number
+  -- tools/building_voxels.py checks this build against.
+  for y = 0, ytop do
+    Budget.tick()
+    for z = zmin, zmax do
+      for x = 0, W - 1 do
+        if ci(x, y, z) and not (ci(x + 1, y, z) and ci(x - 1, y, z)
+            and ci(x, y + 1, z) and ci(x, y - 1, z)
+            and ci(x, y, z + 1) and ci(x, y, z - 1)) then
+          quads.shell = quads.shell + 1
+        end
+      end
+    end
+  end
+
+  -- u/v of a run: `n` texels starting at sprite pixel `i`, stepping along
+  -- the atlas when the run is a strip and standing still when it is flat.
+  local function uvOf(i, strip, n)
+    local x0 = sp.ax[i]
+    local y0 = sp.ay[i]
+    local x1 = strip and (x0 + n) or (x0 + 1)
+    return (x0 + 0.05) / atlasW, (x1 - 0.05) / atlasW,
+           (y0 + 0.05) / atlasH, (y0 + 1 - 0.05) / atlasH
+  end
+
+  local function put(c1, c2, c3, c4, uv, shade)
+    quads[#quads + 1] = { c1, c2, c3, c4, uv = uv, shade = shade }
+  end
+
+  -- How far a run of exposed faces reaches from `x`, and whether it is a
+  -- strip (texels marching along the atlas) or flat (one texel repeated).
+  local function runX(y, z, dx, dy, dz, x)
+    local i0 = ci(x, y, z)
+    local strip, n = nil, 1
+    while true do
+      local nx = x + n
+      local i = ci(nx, y, z)
+      if not i or ci(nx + dx, y + dy, z + dz) then break end
+      local prev = ci(nx - 1, y, z)
+      if sp.ay[i] ~= sp.ay[prev] then break end
+      local d = sp.ax[i] - sp.ax[prev]
+      if d == 1 then
+        if strip == false then break end
+        strip = true
+      elseif d == 0 then
+        if strip == true then break end
+        strip = false
+      else
+        break
+      end
+      n = n + 1
+    end
+    return i0, strip == true, n
+  end
+
+  -- ---- faces along +-Z (the facade, the roof's rims): merge along x ----
+  for _, d in ipairs({ 1, -1 }) do
+    local shade = d == 1 and SHADE.south or SHADE.north
+    for y = 0, ytop do
+      Budget.tick()
+      for z = zmin, zmax do
+        local x = 0
+        while x < W do
+          if ci(x, y, z) and not ci(x, y, z + d) then
+            local i, strip, n = runX(y, z, 0, 0, d, x)
+            local u0, u1, v0, v1 = uvOf(i, strip, n)
+            local zf = d == 1 and (z + 1) or z
+            if d == 1 then
+              put({ x, y, zf }, { x + n, y, zf },
+                  { x + n, y + 1, zf }, { x, y + 1, zf },
+                  { { u0, v1 }, { u1, v1 }, { u1, v0 }, { u0, v0 } }, shade)
+            else
+              put({ x + n, y, zf }, { x, y, zf },
+                  { x, y + 1, zf }, { x + n, y + 1, zf },
+                  { { u1, v1 }, { u0, v1 }, { u0, v0 }, { u1, v0 } }, shade)
+            end
+            x = x + n
+          else
+            x = x + 1
+          end
+        end
+      end
+    end
+  end
+
+  -- ---- faces along +-Y (roof surfaces, undersides): merge along x ----
+  for _, d in ipairs({ 1, -1 }) do
+    local shade = d == 1 and SHADE.top or SHADE.bottom
+    for y = 0, ytop do
+      Budget.tick()
+      -- the underside of the bottom layer is the ground it stands on
+      if not (d == -1 and y == 0) then
+        for z = zmin, zmax do
+          local x = 0
+          while x < W do
+            if ci(x, y, z) and not ci(x, y + d, z) then
+              local i, strip, n = runX(y, z, 0, d, 0, x)
+              local u0, u1, v0, v1 = uvOf(i, strip, n)
+              local yf = d == 1 and (y + 1) or y
+              if d == 1 then
+                put({ x, yf, z }, { x + n, yf, z },
+                    { x + n, yf, z + 1 }, { x, yf, z + 1 },
+                    { { u0, v0 }, { u1, v0 }, { u1, v1 }, { u0, v1 } }, shade)
+              else
+                put({ x, yf, z + 1 }, { x + n, yf, z + 1 },
+                    { x + n, yf, z }, { x, yf, z },
+                    { { u0, v1 }, { u1, v1 }, { u1, v0 }, { u0, v0 } }, shade)
+              end
+              x = x + n
+            else
+              x = x + 1
+            end
+          end
+        end
+      end
+    end
+  end
+
+  -- ---- faces along +-X (the flanks): merge along z, one texel each ----
+  for _, d in ipairs({ 1, -1 }) do
+    for y = 0, ytop do
+      for x = 0, W - 1 do
+        local z = zmin
+        while z <= zmax do
+          local i = ci(x, y, z)
+          if i and not ci(x + d, y, z) then
+            local n = 1
+            while z + n <= zmax do
+              local j = ci(x, y, z + n)
+              if j ~= i or ci(x + d, y, z + n) then break end
+              n = n + 1
+            end
+            local u0, u1, v0, v1 = uvOf(i, false, n)
+            local xf = d == 1 and (x + 1) or x
+            if d == 1 then
+              put({ xf, y, z + n }, { xf, y, z },
+                  { xf, y + 1, z }, { xf, y + 1, z + n },
+                  { { u0, v1 }, { u1, v1 }, { u1, v0 }, { u0, v0 } },
+                  SHADE.side)
+            else
+              put({ xf, y, z }, { xf, y, z + n },
+                  { xf, y + 1, z + n }, { xf, y + 1, z },
+                  { { u0, v1 }, { u1, v1 }, { u1, v0 }, { u0, v0 } },
+                  SHADE.side)
+            end
+            z = z + n
+          else
+            z = z + 1
+          end
+        end
+      end
+    end
+  end
+
+  return quads
+end
+
+-- ------------------------------------------------------------- placement --
+
+-- Does the template's tile grid sit at (tx, ty)?
+local function matches(S, t, tx, ty)
+  local tiles = t.tiles
+  for r = 1, #tiles do
+    local row = tiles[r]
+    for c = 1, #row do
+      if S.tileAt[keyOf(tx + c - 1, ty + r - 1)] ~= row[c] then
+        return false
+      end
+    end
+  end
+  return true
+end
+
+-- Find every placement of every template for this map's tileset, build one
+-- model per template, and stamp it. Returns nothing; the quads land in
+-- S.objectQuads and the tiles are claimed so the volume path never boxes a
+-- building this module has already modelled.
+function Buildings.build(S, map, data, perRow)
+  if not data then return end
+  local tileset = map.tileset
+  local s = profile()
+  local list = s and s.buildings and s.buildings[tileset.id]
+  if not list then return end
+
+  local atlasW = tileset.imageWidth or 128
+  local atlasH = tileset.imageHeight or 48
+  local tw, th = map.def.width * 4, map.def.height * 4
+  local quads = S.objectQuads
+
+  for index, t in ipairs(list) do
+    if type(t.tiles) == "table" and #t.tiles > 0 then
+      local bh, bw = #t.tiles, #t.tiles[1]
+      local first = t.tiles[1][1]
+      local built = nil
+      for ty = 0, th - bh do
+        Budget.tick()
+        for tx = 0, tw - bw do
+          -- A placement never stamps into cells another template already
+          -- claimed. Templates are matched independently, and one
+          -- drawing can satisfy two grids: the Pokemon Tower's upper
+          -- twelve rows on ROUTE_10 are a standard 6-cell block tile for
+          -- tile, so `gabled_block_6x6` matched there and stood a whole
+          -- second building behind the tower. First claim wins, so the
+          -- list order below is the priority order -- the tower's own
+          -- templates come first precisely so they take those cells.
+          local free = S.tileAt[keyOf(tx, ty)] == first
+          if free then
+            for r = 0, bh - 1 do
+              for c = 0, bw - 1 do
+                if S.skip[keyOf(tx + c, ty + r)] then
+                  free = false
+                  break
+                end
+              end
+              if not free then break end
+            end
+          end
+          if free and matches(S, t, tx, ty) then
+            if not built then
+              local key = tileset.id .. ":" .. index
+              if not models[key] then
+                if t.claimOnly then
+                  -- claim the cells, stamp nothing: the drawing here is
+                  -- the off-map half of a building another map models in
+                  -- full (the tower's roof rows on ROUTE_10 -- Lavender's
+                  -- placement composites them via topRows). Left to the
+                  -- detector they stood as a second half-building.
+                  models[key] = {}
+                else
+                  local sp = read(t, data, perRow)
+                  local pr = measure(sp, t)
+                  models[key] = emit(model(sp, pr, t), sp, atlasW, atlasH)
+                end
+              end
+              built = models[key]
+            end
+            Buildings.stamp(S, map, built, tx, ty, bw, bh)
+          end
+        end
+      end
+    end
+  end
+end
+
+-- One placement: claim its tiles (so the detector leaves them alone and
+-- the mesher paints ground under them) and copy the model into place.
+function Buildings.stamp(S, map, quads, tx, ty, bw, bh)
+  local shape = { class = "building", h = 0, art = "building",
+                  flat = false, authored = true }
+
+  -- the ground the building stands on: the commonest flat tile around its
+  -- feet, so a house on a path keeps its path
+  local votes, best, bestN = {}, nil, 0
+  local function vote(x, y)
+    local k = keyOf(x, y)
+    local ns = S.shapeAt[k]
+    if ns and ns.flat and ns.class ~= "void" then
+      local tile = S.tileAt[k]
+      votes[tile] = (votes[tile] or 0) + 1
+      if votes[tile] > bestN then best, bestN = tile, votes[tile] end
+    end
+  end
+  for c = 0, bw - 1 do
+    vote(tx + c, ty - 1)
+    vote(tx + c, ty + bh)
+  end
+  for r = 0, bh - 1 do
+    vote(tx - 1, ty + r)
+    vote(tx + bw, ty + r)
+  end
+
+  for r = 0, bh - 1 do
+    for c = 0, bw - 1 do
+      local k = keyOf(tx + c, ty + r)
+      S.shapeAt[k] = shape
+      S.skip[k] = true
+      S.ground[k] = best or false
+    end
+  end
+
+  local mx, mz = tx * 8, ty * 8
+  local out = S.objectQuads
+  for _, q in ipairs(quads) do
+    out[#out + 1] = {
+      { q[1][1] + mx, q[1][2], q[1][3] + mz },
+      { q[2][1] + mx, q[2][2], q[2][3] + mz },
+      { q[3][1] + mx, q[3][2], q[3][3] + mz },
+      { q[4][1] + mx, q[4][2], q[4][3] + mz },
+      uv = q.uv, shade = q.shade,
+      -- placements only ever scan the BODY, so a building is always this
+      -- map's own structure: the mesher's edge keep-rules must not eat
+      -- the parts that poke past the boundary (an edge-row house's eave
+      -- juts frontEave voxels into the neighbour's airspace, and the
+      -- neighbour-body mask read that overhang as a ring scrap -- which
+      -- opened the roof rim into the sky from across the seam)
+      own = true,
+    }
+  end
+end
+
+-- What the models built so far cost, keyed "<tileset>:<index>": the voxel
+-- and shell counts tools/building_voxels.py checks this implementation
+-- against (Stage 5 of the methodology), and the quad count that ships.
+function Buildings.stats()
+  local out = {}
+  for key, quads in pairs(models) do
+    out[key] = { voxels = quads.voxels, shell = quads.shell,
+                 quads = #quads }
+  end
+  return out
+end
+
+-- Drop the prebuilt models (hot reload, or a mod shadowing the profile).
+function Buildings.invalidate()
+  spec = nil
+  models = {}
+end
+
+return Buildings

--- a/mods/dramatic_shape/lib/ChunkMesher.lua
+++ b/mods/dramatic_shape/lib/ChunkMesher.lua
@@ -1,0 +1,1166 @@
+-- Voxel world mode: turn a map's tile layer into one static 3D mesh.
+--
+-- The scene description comes from Structures.lua, which -- 3dSen-style --
+-- detects each connected drawn thing on the map and picks its model:
+--
+--   flat      ground / water / void: a single quad.
+--   top art   ledges, roofs (profile-authored): a box with the art on its
+--             TOP face; partial side bands crop the art (a 6px ledge face
+--             is the bottom of the lip drawing).
+--   volume    walls, buildings, tree lines: each column rises to the
+--             structure's REAL drawn height (Structures measures it,
+--             repeat-aware and region-consistent -- a 6-row house is 48px,
+--             a 40-row border forest is rows of 16px trees). The south
+--             face folds the full artwork upright, 8px band by band, band
+--             k sampling the map row k tiles north; the top wears the
+--             structure's top rows.
+--   object    small props with a silhouette (plants, signs, lone trees):
+--             per-pixel voxel prisms prebuilt by Structures, standing on
+--             synthesized ground -- this mesher just emits their quads.
+--             Round trees arrive as STAMPS (a shared hull template plus a
+--             cell offset) and expand here, straight into the vertex
+--             stream, so no map retains per-cell copies of its forests.
+--
+-- Side faces are never stretched: all sides are 8px bands with the art
+-- tiled per band and cropped at partial bands.
+--
+-- Texturing samples the TILESET ATLAS, not a rendered copy of the map. The
+-- atlas is 128x48; a map-space canvas covering the biggest routes would be
+-- ~5 MB each with up to five live at once (connected maps), which is real
+-- memory on the mobile targets. Sampling the atlas costs 24 KB, and costs
+-- nothing in fidelity because TerrainAtlas hands back the same atlas
+-- TileRenderer draws with -- including the fully recolored one RED++
+-- bakes -- so terrain color comes through untouched.
+--
+-- BUILDS ARE ASYNCHRONOUS. A frame never blocks on meshing: VoxelScene
+-- requests what it wants to draw, request() queues a build job, and
+-- pump() -- called once a frame from the pipeline's update -- advances
+-- the queue inside a few-millisecond budget (BuildBudget suspends the
+-- job's coroutine mid-loop when the slice is spent). Until a mesh lands
+-- the scene simply draws without it: the engine's flat path while the
+-- current map has nothing, the body-only variant while the full one (the
+-- border ring) is still cooking, neighbours popping in as they finish.
+-- The synchronous get() remains for probes and tests.
+--
+-- Meshes are cached per map id and EVICTED down to the live set (current
+-- map + connected neighbours) whenever that set changes -- setLive()
+-- releases far maps' GPU meshes and their Structures analysis, which is
+-- what used to grow the heap by gigabytes over a cross-region trek.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local Assets = require("src.render.Assets")
+local Structures = V.require("Structures")
+local TileShape = V.require("TileShape")
+local Voxel3D = V.require("Voxel3D")
+local Budget = V.require("BuildBudget")
+
+local ffi = nil
+do
+  local ok, mod = pcall(require, "ffi")
+  if ok then ffi = mod end
+end
+
+local ChunkMesher = {}
+
+-- Ring of border blocks meshed around the body, matching the width
+-- TileRenderer draws so the two modes end at the same place.
+local RING = 3
+
+-- A sliver of a texel, to keep a quad's sampling inside its own tile.
+-- Without any inset the perspective rasteriser lands on a NEIGHBOURING
+-- tile's texel along the shared edge and stitches bright seams across the
+-- whole map.
+--
+-- It has to be a sliver and not, as it first was, half a texel. A tile is
+-- 8 texels of art across 8 world pixels -- one texel per pixel exactly --
+-- and insetting the uv by half a texel at each end squeezes that art into
+-- a 7-texel sample range while the quad still covers 8 world pixels. The
+-- art then advances 7/8 of a texel per pixel: boundaries drift off the
+-- pixel grid, one art pixel gets sampled twice and another never at all.
+-- Nothing showed it until the voxel wireframe drew the grid those pixels
+-- were supposed to be sitting on. Interpolation error is nowhere near a
+-- fiftieth of a texel, so this is as safe against bleed and costs 0.25% of
+-- a pixel of drift across a whole tile.
+local INSET = 0.02
+
+-- The south face of a volume is the artwork itself, so it draws at full
+-- brightness; its top face darkens a touch so the plateau behind a
+-- standing drawing reads as depth rather than repeating the same art at
+-- the same energy.
+local VOLUME_TOP_SHADE = 0.85
+
+local cache = {}     -- map id -> { full = mesh|false, body = ..., grass = ... }
+local gen = {}       -- map id -> generation, bumped by invalidate/evict
+
+-- Horizontal neighbours: tile step, face direction id (see Voxel3D).
+local SIDES = {
+  { 1, 0, 1 },    -- +X east
+  { -1, 0, 2 },   -- -X west
+  { 0, 1, 5 },    -- +Z south
+  { 0, -1, 6 },   -- -Z north
+}
+
+local function keyOf(tx, ty)
+  return (ty + 64) * 4096 + (tx + 64)
+end
+
+-- ------------------------------------------------------------ vertex sinks
+
+-- A sink accepts quads (4 corners, 4 uv pairs, flat or per-corner shade)
+-- and finishes into a drawable mesh. The TABLE sink reproduces the
+-- historical pure-Lua output -- geometry() returns its arrays for the
+-- headless suite. The FFI sink packs the same six floats per vertex
+-- straight into one growing native buffer, unindexed (v1 v2 v3 v1 v3 v4),
+-- skipping ~a million short-lived Lua tables per route and LOVE's slow
+-- table-by-table vertex upload.
+
+local function newTableSink()
+  local verts, indices, quads = {}, {}, 0
+  return {
+    push = function(c, uv, shade)
+      local flat = type(shade) ~= "table"
+      for i = 1, 4 do
+        local cc, t = c[i], uv[i]
+        verts[#verts + 1] = { cc[1], cc[2], cc[3], t[1], t[2],
+                              flat and shade or shade[i] }
+      end
+      Voxel3D.pushQuad(indices, quads)
+      quads = quads + 1
+    end,
+    results = function()
+      return verts, indices, quads
+    end,
+    finish = function()
+      return Voxel3D.newMesh(verts, indices)
+    end,
+  }
+end
+
+local TRI_ORDER = { 1, 2, 3, 1, 3, 4 }
+
+local function newFfiSink()
+  local cap = 4096 * 6
+  local buf = ffi.new("float[?]", cap * 6)
+  local n = 0
+  local sink
+  sink = {
+    push = function(c, uv, shade)
+      if n + 6 > cap then
+        local grown = ffi.new("float[?]", cap * 2 * 6)
+        ffi.copy(grown, buf, n * 6 * 4)
+        buf, cap = grown, cap * 2
+      end
+      local flat = type(shade) ~= "table"
+      local base = n * 6
+      for k = 1, 6 do
+        local i = TRI_ORDER[k]
+        local cc, t = c[i], uv[i]
+        buf[base] = cc[1]
+        buf[base + 1] = cc[2]
+        buf[base + 2] = cc[3]
+        buf[base + 3] = t[1]
+        buf[base + 4] = t[2]
+        buf[base + 5] = flat and shade or shade[i]
+        base = base + 6
+      end
+      n = n + 6
+    end,
+    finish = function()
+      if n == 0 then return nil end
+      -- upload in slices with budget ticks between: a route-sized mesh
+      -- is ~10-20MB and one atomic setVertices was the last remaining
+      -- frame spike. The mesh is not cached (so never drawn) until the
+      -- whole upload lands, and LuaJIT yields fine across pcall.
+      local ok, mesh = pcall(function()
+        local m = love.graphics.newMesh(Voxel3D.FORMAT, n,
+                                        "triangles", "static")
+        local CHUNK = 65536              -- vertices per slice (~1.5MB)
+        local i = 0
+        while i < n do
+          local count = math.min(CHUNK, n - i)
+          local bytes = count * 6 * 4
+          local data = love.data.newByteData(bytes)
+          ffi.copy(data:getFFIPointer(), buf + i * 6, bytes)
+          m:setVertices(data, i + 1)
+          data:release()
+          i = i + count
+          Budget.check()
+        end
+        return m
+      end)
+      return ok and mesh or nil
+    end,
+  }
+  return sink
+end
+
+local function newSink()
+  if ffi and love and love.data and love.data.newByteData
+     and love.graphics and love.graphics.newMesh then
+    return newFfiSink()
+  end
+  return newTableSink()
+end
+
+-- -------------------------------------------------------------- geometry
+
+-- Emit the raw geometry for `map` into `sink`. `bodyOnly` skips the
+-- border ring -- the shape the 2D path's drawMapOnly has always had: a
+-- neighbour map contributes its body, and only the CURRENT map supplies
+-- the ring around the view.
+--
+-- `masks` (full variant only) lists rectangles, in this map's world
+-- pixels, where connected neighbour BODIES sit: ring geometry inside them
+-- is suppressed. The 2D renderer never needed this because it painted
+-- neighbour bodies OVER the ring; with a depth buffer the ring's standing
+-- trees would rise straight through the neighbour's flat ground -- cross
+-- into Route 1 and a wall of border trees sprouts over Pallet.
+--
+-- Kept free of any GPU call so it can be exercised headless -- the
+-- geometry is the part with the interesting invariants, and a suite that
+-- needed a real GL context to check them would never run in CI.
+local function runGeometry(map, bodyOnly, masks, sink)
+  local push = sink.push
+  local tileset = map.tileset
+  local S = Structures.forMap(map)
+  local perRow = tileset.tilesPerRow or 16
+  local atlasW = tileset.imageWidth or (perRow * 8)
+  local atlasH = tileset.imageHeight or 48
+
+  local function heightAt(tx, ty)
+    local k = keyOf(tx, ty)
+    if S.skip[k] then return 0 end
+    local run = S.runs[k]
+    if run then return run.h end
+    local s = S.shapeAt[k]
+    return s and s.h or 0
+  end
+
+  -- one atlas-rect UV, optionally cropped to art rows [vTop, vBot] of 8
+  local function uvRect(tile, vTop, vBot)
+    local ax = (tile % perRow) * 8
+    local ay = math.floor(tile / perRow) * 8
+    local vi = math.min(INSET, (vBot - vTop) / 4)
+    return (ax + INSET) / atlasW, (ax + 8 - INSET) / atlasW,
+           (ay + vTop + vi) / atlasH, (ay + vBot - vi) / atlasH
+  end
+
+  -- ------------------------------------------------------ ambient occlusion
+  --
+  -- Ambient light is what reaches a surface from the sky at large, so it is
+  -- blocked by how much geometry crowds a point rather than by where the
+  -- sun happens to be -- which makes it the exact complement of the shadow
+  -- pass, and the reason both are worth having. The shadow map draws the
+  -- long directional shadow a building throws; this draws the dark seam in
+  -- every corner the sky cannot see into, at every scale finer than a
+  -- shadow map texel.
+  --
+  -- Baked per vertex, the classic voxel way: each corner counts the
+  -- neighbours that crowd it and steps down once per neighbour, and the
+  -- rasteriser interpolates the steps into a smooth falloff. Costs exactly
+  -- nothing at draw time, and it is resolution-independent -- a screen
+  -- space pass would blur across the pixel grid this whole mode is built
+  -- to keep crisp.
+  --
+  -- (What was here before was a one-directional contact shadow keyed to a
+  -- sun in the northwest: two neighbours, one corner, top faces only.)
+
+  -- Intensity. Both terms below are DARKENING amounts rather than
+  -- multipliers, so this one number scales the whole effect: 1.0 is the
+  -- barely-there first cut, and everything is expressed against it.
+  local AO_STRENGTH = 2.4
+  local AO_STEP = 0.09 * AO_STRENGTH      -- per crowding neighbour, max 3
+  local AO_EDGE = 1 - 0.14 * AO_STRENGTH  -- creases / corners on a face
+  local AO_GROUND = 0.12 * AO_STRENGTH    -- a prop's contact with the floor
+  local AO_RISE = 6                       -- px over which the floor lets go
+  local AO_FLOOR = 0.25                   -- never let a vertex reach black
+
+  -- Both sinks copy a per-corner shade straight out into the vertex stream
+  -- and keep no reference, so these two scratch rows are reused for every
+  -- quad on the map rather than allocating a table per face -- a route
+  -- builds a few hundred thousand of them.
+  local aoTop = { 0, 0, 0, 0 }
+  local aoSide = { 0, 0, 0, 0 }
+
+  -- A top face's four corners, each occluded by the three cells that touch
+  -- it: two edge neighbours and the diagonal between them.
+  local function aoShades(tx, ty, h, shade)
+    local n = heightAt(tx, ty - 1) > h
+    local s = heightAt(tx, ty + 1) > h
+    local e = heightAt(tx + 1, ty) > h
+    local w = heightAt(tx - 1, ty) > h
+    local nw = heightAt(tx - 1, ty - 1) > h
+    local ne = heightAt(tx + 1, ty - 1) > h
+    local sw = heightAt(tx - 1, ty + 1) > h
+    local se = heightAt(tx + 1, ty + 1) > h
+    if not (n or s or e or w or nw or ne or sw or se) then return shade end
+    local function corner(a, b, d)
+      local k = 0
+      if a then k = k + 1 end
+      if b then k = k + 1 end
+      -- a diagonal wedged behind both of its edges adds nothing: the
+      -- corner is already as enclosed as it can get, and counting it
+      -- again is what turns an ordinary inside corner black
+      if d and not (a and b) then k = k + 1 end
+      -- floored, so cranking AO_STRENGTH deepens the seams instead of
+      -- punching holes of pure black through the world
+      return shade * math.max(AO_FLOOR, 1 - AO_STEP * k)
+    end
+    -- corners in topQuad order: NW, NE, SE, SW
+    aoTop[1], aoTop[2] = corner(n, w, nw), corner(n, e, ne)
+    aoTop[3], aoTop[4] = corner(s, e, se), corner(s, w, sw)
+    return aoTop
+  end
+
+  -- The same idea on an upright face, where the crowding is of two kinds:
+  -- the CREASE it rises out of (the band sitting on the ground, or on
+  -- whatever lower neighbour exposed the face) and the INSIDE CORNERS
+  -- where the columns flanking it stand proud of the band. `hl`/`hr` are
+  -- those flanking heights in FACE order -- left then right as seen from
+  -- outside, per LATERAL below -- so the shades line up with sideQuad's
+  -- corners without the caller thinking about compass directions.
+  local LATERAL = {
+    [1] = { 0, 1, 0, -1 },    -- east face:  left south, right north
+    [2] = { 0, -1, 0, 1 },    -- west face:  left north, right south
+    [5] = { -1, 0, 1, 0 },    -- south face: left west,  right east
+    [6] = { 1, 0, -1, 0 },    -- north face: left east,  right west
+  }
+  -- Ground contact for the prebuilt prop quads -- the per-pixel plants,
+  -- signs and lone trees, and the round-tree stamps. Those arrive from
+  -- Structures already finished, so the neighbour counting above has no
+  -- columns to count. What it CAN say is that the ground plane itself
+  -- blocks half the sky, so the closer a voxel sits to it the less ambient
+  -- light reaches it -- which is what plants a prop on the floor instead
+  -- of leaving it looking pasted over the top.
+  local aoProp = { 0, 0, 0, 0 }
+  local function groundShades(c, shade)
+    if type(shade) == "table" then return shade end
+    local y1, y2, y3, y4 = c[1][2], c[2][2], c[3][2], c[4][2]
+    if math.min(y1, y2, y3, y4) >= AO_RISE then return shade end
+    for i = 1, 4 do
+      local t = c[i][2] / AO_RISE
+      aoProp[i] = shade * (t >= 1 and 1 or (1 - AO_GROUND * (1 - t)))
+    end
+    return aoProp
+  end
+
+  local AO_CORNER = math.max(AO_FLOOR, AO_EDGE * AO_EDGE)  -- crease AND flank
+  local function sideShades(hl, hr, y0, y1, crease, shade)
+    if not (crease or hl > y0 or hr > y0) then return shade end
+    -- corners run bottom-left, bottom-right, top-right, top-left
+    local base = crease and AO_EDGE or 1
+    aoSide[1] = shade * (hl > y0 and (crease and AO_CORNER or AO_EDGE) or base)
+    aoSide[2] = shade * (hr > y0 and (crease and AO_CORNER or AO_EDGE) or base)
+    aoSide[3] = shade * (hr > y1 and AO_EDGE or 1)
+    aoSide[4] = shade * (hl > y1 and AO_EDGE or 1)
+    return aoSide
+  end
+
+  local function topQuad(x0, z0, h, tile, shade)
+    local u0, u1, v0, v1 = uvRect(tile, 0, 8)
+    push({ { x0, h, z0 }, { x0 + 8, h, z0 },
+           { x0 + 8, h, z0 + 8 }, { x0, h, z0 + 8 } },
+         { { u0, v0 }, { u1, v0 }, { u1, v1 }, { u0, v1 } },
+         aoShades(x0 / 8, z0 / 8, h, shade))
+  end
+
+  -- vertical quad for face direction `d` of the tile column at (x0, z0),
+  -- spanning heights [y0, y1] and showing art rows [vTop, vBot] of `tile`.
+  -- Corners run bottom-left, bottom-right, top-right, top-left as seen
+  -- from outside; u follows +X on the north/south faces so a door or sign
+  -- never draws mirrored.
+  local function sideQuad(d, x0, z0, y0, y1, tile, vTop, vBot, shade)
+    local x1, z1 = x0 + 8, z0 + 8
+    local c
+    if d == 5 then                                       -- south, at z1
+      c = { { x0, y0, z1 }, { x1, y0, z1 }, { x1, y1, z1 }, { x0, y1, z1 } }
+    elseif d == 6 then                                   -- north, at z0
+      c = { { x1, y0, z0 }, { x0, y0, z0 }, { x0, y1, z0 }, { x1, y1, z0 } }
+    elseif d == 1 then                                   -- east, at x1
+      c = { { x1, y0, z1 }, { x1, y0, z0 }, { x1, y1, z0 }, { x1, y1, z1 } }
+    else                                                 -- west, at x0
+      c = { { x0, y0, z0 }, { x0, y0, z1 }, { x0, y1, z1 }, { x0, y1, z0 } }
+    end
+    local u0, u1, v0, v1 = uvRect(tile, vTop, vBot)
+    push(c, { { u0, v1 }, { u1, v1 }, { u1, v0 }, { u0, v0 } }, shade)
+  end
+
+  local def = map.def
+  local tw, th = def.width * 4, def.height * 4         -- map size in tiles
+  local r = bodyOnly and 0 or RING * 4
+
+  -- true when the (ring) position lies under a connected neighbour's body
+  local function masked(px0, pz0, px1, pz1)
+    if not masks then return false end
+    for _, mk in ipairs(masks) do
+      if px1 > mk[1] and px0 < mk[3] and pz1 > mk[2] and pz0 < mk[4] then
+        return true
+      end
+    end
+    return false
+  end
+
+  -- The inclusive variant for OBJECT quads: a quad TOUCHING a neighbour
+  -- body counts as under it. The old test took the quad's center with
+  -- strict bounds, and a quad whose center sat exactly on the body's
+  -- edge line escaped the mask -- stringing stray pixel fragments of
+  -- otherwise-dropped border trees along every map seam.
+  local function maskedClosed(px0, pz0, px1, pz1)
+    if not masks then return false end
+    for _, mk in ipairs(masks) do
+      if px1 >= mk[1] and px0 <= mk[3] and pz1 >= mk[2] and pz0 <= mk[4] then
+        return true
+      end
+    end
+    return false
+  end
+
+  for ty = -r, th + r - 1 do
+    for tx = -r, tw + r - 1 do
+      Budget.tick()
+      local k = keyOf(tx, ty)
+      local s, tile = S.shapeAt[k], S.tileAt[k]
+      local inBody = tx >= 0 and ty >= 0 and tx < tw and ty < th
+      if not inBody and masked(tx * 8, ty * 8, tx * 8 + 8, ty * 8 + 8) then
+        s = nil
+      end
+
+      -- Under the TREES fill the border wall is MODELLED or it is not there
+      -- (see Structures' hullRingOnly): a ring cell nothing claimed would
+      -- be a flat-topped box standing beside carved trunks, which reads as
+      -- a painted-on plateau rather than forest. Structures already stops
+      -- the ring at the carve distance; this catches the odd cell inside it
+      -- that the 2x2 grouping could not take -- a canopy whose partners
+      -- fall outside the shortened ring is left unclaimed, and one strip of
+      -- boxes along an edge is the whole artefact this avoids.
+      if not inBody and S.hideBareRing and not S.skip[k] then
+        s = nil
+      end
+
+      if s and S.skip[k] then
+        -- an object stands here; paint its synthesized ground and let the
+        -- prebuilt prism quads (appended below) carry the art
+        local g = S.ground[k]
+        if g then
+          topQuad(tx * 8, ty * 8, 0, g, 1)
+          -- the claimed tile is still ground at height 0, and water next
+          -- door still recesses below it: without the same below-ground
+          -- side bands ordinary ground emits, the two-pixel shoreline
+          -- face is a slit into the sky behind the mesh -- which is
+          -- exactly what a building plot or a sign standing at the
+          -- waterline showed. Same bands, cut from the synthesized
+          -- ground's own art
+          for _, side in ipairs(SIDES) do
+            local nh = heightAt(tx + side[1], ty + side[2])
+            if nh < 0 then
+              local d = side[3]
+              local lat = LATERAL[d]
+              local hl = lat and heightAt(tx + lat[1], ty + lat[2]) or 0
+              local hr = lat and heightAt(tx + lat[3], ty + lat[4]) or 0
+              for band = math.floor(nh / 8), -1 do
+                local y0 = math.max(nh, band * 8)
+                local y1 = math.min(0, band * 8 + 8)
+                if y1 > y0 then
+                  sideQuad(d, tx * 8, ty * 8, y0, y1, g,
+                           (band * 8 + 8) - y1, (band * 8 + 8) - y0,
+                           sideShades(hl, hr, y0, y1, y0 <= nh,
+                                      Voxel3D.FACE_SHADE[d]))
+                end
+              end
+            end
+          end
+        end
+      elseif s then
+        local run = S.runs[k]
+        local h = run and run.h or s.h
+        local x0, z0 = tx * 8, ty * 8
+
+        -- top face. A roofed volume gets a GABLE segment: the roof rises
+        -- from the facade top at the south eave to a ridge across the
+        -- footprint's middle, then falls back to the facade at the north
+        -- edge -- so the far side sits LOW. (The first cut was a shed
+        -- plane rising all the way north, which turns a building into a
+        -- ramp.) The south slope wears the structure's roof rows (ridge
+        -- art at the ridge, eaves art at the eave); the back slope
+        -- mirrors them. Exposed east/west flanks hip: their outer edge
+        -- drops toward the eave, rounding the drawn corner tiles into 45
+        -- degree corners. Flat-topped volumes wear their top rows;
+        -- everything else its own art.
+        if run and run.rise > 0 then
+          local mid = run.extent / 2
+          local function gableH(d)     -- d = rows north of the south eave
+            local t = d <= mid and d / mid or (run.extent - d) / (run.extent - mid)
+            return run.h + run.rise * math.max(0, math.min(1, t))
+          end
+          local d0 = run.front - ty                -- rows from the south edge
+          local hS = gableH(d0)
+          local hN = gableH(d0 + 1)
+          -- art by proximity to the ridge, mirrored over the back
+          local rel = 1 - math.abs(d0 + 0.5 - mid) / math.max(mid, 0.5)
+          local idx = math.min(run.roofRows - 1,
+                               math.floor((1 - rel) * run.roofRows))
+          local roofTile = map:tileAt(tx, run.north + idx)
+          local swY, seY, neY, nwY = hS, hS, hN, hN
+          if heightAt(tx - 1, ty) < run.h then     -- west flank: hip
+            swY = math.max(run.h, hS - 8)
+            nwY = math.max(run.h, hN - 8)
+          end
+          if heightAt(tx + 1, ty) < run.h then     -- east flank: hip
+            seY = math.max(run.h, hS - 8)
+            neY = math.max(run.h, hN - 8)
+          end
+          local u0, u1, v0, v1 = uvRect(roofTile, 0, 8)
+          push({ { x0, swY, z0 + 8 }, { x0 + 8, seY, z0 + 8 },
+                 { x0 + 8, neY, z0 }, { x0, nwY, z0 } },
+               { { u0, v1 }, { u1, v1 }, { u1, v0 }, { u0, v0 } }, 0.95)
+        elseif run then
+          local m = math.min(2, run.extent)
+          local topTile = map:tileAt(tx, run.north + ((ty - run.north) % m))
+          topQuad(x0, z0, h, topTile, VOLUME_TOP_SHADE)
+        else
+          local topTile = tile
+          if s.art == "upright" and s.authored then
+            -- Top art for a pinned box.  A furniture drawing is top-view
+            -- rows over floor(h/8) face-on rows the fold stands upright;
+            -- a face row's top would repeat its front art lying flat, so
+            -- it wears the nearest row above the face block instead --
+            -- the drawn tabletop (and whatever sits on it) stays on top,
+            -- and a fully-folded structure (wall, desk) tops with its
+            -- northmost row.
+            local north, front = ty, ty
+            while ty - north < 6 do
+              local bs = S.shapeAt[keyOf(tx, north - 1)]
+              if bs and bs.authored and bs.class == s.class then
+                north = north - 1
+              else
+                break
+              end
+            end
+            while front - ty < 6 do
+              local bs = S.shapeAt[keyOf(tx, front + 1)]
+              if bs and bs.authored and bs.class == s.class then
+                front = front + 1
+              else
+                break
+              end
+            end
+            local row = math.min(ty, front - math.floor(h / 8))
+            if row < north then
+              -- the whole run folded onto the face: top with the drawn
+              -- row just above it when that row is furniture too (a
+              -- bookcase wearing its shelf-top trim), else with the
+              -- run's own top row
+              local above = S.shapeAt[keyOf(tx, north - 1)]
+              row = (above and above.authored and above.art == "upright")
+                    and (north - 1) or north
+            end
+            topTile = S.tileAt[keyOf(tx, row)]
+          end
+          topQuad(x0, z0, h, topTile,
+                  s.art == "upright" and VOLUME_TOP_SHADE or 1)
+        end
+
+        -- sides: 8px bands wherever the neighbour is lower. Band k spans
+        -- heights [8k, 8k+8) and shows one full tile of art; a partial
+        -- band crops the art rows to match, so nothing ever stretches.
+        for _, side in ipairs(SIDES) do
+          local nh = heightAt(tx + side[1], ty + side[2])
+          if nh < h then
+            local d = side[3]
+            -- the columns flanking this face, for the inside-corner term:
+            -- fixed for the whole face, so they are read once rather than
+            -- once per 8px band
+            local lat = LATERAL[d]
+            local hl = lat and heightAt(tx + lat[1], ty + lat[2]) or 0
+            local hr = lat and heightAt(tx + lat[3], ty + lat[4]) or 0
+            for band = math.floor(nh / 8), math.ceil(h / 8) - 1 do
+              local y0 = math.max(nh, band * 8)
+              local y1 = math.min(h, band * 8 + 8)
+              if y1 > y0 then
+                local src, shade = tile, Voxel3D.FACE_SHADE[d]
+                if run then
+                  -- fold the structure's artwork up this face: band k
+                  -- samples the map row k tiles north of the structure's
+                  -- front, clamped to its extent. The south face is the
+                  -- drawing itself (full brightness); the other sides wear
+                  -- the same rows darkened, so a building's flank matches
+                  -- its face instead of smearing one tile
+                  if d == 6 then
+                    src = map:tileAt(tx, math.min(run.front,
+                                                  run.north + band))
+                  else
+                    src = map:tileAt(tx, math.max(run.north,
+                                                  run.front - band))
+                  end
+                  if d == 5 then shade = 1 end
+                elseif s.art == "upright" then
+                  -- profile-authored upright (a pinned wall or furniture
+                  -- box): fold the drawing up the face, band 0 the
+                  -- structure's southmost same-class row and higher bands
+                  -- the rows north of it, repeating past the top.  The
+                  -- south face is the drawing itself (full brightness);
+                  -- flanks and back wear the same front stack darkened, so
+                  -- a desk's side matches its face instead of smearing a
+                  -- different jumble per row.
+                  if d == 5 then shade = 1 end
+                  local front = ty
+                  while front < ty + 6 do
+                    local fs2 = S.shapeAt[keyOf(tx, front + 1)]
+                    if fs2 and fs2.authored and fs2.class == s.class then
+                      front = front + 1
+                    else
+                      break
+                    end
+                  end
+                  local fk = keyOf(tx, front - band)
+                  local fs = S.shapeAt[fk]
+                  if fs and fs.authored and fs.class == s.class then
+                    src = S.tileAt[fk]
+                  end
+                end
+                sideQuad(d, x0, z0, y0, y1, src,
+                         (band * 8 + 8) - y1, (band * 8 + 8) - y0,
+                         sideShades(hl, hr, y0, y1, y0 <= nh, shade))
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  -- Prebuilt quads from Structures (per-pixel voxel props, lathed
+  -- columns) plus the round-tree stamps expanded in place. Keep rules,
+  -- by the quad's own extent:
+  --   body-only   the quad must overlap the OPEN body interval -- a
+  --               neighbour's ring props must not march past its edge
+  --               into this map, and a quad lying exactly ON the edge
+  --               plane would z-fight the map that owns that plane.
+  --   full        anything overlapping the body stays whole (props that
+  --               straddle the edge no longer shed their outer half);
+  --               pure ring quads drop when they touch a neighbour body
+  --               (maskedClosed), which is what strings of seam pixels
+  --               were: fragments of dropped border trees whose centers
+  --               sat exactly on the boundary line.
+  local bw, bh = tw * 8, th * 8
+  local function keepQuad(x0, z0, x1, z1)
+    local overBody = x1 > 0 and x0 < bw and z1 > 0 and z0 < bh
+    if bodyOnly then return overBody end
+    return overBody or not maskedClosed(x0, z0, x1, z1)
+  end
+
+  -- A face lying EXACTLY on a body boundary plane is ambiguous to the
+  -- rect tests above: a body structure's outward facade (a Saffron row
+  -- house whose front row is the map's last row, its south wall on the
+  -- shared plane with Route 6) and the inward face of a ring scrap
+  -- occupy the same degenerate rect, and the strict overBody plus the
+  -- closed mask dropped BOTH -- which is why those facades were missing.
+  -- The winding tells them apart: a face pointing AWAY from the body
+  -- belongs to this map's own edge-row structure and nothing in the
+  -- neighbour will ever draw that plane, so it stays; a face pointing
+  -- INTO the body is the scrap the mask rules exist to kill, and falls
+  -- through to them.
+  local function outwardOnEdge(q, x0, z0, x1, z1)
+    if z0 == z1 and (z0 == 0 or z0 == bh) and x1 > 0 and x0 < bw then
+      local nz = (q[2][1] - q[1][1]) * (q[3][2] - q[1][2])
+                 - (q[2][2] - q[1][2]) * (q[3][1] - q[1][1])
+      return (z0 == bh and nz > 0) or (z0 == 0 and nz < 0)
+    end
+    if x0 == x1 and (x0 == 0 or x0 == bw) and z1 > 0 and z0 < bh then
+      local nx = (q[2][2] - q[1][2]) * (q[3][3] - q[1][3])
+                 - (q[2][3] - q[1][3]) * (q[3][2] - q[1][2])
+      return (x0 == bw and nx > 0) or (x0 == 0 and nx < 0)
+    end
+    return false
+  end
+
+  local scUV = { { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 } }
+  local function quadUV(q)
+    if q.uv then return q.uv end
+    for i = 1, 4 do
+      scUV[i][1], scUV[i][2] = q.u, q.v
+    end
+    return scUV
+  end
+
+  for _, q in ipairs(S.objectQuads) do
+    Budget.tick()
+    local x0 = math.min(q[1][1], q[2][1], q[3][1], q[4][1])
+    local x1 = math.max(q[1][1], q[2][1], q[3][1], q[4][1])
+    local z0 = math.min(q[1][3], q[2][3], q[3][3], q[4][3])
+    local z1 = math.max(q[1][3], q[2][3], q[3][3], q[4][3])
+    -- q.own: a body-anchored structure's own quad (a building placed by
+    -- Buildings.build, whose scan never leaves the body). Exempt from
+    -- the edge keep-rules entirely: its eave legitimately overhangs the
+    -- boundary plane into the neighbour's airspace, and no variant of
+    -- the neighbour will ever draw that geometry
+    if q.own or outwardOnEdge(q, x0, z0, x1, z1)
+       or keepQuad(x0, z0, x1, z1) then
+      push({ q[1], q[2], q[3], q[4] }, quadUV(q), groundShades(q, q.shade))
+    end
+  end
+
+  -- true when the rect sits entirely inside one neighbour-body rect
+  local function containedInMask(x0, z0, x1, z1)
+    if not masks then return false end
+    for _, mk in ipairs(masks) do
+      if x0 >= mk[1] and x1 <= mk[3] and z0 >= mk[2] and z1 <= mk[4] then
+        return true
+      end
+    end
+    return false
+  end
+
+  -- round-tree stamps: the shared hull template translated per cell,
+  -- through reusable scratch corners so expansion allocates nothing.
+  -- A hull spans at most its own footprint -- one 16px cell unless the
+  -- stamp carries a wider radius (the 2x2-cell canopy groups) -- so one
+  -- rect test usually answers for the whole stamp: strictly interior
+  -- stamps keep every quad, ring stamps buried under a neighbour body
+  -- (or, body-only, ring stamps full stop) skip without touching their
+  -- quads. Only stamps crossing a boundary walk quad by quad.
+  local sc = { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } }
+  for _, st in ipairs(S.roundStamps or {}) do
+    local mx, mz = st.mx, st.mz
+    local sr = st.r or 8
+    local sx0, sz0, sx1, sz1 = mx - sr, mz - sr, mx + sr, mz + sr
+    local interior = sx0 > 0 and sx1 < bw and sz0 > 0 and sz1 < bh
+    local overBody = sx1 > 0 and sx0 < bw and sz1 > 0 and sz0 < bh
+    local keepAll, skipAll
+    if bodyOnly then
+      keepAll = interior
+      skipAll = not overBody
+    else
+      keepAll = interior or not maskedClosed(sx0, sz0, sx1, sz1)
+      skipAll = not overBody and containedInMask(sx0, sz0, sx1, sz1)
+    end
+    if not skipAll then
+      for _, q in ipairs(st.quads) do
+        Budget.tick()
+        for i = 1, 4 do
+          local c, s2 = q[i], sc[i]
+          s2[1] = c[1] + mx
+          s2[2] = c[2]
+          s2[3] = c[3] + mz
+        end
+        local ok = keepAll
+        if not ok then
+          local x0 = math.min(sc[1][1], sc[2][1], sc[3][1], sc[4][1])
+          local x1 = math.max(sc[1][1], sc[2][1], sc[3][1], sc[4][1])
+          local z0 = math.min(sc[1][3], sc[2][3], sc[3][3], sc[4][3])
+          local z1 = math.max(sc[1][3], sc[2][3], sc[3][3], sc[4][3])
+          ok = keepQuad(x0, z0, x1, z1)
+        end
+        if ok then
+          push(sc, quadUV(q), groundShades(sc, q.shade))
+        end
+      end
+    end
+  end
+end
+
+-- The raw geometry for `map`: (vertex list, triangle index list, quad
+-- count). Synchronous and GPU-free -- the headless suite and the probes
+-- exercise the invariants through this.
+function ChunkMesher.geometry(map, bodyOnly, masks)
+  local sink = newTableSink()
+  runGeometry(map, bodyOnly, masks, sink)
+  return sink.results()
+end
+
+-- Build the mesh for `map` synchronously. Returns nil when there is
+-- nothing to draw or meshes are unavailable (headless).
+function ChunkMesher.build(map, bodyOnly, masks)
+  local sink = newSink()
+  runGeometry(map, bodyOnly, masks, sink)
+  return sink.finish()
+end
+
+local function quadsMesh(quads)
+  if #quads == 0 then return nil end
+  local verts, indices, n = {}, {}, 0
+  for _, q in ipairs(quads) do
+    for i = 1, 4 do
+      local c = q[i]
+      local uv = q.uv and q.uv[i] or { q.u, q.v }
+      verts[#verts + 1] = { c[1], c[2], c[3], uv[1], uv[2], q.shade }
+    end
+    Voxel3D.pushQuad(indices, n)
+    n = n + 1
+  end
+  return Voxel3D.newMesh(verts, indices)
+end
+
+-- The tall-grass rows as their own mesh: VoxelScene draws it AFTER the
+-- characters so the southern row of a grass cell still overdraws a
+-- walker's feet (characters stamp over terrain, Gen 1 style, so ordinary
+-- terrain could never do this).
+local function buildGrassMesh(map)
+  return quadsMesh(Structures.forMap(map).grassQuads)
+end
+
+-- The flower billboards as their own mesh, for the same reason as the
+-- grass one: it draws AFTER the characters WITH the same camera-ward
+-- pull, so a flower south of a walker occludes their feet and one north
+-- of them hides behind them. Baked into the terrain mesh they lost that
+-- depth fight against the pulled character card whenever the player
+-- stood among flowers. Unlike grass this mesh still CASTS shadows (the
+-- sun pass draws it): a handful of flowers per meadow, not thousands of
+-- tufts.
+local function buildFlowerMesh(map)
+  return quadsMesh(Structures.forMap(map).flowerQuads)
+end
+
+-- Authored FIGURES (a person drawn into furniture) as one mesh each, in
+-- the card's own local space -- because each one is placed by its own
+-- matrix at draw time, leaned back by the camera pitch exactly like a
+-- character card (VoxelScene). A figure baked into the terrain mesh could
+-- not lean, and a shared mesh could not carry per-figure placement.
+--
+-- A list, not a mesh: `{ mesh, wx, wz, y }` per figure. Maps have one or
+-- none, so the loop that draws them is shorter than the terrain's.
+local function buildFigureMeshes(map)
+  local out = {}
+  for _, f in ipairs(Structures.forMap(map).figures or {}) do
+    local mesh = quadsMesh(f.quads)
+    if mesh then
+      out[#out + 1] = { mesh = mesh, wx = f.wx, wz = f.wz, y = f.y }
+    end
+  end
+  return out
+end
+
+-- Figure lists hold their meshes one level down, so the generic slot
+-- release cannot reach them.
+local function releaseFigures(list)
+  for _, f in ipairs(type(list) == "table" and list or {}) do
+    if f.mesh and f.mesh.release then pcall(f.mesh.release, f.mesh) end
+  end
+end
+
+-- Replace a cached slot, releasing whatever mesh it held.
+local function swapSlot(c, slot, mesh)
+  local old = c[slot]
+  if old and old ~= mesh and old.release then pcall(old.release, old) end
+  c[slot] = mesh
+end
+
+-- ------------------------------------------------------------- the cache
+
+local function entry(id)
+  local c = cache[id]
+  if not c then
+    c = {}
+    cache[id] = c
+  end
+  return c
+end
+
+local function releaseEntry(c)
+  for _, slot in ipairs({ "full", "body", "grass", "flowers" }) do
+    local mesh = c[slot]
+    if mesh and mesh.release then pcall(mesh.release, mesh) end
+    c[slot] = nil
+  end
+  releaseFigures(c.figures)
+  c.figures = nil
+  c.stale = nil
+end
+
+-- ---------------------------------------------------------- async builds
+
+local jobs = {}       -- FIFO of pending jobs
+local jobIndex = {}   -- "id:slot" -> job
+
+local clock = (love and love.timer and love.timer.getTime) or os.clock
+
+local function jobKey(id, slot)
+  return id .. ":" .. slot
+end
+
+local function finishJob(job, ok, err)
+  jobIndex[jobKey(job.id, job.slot)] = nil
+  for i, j in ipairs(jobs) do
+    if j == job then
+      table.remove(jobs, i)
+      break
+    end
+  end
+  if not ok then
+    -- name the reason: in a real session a lost build is a black map
+    print("[warn] voxel mesh build failed for " .. tostring(job.id)
+          .. ": " .. tostring(err))
+    if (gen[job.id] or 0) == job.gen then
+      entry(job.id)[job.slot] = false
+    end
+  end
+end
+
+-- A build only lands if the map's generation still matches the one the
+-- job was queued under -- invalidate/evict bump it to cancel in-flight
+-- work whose inputs went stale.
+local function runJob(job)
+  local map = job.map
+  local c = entry(job.id)
+  if c.grass == nil or c.flowers == nil or c.figures == nil
+     or (c.stale and c.stale.aux) then
+    local okG, grass = pcall(buildGrassMesh, map)
+    local okF, flowers = pcall(buildFlowerMesh, map)
+    local okX, figures = pcall(buildFigureMeshes, map)
+    if (gen[job.id] or 0) ~= job.gen then
+      if okG and grass and grass.release then pcall(grass.release, grass) end
+      if okF and flowers and flowers.release then
+        pcall(flowers.release, flowers)
+      end
+      if okX then releaseFigures(figures) end
+      return
+    end
+    swapSlot(c, "grass", (okG and grass) or false)
+    swapSlot(c, "flowers", (okF and flowers) or false)
+    releaseFigures(c.figures)
+    c.figures = (okX and figures) or false
+    if c.stale then c.stale.aux = nil end
+  end
+  local sink = newSink()
+  runGeometry(map, job.slot == "body", job.masks, sink)
+  local mesh = sink.finish()
+  if (gen[job.id] or 0) ~= job.gen then
+    if mesh and mesh.release then pcall(mesh.release, mesh) end
+    return
+  end
+  swapSlot(c, job.slot, mesh or false)
+  if c.stale then
+    c.stale[job.slot] = nil
+    if not (c.stale.full or c.stale.body or c.stale.aux) then
+      c.stale = nil
+    end
+  end
+end
+
+-- Queue a build unless the slot is already cached or queued. Returns the
+-- cached mesh when there is one (false-cached misses return nil).
+-- `urgent` marks the current map's meshes: pump() gives those a bigger
+-- slice and runs them before neighbour jobs. A slot refresh() marked
+-- stale queues its rebuild AND keeps handing back the old mesh, so a
+-- one-block edit never drops the scene to the flat 2D path while the
+-- replacement cooks.
+function ChunkMesher.request(map, bodyOnly, masks, urgent)
+  local slot = bodyOnly and "body" or "full"
+  local c = cache[map.id]
+  local stale = c and c.stale and (c.stale[slot] or c.stale.aux)
+  if c and c[slot] ~= nil and not stale then return c[slot] or nil end
+  local key = jobKey(map.id, slot)
+  local job = jobIndex[key]
+  if not job then
+    job = { id = map.id, map = map, slot = slot, masks = masks,
+            urgent = urgent or false, gen = gen[map.id] or 0 }
+    jobIndex[key] = job
+    jobs[#jobs + 1] = job
+  elseif urgent then
+    job.urgent = true
+  end
+  return (c and c[slot]) or nil
+end
+
+function ChunkMesher.pending()
+  return #jobs
+end
+
+-- Advance queued builds inside a per-frame time budget. Urgent jobs (the
+-- current map) come first and get the larger slice -- the first voxel
+-- frame after a toggle is worth more milliseconds than a neighbour
+-- popping in one frame later. `covered` says the world pass is hidden
+-- this frame (a warp's fade, a menu): nothing visible can hitch, so the
+-- slice opens up and a door fade swallows most of a destination build.
+local URGENT_SLICE = 0.012
+local IDLE_SLICE = 0.005
+local COVERED_SLICE = 0.030
+
+function ChunkMesher.pump(covered)
+  if #jobs == 0 then return end
+  local pick = jobs[1]
+  for _, j in ipairs(jobs) do
+    if j.urgent then
+      pick = j
+      break
+    end
+  end
+  local slice = covered and COVERED_SLICE
+                or (pick.urgent and URGENT_SLICE or IDLE_SLICE)
+  local deadline = clock() + slice
+  while pick do
+    if not pick.co then
+      pick.co = coroutine.create(runJob)
+    end
+    Budget.begin(pick.co, deadline - clock())
+    local ok, err = coroutine.resume(pick.co, pick)
+    Budget.finish()
+    if not ok then
+      finishJob(pick, false, err)
+    elseif coroutine.status(pick.co) == "dead" then
+      finishJob(pick, true)
+    else
+      return   -- slice spent mid-build; resume next frame
+    end
+    if clock() >= deadline or #jobs == 0 then return end
+    pick = jobs[1]
+    for _, j in ipairs(jobs) do
+      if j.urgent then
+        pick = j
+        break
+      end
+    end
+  end
+end
+
+-- Meshes for `map`, built SYNCHRONOUSLY on first use -- the historical
+-- contract, kept for probes and any direct caller. `false` is cached for
+-- a map whose mesh could not be built so a headless run does not retry
+-- every frame. `masks` (the full variant's neighbour-body rects) is
+-- static per map id -- a map's connections never change -- so it caches
+-- like everything else.
+function ChunkMesher.get(map, bodyOnly, masks)
+  local slot = bodyOnly and "body" or "full"
+  local c = entry(map.id)
+  if c.grass == nil or c.flowers == nil or (c.stale and c.stale.aux) then
+    local okG, grass = pcall(buildGrassMesh, map)
+    local okF, flowers = pcall(buildFlowerMesh, map)
+    swapSlot(c, "grass", (okG and grass) or false)
+    swapSlot(c, "flowers", (okF and flowers) or false)
+    if c.stale then c.stale.aux = nil end
+  end
+  if c[slot] == nil or (c.stale and c.stale[slot]) then
+    local ok, mesh = pcall(ChunkMesher.build, map, bodyOnly, masks)
+    if not ok then
+      print("[warn] voxel mesh build failed for " .. tostring(map.id)
+            .. ": " .. tostring(mesh))
+    end
+    swapSlot(c, slot, (ok and mesh) or false)
+    if c.stale then
+      c.stale[slot] = nil
+      if not (c.stale.full or c.stale.body or c.stale.aux) then
+        c.stale = nil
+      end
+    end
+    local key = jobKey(map.id, slot)
+    local job = jobIndex[key]
+    if job then finishJob(job, true) end
+  end
+  return c[slot] or nil
+end
+
+-- The cached mesh, or nil -- never builds. The async path's read side.
+function ChunkMesher.peek(map, bodyOnly)
+  local c = cache[map.id]
+  local mesh = c and c[bodyOnly and "body" or "full"]
+  return mesh or nil
+end
+
+function ChunkMesher.grass(map)
+  local c = cache[map.id]
+  return c and c.grass or nil
+end
+
+function ChunkMesher.flowers(map)
+  local c = cache[map.id]
+  return c and c.flowers or nil
+end
+
+-- Authored figures as `{ mesh, wx, wz, y }` records -- each placed by its
+-- own leaning matrix at draw time, so they cannot share one mesh.
+function ChunkMesher.figures(map)
+  local c = cache[map.id]
+  local list = c and c.figures
+  return (type(list) == "table") and list or nil
+end
+
+-- Rebuild a map's meshes IN PLACE: the stale meshes keep drawing while
+-- replacements cook, and each slot swaps as its build lands. This is
+-- the block-edit path (a cut tree, a door stamp) -- invalidate() drops
+-- the mesh outright, and until the async rebuild landed the scene fell
+-- to the flat 2D path, a whole-world blink for a one-block edit.
+function ChunkMesher.refresh(mapId)
+  if not mapId then return ChunkMesher.invalidate() end
+  local c = cache[mapId]
+  -- nothing drawable cached: the plain drop costs nothing visible
+  if not (c and (c.full or c.body)) then
+    return ChunkMesher.invalidate(mapId)
+  end
+  Structures.invalidate(mapId)
+  gen[mapId] = (gen[mapId] or 0) + 1
+  for i = #jobs, 1, -1 do
+    local job = jobs[i]
+    if job.id == mapId then
+      jobIndex[jobKey(job.id, job.slot)] = nil
+      table.remove(jobs, i)
+    end
+  end
+  -- false-cached slots count as stale too: a retry after a failed build
+  -- is exactly a rebuild
+  c.stale = { aux = true,
+              full = (c.full ~= nil) or nil,
+              body = (c.body ~= nil) or nil }
+end
+
+-- Evict everything outside `live` (a set of map ids): far maps' meshes
+-- are released -- GPU buffer and LOVE's CPU copy both -- and their
+-- Structures analysis dropped. The live set is the current map plus its
+-- rendered neighbours, so memory stays bounded by what is on or near the
+-- screen instead of growing with every area ever visited.
+--
+-- The PREVIOUS live set is retained too: warping into a building
+-- collapses the set to one small interior, and evicting the town at the
+-- door means rebuilding the whole neighbourhood on the way out -- a
+-- flat-world flash after every house. One set of history makes the
+-- round trip free while staying bounded at two neighbourhoods.
+local prevLive = {}
+
+function ChunkMesher.setLive(live)
+  for id, c in pairs(cache) do
+    if not live[id] and not prevLive[id] then
+      releaseEntry(c)
+      cache[id] = nil
+      gen[id] = (gen[id] or 0) + 1
+      Structures.invalidate(id)
+    end
+  end
+  for i = #jobs, 1, -1 do
+    local job = jobs[i]
+    if not live[job.id] and not prevLive[job.id] then
+      jobIndex[jobKey(job.id, job.slot)] = nil
+      table.remove(jobs, i)
+    end
+  end
+  prevLive = live
+end
+
+-- Drop one map's mesh (Cut swapped a block) or all of them (hot reload).
+-- Structures' analysis is derived from the same block layer, so it drops
+-- in the same breath; in-flight builds of the map are cancelled through
+-- the generation counter.
+function ChunkMesher.invalidate(mapId)
+  Structures.invalidate(mapId)
+  if mapId then
+    local c = cache[mapId]
+    if c then releaseEntry(c) end
+    cache[mapId] = nil
+    gen[mapId] = (gen[mapId] or 0) + 1
+  else
+    for _, c in pairs(cache) do releaseEntry(c) end
+    cache = {}
+    for id in pairs(gen) do gen[id] = gen[id] + 1 end
+  end
+  for i = #jobs, 1, -1 do
+    local job = jobs[i]
+    if mapId == nil or job.id == mapId then
+      jobIndex[jobKey(job.id, job.slot)] = nil
+      table.remove(jobs, i)
+    end
+  end
+end
+
+Assets.register(function() ChunkMesher.invalidate() end)
+
+return ChunkMesher

--- a/mods/dramatic_shape/lib/DayNight.lua
+++ b/mods/dramatic_shape/lib/DayNight.lua
@@ -1,0 +1,499 @@
+-- Voxel world mode: the day/night cycle -- one clock, and everything the
+-- frame asks it.
+--
+-- THE CLOCK is twenty minutes around: ten of day, ten of night. The DAYTIME
+-- row either PINS it -- DAY, NIGHT, DUSK and DAWN are fixed times on that
+-- dial, not separate looks -- or lets it run (CYCLE), in which case the pin
+-- the player left is where the cycle picks up. Everything below is a pure
+-- function of the clock, so the pinned settings and the running cycle can
+-- never drift apart: DUSK is simply the cycle stopped at sunset.
+--
+-- THE SUN's noon is this mod's existing sun, exactly: shear (-0.85, -0.55),
+-- hanging in the southeast about 45 degrees up. That is the DAY setting and
+-- the default, so a player who never touches the row sees the mod they
+-- already had. From there the arc swings NORTH at both ends -- rising 70
+-- degrees north of east, setting the mirror of that -- because the camera
+-- looks north and the northern sky is the only sky it ever frames: a sun
+-- that rose due east would light the world for ten minutes without once
+-- being seen. Swung north, the disc stands in frame through dawn and dusk
+-- (the hours worth looking at) and passes overhead-behind-the-camera
+-- through midday, which is where a noon sun belongs.
+--
+-- THE MOON arcs entirely through the northern sky -- rising northeast, due
+-- north at mid-night, setting northwest -- so it hangs over the diorama all
+-- night and the pinned NIGHT setting puts it dead centre. Its shadows fall
+-- softly south, away from it, at about two-thirds the sun's weight.
+--
+-- SHADOWS are the shear the light throws: direction opposite the body's
+-- bearing, length its elevation's cotangent (clamped -- a rising sun throws
+-- a long shadow, not an infinite one), strength fading to nothing over the
+-- last twelve degrees before the horizon so the handoff between sun and
+-- moon is a soft gap rather than a snap. Face shading (Voxel3D.FACE_SHADE)
+-- deliberately stays the noon bake: it is a subtle angle term baked into
+-- every mesh, and rebaking the world's geometry per phase buys less than
+-- the cast shadows, the sky and the tint already say.
+--
+-- OUTDOOR ONLY. Indoors keeps the noon rig, the untinted world and no sky:
+-- a cave at midnight is exactly as dark as a cave at noon, which is what a
+-- room with no windows looks like. Map.isOutdoor is the same test the sky
+-- already rests on; the caller passes its answer in (applyRig/tint).
+--
+-- Persistence: the running cycle's clock is written into the mod's own
+-- save-file bucket (save.modData.DRAMATIC_SHAPE, via mod.save) on the
+-- engine's save.writing event, and read back on save.loaded/created. A save
+-- with no clock in it starts at noon.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local ModSetting = V.require("ModSetting")
+local PaletteFX = require("src.render.PaletteFX")
+
+local DayNight = {}
+
+-- ------- the dial
+
+DayNight.CYCLE = 1200         -- seconds around the whole dial
+DayNight.DAY_LEN = 600        -- the sun's half; the moon has the rest
+DayNight.BLEND = 75           -- seconds of palette blend either side of a twilight
+
+-- where the pinned settings stop the clock
+DayNight.T = { dawn = 0, day = 300, dusk = 600, night = 900 }
+
+DayNight.KEY = "daytime"
+DayNight.LABEL = "DAYTIME"
+
+-- "sync" first: an unset or unreadable value follows the machine's own
+-- clock, per the row's contract (ModSetting values[1] is the default) --
+-- and forceSync below reaches for it by the same position.
+DayNight.setting = ModSetting.new(DayNight.KEY, DayNight.LABEL,
+                                  { "sync", "day", "night", "dusk",
+                                    "dawn", "cycle" },
+                                  { "SYNC", "DAY", "NIGHT", "DUSK",
+                                    "DAWN", "CYCLE" })
+
+-- The one writer for the FULL pin. While VOXEL sits on FULL the DAYTIME
+-- row is off the menu with the rest of the rows the preset owns, and the
+-- value is held HERE at SYNC -- the diorama preset's sky follows the clock
+-- on the wall, whatever was chosen before. Called from every path that can
+-- arrive at or act under FULL (main.lua: the preset itself, the rows hook,
+-- the manager's options_changed), mirroring OverworldBattle.forceOG.
+function DayNight.forceSync(game)
+  if DayNight.setting:get() ~= "sync" then
+    DayNight.setting:setIndex(1, game)
+  end
+end
+
+DayNight.clock = DayNight.T.day     -- the running cycle's own position
+
+-- ------- the two arcs
+--
+-- Bearings in DEGREES from east toward south (the world's +X is east, +Z
+-- south), elevations in degrees up from the ground plane.
+
+-- noon IS the existing sun: shear (-0.85, -0.55) hangs it at
+-- atan2(0.55, 0.85) south of east, atan(1/hypot) = 44.65 degrees up
+local NOON_KX, NOON_KZ = -0.85, -0.55
+local TH_NOON = math.deg(math.atan2(-NOON_KZ, -NOON_KX))
+local EL_NOON = math.deg(math.atan(1 / math.sqrt(NOON_KX * NOON_KX
+                                                 + NOON_KZ * NOON_KZ)))
+
+local TH_RISE, TH_SET = -70, 250            -- north of east / north of west
+local TH_MRISE, TH_MMID, TH_MSET = -20, -90, -160
+local EL_MOON = 40
+
+DayNight.K_MAX = 2.0          -- shear clamp: a shadow at most twice its height
+DayNight.ALPHA_SUN = 0.40     -- the existing midday shadow weight
+DayNight.ALPHA_MOON = 0.26    -- moonlight is a softer press
+DayNight.FADE_DEG = 12        -- shadows fade out over the last degrees of a rise/set
+
+-- disc PLACEMENT only: the true elevation would put the noon sun far above
+-- any frame, so the arc the discs ride is squashed toward the horizon. The
+-- shadows always use the true elevation.
+DayNight.ELEV_SQUASH = 0.14
+
+-- three-point arc: a at s=0, b at s=0.5, c at s=1
+local function arc(a, b, c, s)
+  if s < 0.5 then return a + (b - a) * 2 * s end
+  return b + (c - b) * (2 * s - 1)
+end
+
+-- The body lighting the world at clock `t`: bearing and elevation in
+-- degrees, and whether it is the moon. The t == DAY_LEN boundary belongs to
+-- the SUN, so the pinned DUSK setting is the sun half-set in the northwest,
+-- not the moon rising.
+function DayNight.bodyAt(t)
+  t = t % DayNight.CYCLE
+  if t <= DayNight.DAY_LEN then
+    local s = t / DayNight.DAY_LEN
+    return arc(TH_RISE, TH_NOON, TH_SET, s),
+           EL_NOON * math.sin(math.pi * s), false
+  end
+  local s = (t - DayNight.DAY_LEN) / (DayNight.CYCLE - DayNight.DAY_LEN)
+  return arc(TH_MRISE, TH_MMID, TH_MSET, s),
+         EL_MOON * math.sin(math.pi * s), true
+end
+
+-- The shadow shear that body throws: drift per pixel of height, opposite
+-- the bearing, cot(elevation) long, clamped.
+function DayNight.shearAt(t)
+  local th, el, moon = DayNight.bodyAt(t)
+  if el < 0.5 then el = 0.5 end
+  local k = math.min(DayNight.K_MAX, 1 / math.tan(math.rad(el)))
+  return -math.cos(math.rad(th)) * k, -math.sin(math.rad(th)) * k, moon
+end
+
+-- How much shadow the light can press right now, 0..1 of the body's own
+-- weight: full up high, gone at the horizon, so sunset hands off to
+-- moonrise through a soft shadowless gap instead of snapping.
+function DayNight.strengthAt(t)
+  local _, el = DayNight.bodyAt(t)
+  local s = el / DayNight.FADE_DEG
+  if s < 0 then return 0 end
+  return s < 1 and s or 1
+end
+
+-- ------- the palettes
+--
+-- Sky bands, lightest FIRST (the horizon end), exactly the shape Sky.bands
+-- reads. Six bands, not four: twilight is the whole show here, and six rungs
+-- of it is what keeps a sunset reading as a gradient rather than as stripes.
+-- Every channel is a multiple of 8 -- the 5-bit GBC lattice -- including
+-- after blending, which re-quantises onto it.
+-- `golden` and `violet` are not pins -- they are WAYPOINTS the blends pass
+-- through. Day's blue horizon and dusk's gold one are near-complements, and
+-- a straight lerp between complements bottoms out in grey: mid-transition
+-- the whole sky went the colour of dishwater, and gold-to-navy did the same
+-- on the far side of sunset. So the evening bends through a golden hour
+-- (horizon warming, zenith still blue -- late afternoon), and both edges of
+-- the night bend through a violet civil twilight (rose horizon under a
+-- violet sky -- the real colour of that half hour).
+DayNight.PALETTES = {
+  day = { { 184, 216, 248 }, { 144, 192, 248 }, { 104, 160, 240 },
+          { 72, 128, 224 }, { 48, 96, 200 }, { 40, 72, 168 } },
+  golden = { { 248, 216, 144 }, { 232, 184, 136 }, { 176, 152, 168 },
+             { 120, 128, 192 }, { 80, 104, 184 }, { 56, 80, 152 } },
+  dawn = { { 248, 216, 152 }, { 248, 176, 136 }, { 232, 136, 144 },
+           { 176, 104, 168 }, { 112, 80, 168 }, { 64, 64, 136 } },
+  dusk = { { 248, 200, 112 }, { 248, 152, 96 }, { 232, 104, 96 },
+           { 184, 80, 136 }, { 120, 64, 152 }, { 56, 48, 120 } },
+  violet = { { 200, 136, 160 }, { 152, 104, 160 }, { 112, 80, 152 },
+             { 72, 56, 128 }, { 40, 40, 96 }, { 16, 24, 64 } },
+  night = { { 88, 104, 160 }, { 64, 80, 136 }, { 48, 56, 112 },
+            { 32, 40, 88 }, { 16, 24, 64 }, { 8, 8, 40 } },
+}
+
+-- what the world's own colours are multiplied by, per phase (0..255)
+DayNight.TINTS = {
+  day = { 255, 255, 255 },
+  golden = { 255, 232, 208 },
+  dawn = { 255, 216, 192 },
+  dusk = { 255, 192, 168 },
+  violet = { 184, 160, 200 },
+  night = { 120, 136, 192 },
+}
+
+-- the twilight glow around the low sun, and the discs' own four-shade
+-- palettes (lightest first, so a display mode transforms them like any
+-- other palette)
+DayNight.GLOWS = { dawn = { 248, 232, 176 }, dusk = { 248, 224, 168 } }
+DayNight.SUN_COLORS = { { 248, 240, 200 }, { 248, 208, 96 },
+                        { 248, 144, 80 }, { 216, 96, 64 } }
+DayNight.MOON_COLORS = { { 240, 244, 248 }, { 224, 232, 240 },
+                         { 168, 184, 208 }, { 120, 136, 168 } }
+
+-- The dial as keyframes: a repeated name is a plateau, a change is a
+-- BLEND-wide ramp. Laid out so DUSK and DAWN proper land exactly on their
+-- pinned times, and so the evening approaches dusk THROUGH the golden-hour
+-- waypoint rather than straight across the grey between blue and gold. The
+-- morning side needs no waypoint of its own: dawn's pinks into day's blues
+-- share a family and blend clean.
+local DIAL
+local function dial()
+  if DIAL then return DIAL end
+  local B, D, C = DayNight.BLEND, DayNight.DAY_LEN, DayNight.CYCLE
+  DIAL = {
+    { 0, "dawn" }, { B, "day" },
+    { D - 2 * B, "day" }, { D - B, "golden" }, { D, "dusk" },
+    { D + B / 2, "violet" }, { D + B, "night" },
+    { C - B, "night" }, { C - B / 2, "violet" }, { C, "dawn" },
+  }
+  return DIAL
+end
+
+-- Phase weights at clock `t`, off the dial above.
+function DayNight.mix(t)
+  t = t % DayNight.CYCLE
+  local d = dial()
+  for i = 1, #d - 1 do
+    local a, b = d[i], d[i + 1]
+    if t >= a[1] and t < b[1] then
+      if a[2] == b[2] then return { [a[2]] = 1 } end
+      local u = (t - a[1]) / (b[1] - a[1])
+      return { [a[2]] = 1 - u, [b[2]] = u }
+    end
+  end
+  return { dawn = 1 }
+end
+
+-- back onto the 5-bit lattice after any blend
+local function q8(v)
+  v = math.floor(v / 8 + 0.5) * 8
+  if v < 0 then return 0 end
+  return v > 248 and 248 or v
+end
+
+local function blend3(key, mix, fallback)
+  local r, g, b = 0, 0, 0
+  for name, w in pairs(mix) do
+    local c = key[name] or fallback
+    r = r + c[1] * w
+    g = g + c[2] * w
+    b = b + c[3] * w
+  end
+  return { q8(r), q8(g), q8(b) }
+end
+
+-- The sky palette for clock `t`, blended between the phase palettes and
+-- re-quantised to the lattice. Memoised per whole second: the answer only
+-- moves as the cycle runs, and the cycle moves it slowly.
+local palCache = { key = nil, pal = nil }
+
+function DayNight.palette(t)
+  t = t or DayNight.time()
+  local key = math.floor(t % DayNight.CYCLE)
+  if palCache.key == key then return palCache.pal end
+  local mix = DayNight.mix(t)
+  local pal = {}
+  for i = 1, #DayNight.PALETTES.day do
+    local r, g, b = 0, 0, 0
+    for name, w in pairs(mix) do
+      local c = DayNight.PALETTES[name][i]
+      r = r + c[1] * w
+      g = g + c[2] * w
+      b = b + c[3] * w
+    end
+    pal[i] = { q8(r), q8(g), q8(b) }
+  end
+  palCache.key, palCache.pal = key, pal
+  return pal
+end
+
+-- The world tint for clock `t`, {r, g, b} in 0..1. Neutral indoors -- the
+-- caller answers for where it is standing (see the header).
+local tintCache = { key = nil, tint = nil }
+local NEUTRAL = { 1, 1, 1 }
+
+function DayNight.tint(outdoor, t)
+  if not outdoor then return NEUTRAL end
+  t = t or DayNight.time()
+  local key = math.floor(t % DayNight.CYCLE)
+  if tintCache.key ~= key then
+    -- NOT re-quantised: this is a light level the shader multiplies by, not
+    -- a palette colour, and the lattice's 248 ceiling would make even noon
+    -- fractionally dim
+    local mix = DayNight.mix(t)
+    local r, g, b = 0, 0, 0
+    for name, w in pairs(mix) do
+      local c = DayNight.TINTS[name] or DayNight.TINTS.day
+      r = r + c[1] * w
+      g = g + c[2] * w
+      b = b + c[3] * w
+    end
+    tintCache.key = key
+    tintCache.tint = { r / 255, g / 255, b / 255 }
+  end
+  return tintCache.tint
+end
+
+-- The twilight glow: how strongly (0..1) and in what colour the sky warms
+-- around the low sun. Only the SUN glows -- a moonrise is silver, not gold.
+function DayNight.glow(t)
+  t = t or DayNight.time()
+  local _, _, moon = DayNight.bodyAt(t)
+  if moon then return 0, nil end
+  local mix = DayNight.mix(t)
+  local amt = (mix.dawn or 0) + (mix.dusk or 0)
+  if amt <= 0 then return 0, nil end
+  return amt, blend3(DayNight.GLOWS, mix, DayNight.GLOWS.dusk)
+end
+
+-- ------- the clock itself
+
+local lastMode = nil
+
+local function mode()
+  return DayNight.setting:get() or "day"
+end
+
+-- Where SYNC reads the real clock: local hours, 0..24 with the minutes as
+-- fraction. A named seam rather than a bare os.date call, so the suite can
+-- hand it a fixed hour.
+function DayNight.hours()
+  local d = os.date("*t")
+  return d.hour + d.min / 60 + d.sec / 3600
+end
+
+-- SYNC: the machine's own time of day laid onto the dial. Local noon is
+-- the DAY pin, midnight the NIGHT pin, six and eighteen the twilights --
+-- an hour of the real day is fifty seconds of dial, and Kanto's evening
+-- falls when the player's does.
+function DayNight.syncTime()
+  return ((DayNight.hours() - 6) * (DayNight.CYCLE / 24)) % DayNight.CYCLE
+end
+
+-- The effective time: the pin, the running clock under CYCLE, or the wall
+-- clock under SYNC.
+function DayNight.time()
+  local m = mode()
+  if m == "cycle" then return DayNight.clock end
+  if m == "sync" then return DayNight.syncTime() end
+  return DayNight.T[m] or DayNight.T.day
+end
+
+-- Advance the cycle. Runs every frame from the voxel pipeline's update hook
+-- (which ticks through battles and menus too, so night falls during a long
+-- fight exactly as it does on a walk). Stepping ONTO cycle picks up from
+-- the pin the player was just looking at: DUSK then CYCLE rolls on into
+-- night rather than teleporting the sky.
+function DayNight.update(dt)
+  local m = mode()
+  if m ~= lastMode then
+    if m == "cycle" then
+      -- from a pin, its time; from SYNC, wherever the real sky already was
+      DayNight.clock = DayNight.T[lastMode]
+                       or (lastMode == "sync" and DayNight.syncTime())
+                       or DayNight.clock
+    end
+    lastMode = m
+  end
+  if m == "cycle" and dt and dt > 0 then
+    DayNight.clock = (DayNight.clock + dt) % DayNight.CYCLE
+  end
+end
+
+-- The clock the RIG runs on: quantised, so the shadow map redraws a few
+-- times a minute as the sun crawls rather than every frame.
+DayNight.STEP = 2
+
+function DayNight.rigTime()
+  local t = DayNight.time()
+  return math.floor(t / DayNight.STEP) * DayNight.STEP
+end
+
+-- ------- what the frame reads
+
+-- Point the shared light rig at the clock -- or at noon, indoors. This
+-- writes the same fields everything already reads (ShadowMap.KX/KZ for the
+-- sun pass and its frustum, Voxel3D.SHADOW_* for the decal fallback and the
+-- sunDark uniform), so no draw path changes to follow the sun; they follow
+-- the rig, and the rig follows the clock.
+function DayNight.applyRig(outdoor)
+  local ShadowMap = V.require("ShadowMap")
+  local Voxel3D = V.require("Voxel3D")
+  local t = outdoor and DayNight.rigTime() or DayNight.T.day
+  local kx, kz, moon = DayNight.shearAt(t)
+  ShadowMap.KX, ShadowMap.KZ = kx, kz
+  Voxel3D.SHADOW_KX, Voxel3D.SHADOW_KZ = kx, kz
+  local base = moon and DayNight.ALPHA_MOON or DayNight.ALPHA_SUN
+  Voxel3D.SHADOW_ALPHA = base * DayNight.strengthAt(t)
+  return t
+end
+
+-- How much of a pass's OWN shadow weight the hour leaves it, 0..1 -- for a
+-- caller that sets its own alpha (the battle arena) and should still lose
+-- its shadows to a sunset.
+function DayNight.shadowScale(outdoor, t)
+  if not outdoor then return 1 end
+  t = t or DayNight.rigTime()
+  local _, _, moon = DayNight.bodyAt(t)
+  local s = DayNight.strengthAt(t)
+  return moon and s * (DayNight.ALPHA_MOON / DayNight.ALPHA_SUN) or s
+end
+
+-- The disc to hang in the sky, or nil when the body is set or behind the
+-- camera's half of the sky. Returns a direction for the PLACEMENT arc --
+-- true bearing, squashed elevation (see ELEV_SQUASH) -- plus which body it
+-- is; the caller projects it through its own camera.
+function DayNight.body(t)
+  t = t or DayNight.time()
+  local th, el, moon = DayNight.bodyAt(t)
+  if el < -2 then return nil end
+  local e = math.rad(el * DayNight.ELEV_SQUASH)
+  local b = math.rad(th)
+  return {
+    dx = math.cos(b) * math.cos(e),
+    dy = math.sin(e),
+    dz = math.sin(b) * math.cos(e),
+    moon = moon,
+  }
+end
+
+-- Maps under a CANOPY: not outdoor -- there is no sky to paint and no sun
+-- or moon to see, so the shadow rig stays the mod's fixed noon light,
+-- which is all that ever filtered through the leaves -- but not a sealed
+-- room either: night still FALLS in them. Of everything the clock does,
+-- exactly one thing reaches a canopy map: the hour's tint.
+DayNight.CANOPY = { VIRIDIAN_FOREST = true }
+
+function DayNight.isCanopy(map)
+  return (map and map.id and DayNight.CANOPY[map.id]) and true or false
+end
+
+-- How lit the WINDOWS are, 0..1 -- the lamps behind the glass, not the sky.
+-- They come on through dusk (a lit window against a sunset is half the point
+-- of having either), burn all night, and are mostly out again by dawn:
+-- people wake before it is bright, they do not read at sunrise.
+local LAMPS = { night = 1, violet = 1, dusk = 0.7, dawn = 0.25 }
+
+function DayNight.windowLight(t)
+  local mix = DayNight.mix(t or DayNight.time())
+  local lit = 0
+  for name, w in pairs(mix) do
+    lit = lit + (LAMPS[name] or 0) * w
+  end
+  return lit
+end
+
+-- The period name for the engine's world.tod hook (map.palette ctx.tod,
+-- music.select): the dominant phase, in the vocabulary day/night mods use.
+local TOD = { day = "DAY", golden = "DAY", night = "NIGHT",
+              violet = "NIGHT", dawn = "MORNING", dusk = "EVENING" }
+
+function DayNight.tod(t)
+  local mix = DayNight.mix(t or DayNight.time())
+  local best, bestW = "day", -1
+  for name, w in pairs(mix) do
+    if w > bestW then best, bestW = name, w end
+  end
+  return TOD[best] or "DAY"
+end
+
+-- ------- persistence
+--
+-- The clock rides the SAVE SLOT, not the options file: what time it is in
+-- Kanto is a fact about that journey, like where the player is standing.
+-- mod.save is the loader's per-mod bucket in save.modData, which persists
+-- with the slot on its own -- writing the value is all there is to do.
+
+DayNight.SAVE_KEY = "clock"
+
+function DayNight.store()
+  local saveApi = V.mod and V.mod.save
+  if not (saveApi and saveApi.set) then return end
+  pcall(saveApi.set, saveApi, DayNight.SAVE_KEY, DayNight.clock)
+end
+
+function DayNight.restore()
+  local saveApi = V.mod and V.mod.save
+  local stored = nil
+  if saveApi and saveApi.get then
+    local ok, got = pcall(saveApi.get, saveApi, DayNight.SAVE_KEY)
+    if ok then stored = got end
+  end
+  -- no time set: it is day (the requirement, verbatim)
+  DayNight.clock = type(stored) == "number"
+                   and stored % DayNight.CYCLE or DayNight.T.day
+end
+
+return DayNight

--- a/mods/dramatic_shape/lib/GlassMask.lua
+++ b/mods/dramatic_shape/lib/GlassMask.lua
@@ -1,0 +1,174 @@
+-- Voxel world mode: the glass in the windows, found rather than listed.
+--
+-- Buildings and doors in the overworld art carry small panes -- six texels
+-- wide, framed in black, with a diagonal shine drawn in. This module finds
+-- them by SHAPE in the tileset image itself: a border row of six black
+-- texels, four or five rows of black-flanked non-black glass under it, and
+-- a closing border row. No tile ids are hardcoded, so a total conversion
+-- that draws its own windows in the same idiom gets glass for free, and art
+-- with no windows gets an empty mask and costs nothing.
+--
+-- The scan slides at PIXEL granularity because the art does: the building
+-- window sits a row down inside its tile, and the door's pane straddles a
+-- 2x2 tile block entirely -- a per-tile matcher finds neither.
+--
+-- What the scan yields is a MASK TEXTURE the same size as the tileset
+-- atlas: opaque white on glass texels, transparent everywhere else. Terrain
+-- meshes sample the atlas by normalized coordinates (ChunkMesher.uvRect),
+-- so the scene shader can sample this mask with the SAME coordinates and
+-- know, per fragment, whether it is drawing glass -- on any wall, at any
+-- angle, in free-roam or a staged battle, with no geometry work anywhere.
+-- The recoloured atlases (display modes, RED++) keep the tileset's layout,
+-- so the alignment holds under every palette.
+--
+-- What the shader does with the answer (Voxel3D): by day a thin glint
+-- sweeps across the panes -- a pseudo reflection, view-anchored, preserving
+-- the art under it -- and after dark the panes are LIT: the texel's own
+-- shine pattern, warmed and brightened, exempt from the sun, the shadow
+-- map and the hour's tint, as a window with a lamp behind it is.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local Assets = require("src.render.Assets")
+
+local GlassMask = {}
+
+-- pane geometry the scan accepts: six glass texels across, and this many
+-- rows of them between the two border rows
+GlassMask.GLASS_W = 6
+GlassMask.ROWS = { 4, 5 }        -- door pane, building pane
+
+-- Whether a channel triple is the border black. The raw tileset art is the
+-- four DMG greys, so black is genuinely zero; the threshold forgives a
+-- rescaled asset without accepting the dark grey rung (85/255 = 0.33).
+local function isBlack(r, g, b)
+  return r < 0.12 and g < 0.12 and b < 0.12
+end
+
+GlassMask._isBlack = isBlack     -- named for the suite
+
+-- Find every pane in an image, through a pure reader so the geometry is
+-- testable headless: `getPixel(x, y)` returns r, g, b in 0..1 for 0-based
+-- coordinates. Returns { {x=, y=, w=, h=}, ... } rects of GLASS texels
+-- (the border is the detector's evidence, not part of the answer).
+function GlassMask.scan(getPixel, w, h)
+  local function black(x, y)
+    return isBlack(getPixel(x, y))
+  end
+  local function borderRow(x, y)
+    for c = 1, 6 do
+      if not black(x + c, y) then return false end
+    end
+    return true
+  end
+  local function glassRow(x, y)
+    if not (black(x, y) and black(x + 7, y)) then return false end
+    for c = 1, 6 do
+      if black(x + c, y) then return false end
+    end
+    return true
+  end
+  local want = {}
+  for _, n in ipairs(GlassMask.ROWS) do want[n] = true end
+
+  local rects = {}
+  for y = 0, h - 1 do
+    for x = 0, w - 8 do
+      if borderRow(x, y) then
+        local n = 0
+        while y + 1 + n < h and glassRow(x, y + 1 + n) do
+          n = n + 1
+        end
+        if want[n] and y + 1 + n < h and borderRow(x, y + 1 + n) then
+          rects[#rects + 1] = { x = x + 1, y = y + 1,
+                                w = GlassMask.GLASS_W, h = n }
+        end
+      end
+    end
+  end
+  return rects
+end
+
+-- ------- the runtime cache, one entry per tileset image
+
+local cache = {}       -- image path -> { rects, texture (or false) }
+
+local function entry(tileset)
+  local path = tileset and tileset.image
+  if not path then return nil end
+  local hit = cache[path]
+  if hit then return hit end
+  local ok, data = pcall(Assets.imageData, path)
+  if not (ok and data) then
+    -- unreadable art is a verdict for the session, not a retry loop
+    cache[path] = { rects = {}, texture = false }
+    return cache[path]
+  end
+  local w, h = data:getDimensions()
+  local rects = GlassMask.scan(function(x, y)
+    return data:getPixel(x, y)
+  end, w, h)
+  local texture = false
+  if #rects > 0 and love.image and love.image.newImageData
+     and love.graphics and love.graphics.newImage then
+    local built = pcall(function()
+      local mask = love.image.newImageData(w, h)
+      for _, r in ipairs(rects) do
+        for yy = r.y, r.y + r.h - 1 do
+          for xx = r.x, r.x + r.w - 1 do
+            mask:setPixel(xx, yy, 1, 1, 1, 1)
+          end
+        end
+      end
+      texture = love.graphics.newImage(mask)
+      texture:setFilter("nearest", "nearest")
+    end)
+    if not built then texture = false end
+  end
+  cache[path] = { rects = rects, texture = texture }
+  return cache[path]
+end
+
+-- The panes found in a tileset's art, as glass rects in atlas pixels.
+function GlassMask.rects(tileset)
+  local e = entry(tileset)
+  return e and e.rects or {}
+end
+
+-- The mask texture for a tileset, or nil when it has no panes (or the art
+-- is unreadable, or there is no GPU) -- callers bind the blank instead.
+function GlassMask.texture(tileset)
+  local e = entry(tileset)
+  return (e and e.texture) or nil
+end
+
+-- A 1x1 transparent stand-in, for the frames (and drivers) with no mask:
+-- the scene shader always declares the sampler, and an unbound sampler is
+-- a driver-dependent crash rather than a fallback.
+local blank = nil
+
+function GlassMask.blank()
+  if blank == nil then
+    local ok, img = pcall(function()
+      local data = love.image.newImageData(1, 1)
+      data:setPixel(0, 0, 0, 0, 0, 0)
+      return love.graphics.newImage(data)
+    end)
+    blank = (ok and img) or false
+  end
+  return blank or nil
+end
+
+-- Drop the GPU objects (window resize, hot reload). The rects survive --
+-- they are a fact about the art -- but textures are rebuilt on demand.
+function GlassMask.invalidate()
+  for _, e in pairs(cache) do
+    if e.texture and e.texture.release then pcall(e.texture.release, e.texture) end
+    e.texture = false
+  end
+  cache = {}
+  blank = nil
+end
+
+return GlassMask

--- a/mods/dramatic_shape/lib/Mat4.lua
+++ b/mods/dramatic_shape/lib/Mat4.lua
@@ -1,0 +1,112 @@
+-- Minimal 4x4 matrix math for voxel world mode.
+--
+-- Row-major, and sent to the shader with shader:send("mvp", "row", m).
+-- LOVE 11.5's matrix uniform defaults to column-major, so the "row" layout
+-- argument is what lets these tables read the same way they are written
+-- here -- translation in the fourth column, m[4]/m[8]/m[12].
+--
+-- Only what the renderer actually needs: a perspective projection (the
+-- camera), an orthographic one (the sun's shadow pass), a look-based view,
+-- and the translate/rotateY/scale a model matrix is built from. No general
+-- inverse, no quaternions.
+
+local Mat4 = {}
+
+function Mat4.identity()
+  return { 1, 0, 0, 0,
+           0, 1, 0, 0,
+           0, 0, 1, 0,
+           0, 0, 0, 1 }
+end
+
+-- a * b, both row-major
+function Mat4.mul(a, b)
+  local o = {}
+  for r = 0, 3 do
+    local a0, a1 = a[r * 4 + 1], a[r * 4 + 2]
+    local a2, a3 = a[r * 4 + 3], a[r * 4 + 4]
+    for c = 1, 4 do
+      o[r * 4 + c] = a0 * b[c] + a1 * b[4 + c] + a2 * b[8 + c] + a3 * b[12 + c]
+    end
+  end
+  return o
+end
+
+function Mat4.translate(x, y, z)
+  return { 1, 0, 0, x,
+           0, 1, 0, y,
+           0, 0, 1, z,
+           0, 0, 0, 1 }
+end
+
+function Mat4.scale(x, y, z)
+  return { x, 0, 0, 0,
+           0, y, 0, 0,
+           0, 0, z, 0,
+           0, 0, 0, 1 }
+end
+
+function Mat4.rotateY(a)
+  local c, s = math.cos(a), math.sin(a)
+  return { c, 0, s, 0,
+           0, 1, 0, 0,
+          -s, 0, c, 0,
+           0, 0, 0, 1 }
+end
+
+function Mat4.rotateX(a)
+  local c, s = math.cos(a), math.sin(a)
+  return { 1, 0, 0, 0,
+           0, c, -s, 0,
+           0, s, c, 0,
+           0, 0, 0, 1 }
+end
+
+-- Right-handed perspective onto GL clip space (z in [-1, 1]).
+function Mat4.perspective(fovY, aspect, near, far)
+  local f = 1 / math.tan(fovY / 2)
+  local d = near - far
+  return { f / aspect, 0, 0, 0,
+           0, f, 0, 0,
+           0, 0, (far + near) / d, (2 * far * near) / d,
+           0, 0, -1, 0 }
+end
+
+-- Right-handed orthographic projection onto GL clip space (z in [-1, 1]).
+-- The view-space box is x in [l, r], y in [b, t], z in [-f, -n] -- near and
+-- far are DISTANCES down the view's -z, exactly as in perspective() above.
+-- Parallel, so a sun is a direction and nothing else: no eye point, no
+-- foreshortening, and clip z stays linear in world units, which is what
+-- lets the shadow pass store depth as a plain number.
+function Mat4.ortho(l, r, b, t, n, f)
+  return { 2 / (r - l), 0, 0, -(r + l) / (r - l),
+           0, 2 / (t - b), 0, -(t + b) / (t - b),
+           0, 0, -2 / (f - n), -(f + n) / (f - n),
+           0, 0, 0, 1 }
+end
+
+-- Right-handed look-at. eye/target/up are {x, y, z}.
+function Mat4.lookAt(eye, target, up)
+  local function sub(a, b) return { a[1] - b[1], a[2] - b[2], a[3] - b[3] } end
+  local function norm(v)
+    local l = math.sqrt(v[1] * v[1] + v[2] * v[2] + v[3] * v[3])
+    if l == 0 then return { 0, 0, 0 } end
+    return { v[1] / l, v[2] / l, v[3] / l }
+  end
+  local function cross(a, b)
+    return { a[2] * b[3] - a[3] * b[2],
+             a[3] * b[1] - a[1] * b[3],
+             a[1] * b[2] - a[2] * b[1] }
+  end
+  local function dot(a, b) return a[1] * b[1] + a[2] * b[2] + a[3] * b[3] end
+
+  local f = norm(sub(target, eye))     -- forward
+  local s = norm(cross(f, up))         -- right
+  local u = cross(s, f)                -- true up
+  return { s[1], s[2], s[3], -dot(s, eye),
+           u[1], u[2], u[3], -dot(u, eye),
+          -f[1], -f[2], -f[3], dot(f, eye),
+           0, 0, 0, 1 }
+end
+
+return Mat4

--- a/mods/dramatic_shape/lib/ModSetting.lua
+++ b/mods/dramatic_shape/lib/ModSetting.lua
@@ -1,0 +1,132 @@
+-- One of this mod's own settings: a ladder of values, where it persists,
+-- and the row the player cycles it on.
+--
+-- The engine gives a render pipeline all of this for free -- ladder,
+-- options row, hotkey, persistence -- but only to something that OWNS a
+-- pass of the frame. The voxel wireframe and the world curve do not: they
+-- parameterise the voxel pass, so they have nothing to put in drawWorld or
+-- present and the registry rightly rejects them. What is left is a plain
+-- mod setting, and this is the boilerplate two of them would otherwise
+-- each carry a copy of:
+--
+--   options:define   a home in options.modOptions.DRAMATIC_SHAPE, plus a row
+--                    on this mod's page in the mod manager.
+--   ui.options.rows  the same setting on the OPTIONS menu, where the
+--                    player already goes for VOXEL and T-SHIFT.
+--
+-- Both rows read and write the one stored value, so they cannot disagree.
+-- Writing mirrors what the manager's own page does (ManagerState:setOption):
+-- the live save's options table, the loader's copy that mod.options:get
+-- reads, and then the file.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local ModSetting = {}
+ModSetting.__index = ModSetting
+
+local function modId()
+  local mod = V.mod
+  return (mod and mod.id) or "DRAMATIC_SHAPE"
+end
+
+-- `values` are the stored values in ladder order and `labels` what the row
+-- shows for each; values[1] is the default, and the one an unreadable or
+-- unrecognised stored value falls back to.
+function ModSetting.new(key, label, values, labels)
+  return setmetatable({
+    key = key, label = label, values = values, labels = labels,
+    index = nil,          -- nil = not yet read back from the persisted options
+  }, ModSetting)
+end
+
+local function indexOf(self, value)
+  for i, v in ipairs(self.values) do
+    if v == value then return i end
+  end
+  return 1
+end
+
+-- What the player left it at last session. Read lazily rather than at load
+-- time: the loader fills modOptions before a mod runs, but reading through
+-- the API keeps this honest about where the value lives.
+function ModSetting:read()
+  if self.index then return self.index end
+  local mod = V.mod
+  local value
+  if mod and mod.options then
+    local ok, got = pcall(mod.options.get, mod.options, self.key)
+    if ok then value = got end
+  end
+  self.index = indexOf(self, value)
+  return self.index
+end
+
+function ModSetting:get()
+  return self.values[self:read()]
+end
+
+function ModSetting:level()
+  return self:read() - 1
+end
+
+function ModSetting:setIndex(i, game)
+  local n = #self.values
+  i = ((i - 1) % n + n) % n + 1
+  self.index = i
+  local value, id = self.values[i], modId()
+  local opts = game and game.save and game.save.options
+  if opts then
+    opts.modOptions = opts.modOptions or {}
+    opts.modOptions[id] = opts.modOptions[id] or {}
+    opts.modOptions[id][self.key] = value
+  end
+  local loader = game and game.mods
+  if loader then
+    loader.modOptions = loader.modOptions or {}
+    loader.modOptions[id] = loader.modOptions[id] or {}
+    loader.modOptions[id][self.key] = value
+  end
+  if game and game.writeOptions then pcall(game.writeOptions, game) end
+  return value
+end
+
+function ModSetting:cycle(game, dir)
+  return self:setIndex(self:read() + (dir or 1), game)
+end
+
+-- Adopt a value set from somewhere else (the mod manager's settings page,
+-- which writes and persists on its own). Nothing to store: just move the
+-- cached index so the next read agrees with it.
+function ModSetting:sync(value)
+  self.index = indexOf(self, value)
+end
+
+-- The descriptor src/ui/OptionRows.lua renders, in the shape the
+-- ui.options.rows hook appends.
+function ModSetting:row()
+  local self_ = self
+  return {
+    id = "DRAMATIC_SHAPE:" .. self.key,
+    label = self.label,
+    value = function() return self_.labels[self_:read()] end,
+    step = function(game, dir)
+      self_:cycle(game, dir)
+      return true
+    end,
+  }
+end
+
+-- The row the mod manager's own settings page builds for this mod.
+function ModSetting:schema(help)
+  local choices = {}
+  for i, v in ipairs(self.values) do choices[i] = { self.labels[i], v } end
+  if #self.values == 2 and self.values[1] == false then
+    return { key = self.key, type = "toggle", label = self.label,
+             default = self.values[1], help = help }
+  end
+  return { key = self.key, type = "choice", label = self.label,
+           choices = choices, default = self.values[1], help = help }
+end
+
+return ModSetting

--- a/mods/dramatic_shape/lib/OverworldBattle.lua
+++ b/mods/dramatic_shape/lib/OverworldBattle.lua
@@ -1,0 +1,936 @@
+-- Overworld battles: fights that happen on the map you were standing on.
+--
+-- The engine's battle is a screen: a white field with two pics on it, pushed
+-- over a frozen overworld that stops drawing. This turns that white field
+-- into the world -- the same terrain the free-roam mode extrudes, shot from
+-- a placed over-the-shoulder camera at a clear patch of ground nearby --
+-- while leaving the battle ITSELF alone. Every pic, HUD, HP bar, move
+-- animation, faint slide and text box is the engine's own, drawn in the
+-- engine's own order. What changes is what is behind them, and where the two
+-- pics stand.
+--
+-- The sequence, from the moment something picks a fight:
+--
+--   1. the overworld cast is culled -- every NPC vanishes, so the wipe
+--      plays over an empty map and no bystander is left standing in the
+--      arena shot
+--   2. the engine's own transition wipes the screen (untouched: it is the
+--      right wipe, picked by the right three bits)
+--   3. the battle draws over a live, window-resolution render of the arena,
+--      with each mon PINNED to the cell it is standing on, the camera
+--      drifting slowly enough to read as parallax, and a depth-of-field pass
+--      holding the slab of world the two of them occupy sharp
+--   4. the battle ends, the cast comes back, and the player is exactly
+--      where they were standing
+--
+-- WHAT DOES NOT MOVE. The arena is where the CAMERA goes, not where the
+-- player goes: nothing here writes a cell, a facing, a flag or a warp. A
+-- real warp would have to survive trainer sight-lines, post-battle
+-- dialogue, the blackout path and every script that assumes the player is
+-- where it left them -- and it would have to put them back afterwards.
+-- Moving the camera buys the whole shot and owes nothing back.
+--
+-- The feature declines cleanly rather than half-working: no depth support,
+-- no open ground on the map, the row switched off, or a mesh still building
+-- all end at the same place, which is the battle screen the engine has
+-- always drawn.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local ModSetting = V.require("ModSetting")
+local BattleArena = V.require("BattleArena")
+local BattleCam = V.require("BattleCam")
+local BattleScene = V.require("BattleScene")
+local BattleDOF = V.require("BattleDOF")
+local BattleHud = V.require("BattleHud")
+local BattlePics = V.require("BattlePics")
+local Voxel3D = V.require("Voxel3D")
+local ChunkMesher = V.require("ChunkMesher")
+
+local OverworldBattle = {}
+
+-- DS_BATTLE_DEBUG=1 logs what the HUD's brightness probe is reading, once a
+-- second, which is how the glyph flip is checked from a shot run. Read
+-- through pcall: the loader's sandbox does not hand a mod `os`, and a
+-- diagnostic must never be the reason the mod fails to load.
+local DEBUG = select(2, pcall(function() return os.getenv("DS_BATTLE_DEBUG") end))
+if DEBUG == nil or DEBUG == false then DEBUG = nil end
+
+OverworldBattle.KEY = "battles"
+OverworldBattle.LABEL = "3D-BTL"
+
+-- On by default: a mod whose headline is "the world in 3D" should not need
+-- the player to go and find the switch before the world shows up in a
+-- battle. ON is first, so it is also what an unreadable stored value falls
+-- back to.
+OverworldBattle.setting = ModSetting.new(OverworldBattle.KEY,
+                                         OverworldBattle.LABEL,
+                                         { true, false }, { "ON", "OFF" })
+
+function OverworldBattle.enabled()
+  return OverworldBattle.setting:get() and true or false
+end
+
+-- ------- both mons face you
+--
+-- Standing on a map, seen from in front, a Pokemon showing you its BACK is
+-- wrong twice over: it is turned away from the camera that is looking at it,
+-- and the back pics are a different, smaller drawing made for a slot the
+-- player never really sees. So the player's side asks for the FRONT pic too,
+-- through the engine's own pokemon.sprite hook -- the seam that exists for
+-- exactly this, so no battle code has to be touched to get it.
+--
+-- Answered BEFORE a battle exists, because the battler is built before the
+-- battle is pushed. So it cannot ask whether this fight is staged; it asks
+-- whether one on this map WOULD be -- the row is on, the 3D pass is
+-- available, and the map has an arena -- which is the same question with the
+-- same answer a moment later. Cached per map, because the arena search walks
+-- the whole grid and this runs once per battler.
+local staged = { mapId = nil, ok = false }
+
+function OverworldBattle.wantsFront()
+  if not OverworldBattle.enabled() then return false end
+  if not Voxel3D.available() then return false end
+  -- required here rather than through the file's own helper: this runs
+  -- while a battler is being built, which is before that helper is defined
+  local g = require("src.core.Game")
+  local ow = g and g.overworld
+  if not (ow and ow.map and ow.player) then return false end
+  if staged.mapId ~= ow.map.id then
+    local ok, arena = pcall(BattleArena.find, ow.map,
+                            ow.player.cellX, ow.player.cellY,
+                            ow.player.surfing)
+    staged = { mapId = ow.map.id, ok = (ok and arena) and true or false }
+  end
+  return staged.ok
+end
+
+-- ------- where the engine's own pics stand
+--
+-- The GB draws the player's back pic with its feet on the text box at row 96
+-- and its 7x7-tile slot centred on x=40, and the enemy's front pic
+-- bottom-aligned in a 7x7 slot centred on x=124 ending at row 56. Those two
+-- points are the pics' FEET, they hold for every species at every scale (the
+-- engine's placement helpers pin the bottom edge and the centre), and they
+-- are what BattleCam is solved to put the two arena cells under.
+--
+-- Which makes the pin a subtraction: whatever the drift has done to the
+-- camera this frame, each pic moves by its own cell's projected position
+-- minus its anchor. At the middle of the drift that is zero.
+OverworldBattle.ANCHOR = {
+  player = { 26, 96 },
+  enemy = { 124, 56 },
+}
+
+-- ------- how big a mon is
+--
+-- Not a decision made here. A pic is drawn at its own integer scale -- 1x for
+-- a 56px front pic, 2x for a 32px back one -- because that is the only way it
+-- keeps every pixel the artist drew, and the CAMERA is solved so that one
+-- overworld square is that big on screen (see BattleCam). The mon fits its
+-- tile because the tile was sized to the mon, not the other way round.
+OverworldBattle.SLOT_W = { front = 56, back = 32 }
+
+-- The two HUD blocks, as the pixel spans DrawEnemyHUDAndHPBar and
+-- DrawPlayerHUDAndHPBar actually reach. Neither overlaps its side's pic at
+-- the anchors above.
+OverworldBattle.HUD_RECT = {
+  enemy = { 8, 0, 80, 32 },
+  player = { 72, 56, 88, 40 },
+}
+
+-- ------- the HUDs, out at the window's own edges
+--
+-- The battle screen is 160x144 in the MIDDLE of the window and the world is the
+-- whole of it. That left both HUD blocks huddled together in the middle of the
+-- frame with map showing on either side of them, which reads as a Game Boy
+-- screenshot pasted over a diorama rather than as the diorama's own furniture.
+--
+-- So each block is snapped to its own side: the foe's to the left edge of the
+-- window, the player's to the right. Nothing about either block changes -- same
+-- tiles, same size, same rows, drawn by the engine's own DrawEnemyHUDAndHPBar
+-- and DrawPlayerHUDAndHPBar -- only where the pair sits. On a window the shape
+-- of the GB screen there is nowhere to go and the snap is a no-op.
+--
+-- They cannot simply be MOVED there: the engine draws them into the 160x144 UI
+-- canvas and everything outside it is clipped away. So the layer is rendered to
+-- a texture and composited into the WORLD image instead, which is the one
+-- surface in this mode that covers the whole window.
+
+-- The rows each block is cut out of, full width. Generous on purpose:
+-- AnimationShakeEnemyHUD nudges the foe's block sideways, a long name reaches
+-- further than the panel does, and the pokeball rows and the safari ball count
+-- belong to the block whose rows they sit in. Nothing drawHUDs draws lies
+-- outside rows 0-96, and the two bands split that between them.
+OverworldBattle.HUD_BAND = {
+  enemy = { 0, 0, 160, 48 },
+  player = { 0, 48, 160, 48 },
+}
+
+-- Where each block lands, in WORLD-canvas pixels: the panel rect the frosted
+-- glass is cut to, plus the x its band is blitted at.
+--
+-- The foe's panel starts at the window's left edge and the player's ends at the
+-- right one. The vertical is untouched, so both stay on the rows the GB put
+-- them on. A band's own origin sits outside the window by the panel's inset --
+-- the couple of pixels a HUD shake can push past the edge are clipped there,
+-- which is the whole cost of the snap and is invisible.
+function OverworldBattle.snapRects(shot)
+  local s = shot.scale
+  local e, p = OverworldBattle.HUD_RECT.enemy, OverworldBattle.HUD_RECT.player
+  local ex = -e[1] * s                       -- foe: panel's left edge to 0
+  local px = shot.pw - (p[1] + p[3]) * s     -- player: right edge to the far side
+  local rects = {
+    enemy = { ex + e[1] * s, shot.ly + e[2] * s, e[3] * s, e[4] * s },
+    player = { px + p[1] * s, shot.ly + p[2] * s, p[3] * s, p[4] * s },
+  }
+  return rects, { enemy = ex, player = px }
+end
+
+-- ------- the live battle
+--
+-- nil when no overworld battle is running. Never more than one: battles do
+-- not nest.
+local session = nil
+
+local function game()
+  return require("src.core.Game")
+end
+
+-- Whether this frame's HUDs went out to the window's edges instead of being
+-- drawn in the GB frame. False whenever the composite could not be made, which
+-- is what leaves the in-frame HUD as the fallback rather than no HUD at all.
+local function snapped()
+  return (session and session.snapped) and true or false
+end
+
+-- Put the map's cast back. Both lists are handed back by identity, so
+-- anything that captured one before the battle still sees the same table.
+local function restoreCast()
+  if not (session and session.state) then return end
+  if session.entities then session.state.entities = session.entities end
+  if session.ghosts then session.state.ghosts = session.ghosts end
+  session.entities, session.ghosts = nil, nil
+end
+
+-- Cull them. The player stays -- they are not an NPC, they are who the
+-- battle belongs to, and Fly/surf animations and the save's own capture read
+-- state.player through this list.
+--
+-- Only the DRAW lists are touched, and only while the overworld is frozen
+-- underneath a battle: StateStack updates the top state alone, so nothing
+-- walks, wanders, triggers or collides against a list that is short for
+-- these frames. The originals go back at battle.ended.
+local function cullCast(state)
+  session.entities = state.entities
+  session.ghosts = state.ghosts
+  state.entities = { state.player }
+  state.ghosts = {}
+end
+
+-- ------- one right battle layout
+--
+-- Everything this file composes is measured in the GB's own 160x144 frame: the
+-- two ANCHORs the arena camera is solved to put a cell under, the HUD_RECTs
+-- the frosted panels are cut to, and the full-frame white intercepted to let
+-- the world through. BATTLE LAYOUT's WIDE lays the same battle out on a
+-- 304x144 surface (src/battle/WideBattle.lua), which moves every one of those
+-- -- the mons would stand where no camera was solved for them, and the panels
+-- would land beside the HUDs they are supposed to be under.
+--
+-- So while a fight can be staged on the map there is one right answer, and it
+-- is SET rather than worked around. The engine reads the option live
+-- (BattleState:isWideBattleLayout is asked per frame, and Renderer asks the
+-- top state for its surface the same way), so writing it here lands on the
+-- battle being pushed as well as every one after it.
+--
+-- This is the last line rather than the first: the OPTIONS menu takes the row
+-- off the list and pins the value while 3D-BTL is on (see main.lua), so a
+-- player is never offered a switch that gets reverted under them. What reaches
+-- here is a value that arrived some other way -- a save written before the mod
+-- was installed, the mod manager's own page, another mod.
+function OverworldBattle.forceOG(g)
+  g = g or game()
+  local opts = g and g.save and g.save.options
+  if not opts or opts.battleLayout ~= "wide" then return false end
+  opts.battleLayout = "og"
+  if g.writeOptions then pcall(g.writeOptions, g) end
+  return true
+end
+
+-- Stage a battle triggered from `state`, if this mode can. Returns true when
+-- a session started -- which is also the only case where anything visible
+-- changes, so a map with no room for an arena plays exactly the vanilla
+-- battle it always did, cast and all.
+function OverworldBattle.begin(state, battle)
+  OverworldBattle.finish()
+  if not OverworldBattle.enabled() then return false end
+  if not (state and state.map and state.player) then return false end
+  if not Voxel3D.available() then return false end
+
+  local ok, arena = pcall(BattleArena.find, state.map,
+                          state.player.cellX, state.player.cellY,
+                          state.player.surfing)
+  if not (ok and arena) then return false end
+
+  -- the fight is staged from here on, so the layout it is composed for is not
+  -- optional any more (see forceOG)
+  OverworldBattle.forceOG()
+
+  session = { state = state, arena = arena, battle = battle, shot = nil,
+              armed = false, token = 0 }
+  cullCast(state)
+  BattleCam.reset()
+  return true
+end
+
+-- The fallback entry point: a battle that arrived without going through the
+-- overworld's own pushBattle (a link battle, a script pushing a BattleState
+-- directly). Nothing visible depends on the cull for those -- the wipe has
+-- already been and gone -- but the arena still has to be picked.
+function OverworldBattle.ensure(battle)
+  if session then
+    -- a battle pushed through the overworld reaches begin() before it is
+    -- built far enough to draw; battle.started is where it is finished
+    if battle and not session.battle then session.battle = battle end
+    return
+  end
+  local g = game()
+  local ow = g and g.overworld
+  if ow and ow.map then OverworldBattle.begin(ow, battle) end
+end
+
+-- The arena this battle is staged on, or nil. Read by the shot driver so a
+-- screenshot can be labelled with the ground it was taken on.
+function OverworldBattle.arena()
+  return session and session.arena or nil
+end
+
+function OverworldBattle.finish()
+  if not session then return end
+  restoreCast()
+  session = nil
+  Voxel3D.camera = nil
+end
+
+-- ------- per-frame
+--
+-- Driven from the voxel pipeline's update hook, which the engine ticks every
+-- frame regardless of which state is on top -- including the frames the
+-- transition wipe covers, which is what gets the arena's meshes built before
+-- the first battle frame needs them.
+--
+-- The scene is rendered HERE rather than inside the battle's draw, because
+-- update runs with no canvas bound: a 3D pass that binds a depth target and
+-- unbinds to the screen when it is done cannot do that in the middle of
+-- someone else's frame without putting the frame back itself.
+function OverworldBattle.update(dt)
+  if not session then return end
+
+  local g = game()
+  local top = g and g.stack and g.stack:top()
+  local ow = g and g.overworld
+  -- A battle that ended without saying so (a script tearing the state down,
+  -- a path that never emits battle.ended) would otherwise leave the cast
+  -- culled for good. Armed only once something has actually covered the
+  -- overworld, because begin() runs while the overworld is still on top.
+  if top ~= nil and top ~= ow then
+    session.armed = true
+  elseif session.armed then
+    OverworldBattle.finish()
+    return
+  end
+
+  BattleCam.update(dt)
+  -- the battle only exists once it has been pushed; a session opened at
+  -- pushBattle time has it, one opened from battle.started was handed it
+  session.battle = session.battle or (top ~= ow and top or nil)
+  -- the world pass is hidden behind the battle, so mesh builds get the wide
+  -- slice: nothing visible can hitch on them
+  ChunkMesher.pump(true)
+
+  -- The mons' textures are rendered HERE, with no canvas bound, for the same
+  -- reason the scene is: the pics layer binds its own targets, and doing that
+  -- inside somebody else's frame means putting the frame back afterwards.
+  local okTex, textures = pcall(OverworldBattle.textures, session.battle)
+  if not okTex then textures = nil end
+  session.token = (session.token or 0) + 1
+  local ok, shot = pcall(BattleScene.render, session.state, session.arena,
+                         textures, session.token)
+  if not ok then
+    -- One failure retires the arena for THIS battle and nothing else: the
+    -- battle screen carries on as the engine's own, the free-roam pipeline
+    -- this runs inside keeps rendering the overworld, and the next battle
+    -- tries again. Rethrowing would hand the whole voxel mode to Pipelines'
+    -- guard, which retires a pipeline for the session.
+    session.shot = nil
+    session.snapped = false
+    session.broken = true
+    V.mod.log:warn("overworld battle scene failed: %s -- this battle draws "
+                   .. "on the plain battle background", tostring(shot))
+    return
+  end
+  session.snapped = false
+  if shot and shot.canvas then
+    -- the depth of field is measured off the two marks: the slab in focus is
+    -- the one the mons are standing in, at whatever the drift has done to
+    -- where that lands
+    local y1 = shot.ly + shot.player[2] * shot.scale
+    local y2 = shot.ly + shot.enemy[2] * shot.scale
+    local focusY, band, range = BattleDOF.bandFor(y1, y2, shot.ph)
+    local okDof, blurred = pcall(BattleDOF.apply, shot.canvas,
+                                 focusY, band, range)
+    if okDof and blurred then shot.canvas = blurred end
+    -- the frosted glass the HUDs sit on is built from the FINISHED backdrop,
+    -- so a panel over a blurred far field is frosted from what is actually
+    -- behind it
+    pcall(BattleHud.build, shot.canvas)
+    -- and then the HUDs go ON that backdrop, snapped out to the window's own
+    -- edges (snapHUDs). Here rather than in the battle's draw for the same
+    -- reason the scene is: it binds a canvas of its own. After the frost, so
+    -- the glass is frosted from the world alone and never from the glyphs
+    -- about to sit on it.
+    local okHud, up = pcall(OverworldBattle.snapHUDs, session.battle, shot)
+    session.snapped = (okHud and up) and true or false
+    -- once per battle, not once per frame: a driver that cannot do this cannot
+    -- do it sixty times a second either, and the fallback is silent and fine
+    if not okHud and not session.hudWarned then
+      session.hudWarned = true
+      V.mod.log:warn("overworld battle HUD snap failed: %s -- the HUDs draw "
+                     .. "in the battle frame this battle", tostring(up))
+    end
+  end
+  session.shot = shot
+end
+
+-- The finished shot for this frame, or nil when there is none and the battle
+-- should draw the way it always did.
+function OverworldBattle.shot()
+  if not session or session.broken then return nil end
+  local s = session.shot
+  if s and s.canvas then return s end
+  return nil
+end
+
+function OverworldBattle.invalidate()
+  BattleDOF.invalidate()
+  BattleHud.invalidate()
+  BattlePics.invalidate()
+end
+
+-- ------- the battle screen's background
+--
+-- BattleState opens by filling 160x144 white -- that fill IS the battle's
+-- background, and in the colorized pipeline it is also the BG canvas's clear
+-- (nothing else clears it, so skipping it outright would ghost last frame).
+-- So for the length of one draw, that one call is intercepted: on the two
+-- offscreen canvases it becomes a transparent clear, so the shade-remap pass
+-- composites the HUD and the text box over the arena and leaves the empty
+-- field showing it; on the screen it is simply dropped, because the UI canvas
+-- has already been cleared transparent for the world to show through.
+--
+-- Matched exactly -- fill, the full frame, at the origin, in opaque white --
+-- so the text box (a 20x6 box lower down), a mon pic, an HP bar and the
+-- move-animation flash (which is white at 0.85) all pass through untouched.
+--
+-- This is a shim over love.graphics and it is the one invasive thing here,
+-- so it is scoped as tightly as it can be: installed around a single call,
+-- removed on the way out including on error, and never live outside a battle
+-- frame this mode is drawing.
+local function withoutBackgroundFill(battle, fn)
+  local g = love.graphics
+  local rectangle = g.rectangle
+  g.rectangle = function(mode, x, y, w, h, ...)
+    if mode == "fill" and x == 0 and y == 0
+       and w == BattleScene.GB_W and h == BattleScene.GB_H then
+      local r, gr, b, a = g.getColor()
+      if r > 0.99 and gr > 0.99 and b > 0.99 then
+        -- Two different full-frame whites, both replaced rather than drawn.
+        --
+        -- OPAQUE is the battle's background, and on the offscreen canvases it
+        -- doubles as their clear, so there it becomes a transparent one.
+        --
+        -- TRANSLUCENT is the hit flash. Over a white field that reads as a
+        -- flash; over a world it whites out the map, the HUD and the text box
+        -- together. BattleScene puts it back on the mons alone.
+        if a > 0.99 then
+          local target = g.getCanvas()
+          if target ~= nil
+             and (target == battle.bgCanvas or target == battle.waveCanvas) then
+            g.clear(0, 0, 0, 0)
+          end
+        end
+        return
+      end
+    end
+    return rectangle(mode, x, y, w, h, ...)
+  end
+  local ok, err = pcall(fn, battle)
+  g.rectangle = rectangle
+  if not ok then error(err, 0) end
+end
+
+-- ------- the mons, as textures for the 3D pass
+--
+-- The two Pokemon are not composited over the world any more: they are quads
+-- standing in it (see BattleBillboard). What that needs from the battle
+-- screen is a TEXTURE per side -- and the honest way to get one is to let the
+-- engine draw its own pics layer, unchanged, into a canvas.
+--
+-- So the layer is rendered twice, once per side, with the other side
+-- falsified out of existence by nulling exactly the fields its branches
+-- test. Everything the engine does to a pic comes along for free that way:
+-- the trainer pic before the send-out, the grow-out-of-the-ball scale, the
+-- faint slide, the damage blink, the squish, every SE displacement. None of
+-- it is reimplemented and none of it can drift.
+--
+-- Two things are forced during that render. The scale, to 1, so the texture
+-- carries the artwork's own pixels and the BILLBOARD does the sizing; and the
+-- placement, so the pic lands centred on a known column with its feet on a
+-- known row. That known point is what the quad is then hung from.
+local TEX_AX, TEX_AY = 80, 96          -- forced pic centre and baseline
+local TRAINER_AX, TRAINER_AY = 124, 56 -- the intro trainer pic's own slot
+
+OverworldBattle.TEX_AX, OverworldBattle.TEX_AY = TEX_AX, TEX_AY
+
+-- Which side is being rendered, or nil. The placement wrappers read it.
+local texturing = nil
+
+local texCanvas = {}
+local innerPics = nil                   -- captured by install()
+local innerHUDs = nil                   -- likewise, for the snapped HUD layer
+
+local function texCanvasFor(side)
+  local c = texCanvas[side]
+  if c then return c end
+  local ok, made = pcall(love.graphics.newCanvas, BattleScene.GB_W,
+                         BattleScene.GB_H, { dpiscale = 1 })
+  if not ok then return nil end
+  made:setFilter("nearest", "nearest")
+  texCanvas[side] = made
+  return made
+end
+
+-- Whether this side has anything to draw at all. Mirrors drawPicsLayer's own
+-- guards, so an empty canvas is never hung on a quad: a fainted, hidden or
+-- not-yet-sent-out mon simply has no billboard this frame.
+local function sideVisible(battle, side)
+  if side == "enemy" then
+    if battle.showEnemyTrainer and battle.trainerPic then return true end
+    return (battle.enemy and battle.enemy.sprite and not battle.enemyHidden
+            and not battle.enemySendingOut
+            and not battle:fxHidden(battle.enemy)) and true or false
+  end
+  if battle.showPlayerBack and battle.playerBackPic then return true end
+  local hide = battle.safari or battle.demo
+  return (battle.player and battle.player.sprite and not hide
+          and not battle.sendingOut
+          and not battle:fxHidden(battle.player)) and true or false
+end
+
+local OFF = {
+  enemy = { player = false, showPlayerBack = false },
+  player = { enemy = false, showEnemyTrainer = false },
+}
+
+-- Render one side's pics layer into its canvas and report where the pic's
+-- feet ended up, in canvas coordinates.
+function OverworldBattle.sideTexture(battle, side)
+  if not (innerPics and battle) then return nil end
+  if not sideVisible(battle, side) then return nil end
+  local canvas = texCanvasFor(side)
+  if not canvas then return nil end
+
+  local g = love.graphics
+  local prevCanvas = g.getCanvas()
+  local prevBlend, prevAlpha = g.getBlendMode()
+  -- The pic-window scissors are in the battle screen's fixed coordinates and
+  -- would clip a pic that has been moved to the middle of its own canvas.
+  -- There is nothing here for them to protect -- no HUD, no text box, just
+  -- the one pic -- so they are switched off for the render.
+  local setScissor, intersectScissor = g.setScissor, g.intersectScissor
+  local getScissor = g.getScissor
+  g.setScissor = function() end
+  g.intersectScissor = function() end
+  g.getScissor = function() return nil end
+
+  local saved = {}
+  for k, v in pairs(OFF[side]) do saved[k] = battle[k]; battle[k] = v end
+  texturing = side
+
+  local ok, err = pcall(function()
+    g.setCanvas(canvas)
+    g.clear(0, 0, 0, 0)
+    g.setBlendMode("alpha")
+    g.setColor(1, 1, 1, 1)
+    innerPics(battle, 0, 0, 0)
+  end)
+
+  texturing = nil
+  for k in pairs(OFF[side]) do battle[k] = saved[k] end
+  g.setScissor, g.intersectScissor, g.getScissor =
+    setScissor, intersectScissor, getScissor
+  if prevCanvas then g.setCanvas(prevCanvas) else g.setCanvas() end
+  g.setBlendMode(prevBlend or "alpha", prevAlpha)
+  if not ok then error(err, 0) end
+
+  local ax, ay = TEX_AX, TEX_AY
+  local trainer = false
+  -- The intro trainer pic draws itself straight into its own 7x7 slot rather
+  -- than through the placement helpers, so it is hung from that slot instead.
+  if side == "enemy" and battle.showEnemyTrainer and battle.trainerPic then
+    ax, ay, trainer = TRAINER_AX, TRAINER_AY, true
+  elseif side == "player" and battle.showPlayerBack and battle.playerBackPic then
+    trainer = true
+  end
+  return { canvas = canvas, ax = ax, ay = ay, trainer = trainer }
+end
+
+-- Whether the hit flash is showing this frame.
+--
+-- Mirrors BattleState:draw's own test, because the flash is a DRAW-time
+-- decision there (a counter plus the frame parity that makes it flicker) and
+-- there is no seam that reports it. Read-only, so the worst a future engine
+-- change can do is flash on a frame the engine would not have.
+function OverworldBattle.flashing(battle)
+  local fx = battle and battle.fx
+  if not (fx and fx.flash and fx.flash > 0) then return false end
+  return (battle.frame or 0) % 4 < 2
+end
+
+-- Both sides, or nil when neither has anything to show.
+function OverworldBattle.textures(battle)
+  if not battle then return nil end
+  local out = {}
+  local okE, enemy = pcall(OverworldBattle.sideTexture, battle, "enemy")
+  local okP, player = pcall(OverworldBattle.sideTexture, battle, "player")
+  out.enemy = okE and enemy or nil
+  out.player = okP and player or nil
+  if not (out.enemy or out.player) then return nil end
+  out.flash = OverworldBattle.flashing(battle)
+  return out
+end
+
+-- ------- engine seams
+--
+-- Four wraps, each idempotent so a hot reload cannot stack them.
+
+function OverworldBattle.install()
+  local OverworldState = require("src.world.OverworldController")
+  if not OverworldState.dramaticShapeBattleHook then
+    local inner = OverworldState.pushBattle
+    -- The one place the overworld starts a battle, and it runs BEFORE the
+    -- transition is pushed -- which is what lets the cull happen off-screen
+    -- and the wipe play over a map with nobody on it.
+    function OverworldState:pushBattle(battle)
+      pcall(OverworldBattle.begin, self, battle)
+      return inner(self, battle)
+    end
+    OverworldState.dramaticShapeBattleHook = true
+  end
+
+  local BattleState = require("src.battle.BattleState")
+  if BattleState.dramaticShapeBattleHook then return end
+
+  -- Integer scales only. The camera is solved to make one overworld square
+  -- exactly big enough for a pic at its own integer scale (see BattleCam), so
+  -- the fit never has to come out of the pixels -- and a species override or
+  -- a battle_sprite_scales entry that asks for 1.7x would undo that and
+  -- resample the sprite into mush. Rounded rather than refused, so such a mod
+  -- still gets the bigger or smaller mon it asked for, on the pixel grid.
+  local innerScale = BattleState.resolveBattleScale
+  function BattleState.resolveBattleScale(data, side, path, species)
+    local base = innerScale(data, side, path, species)
+    -- 1:1 into the billboard texture: the artwork's own pixels, with the
+    -- quad's world size doing every bit of the scaling. Anything else would
+    -- resample the sprite twice -- once into the texture and again on the way
+    -- to the screen -- and a twice-resampled Gen 1 pic is mush.
+    if texturing then return 1 end
+    if not OverworldBattle.shot() then return base end
+    return math.max(1, math.floor((tonumber(base) or 1) + 0.5))
+  end
+
+  -- Keyed-out whites inside a pic used to be filled by the white field
+  -- behind it. There is a world back there now, so they are filled here
+  -- instead -- see BattlePics, which puts the paper back without touching
+  -- the silhouette.
+  local innerPic = BattleState.picImage
+  function BattleState:picImage(img)
+    local out = innerPic(self, img)
+    if not OverworldBattle.shot() then return out end
+    return BattlePics.filled(out)
+  end
+
+  -- While a billboard texture is being rendered both pics are put in the same
+  -- known place -- centred on TEX_AX with their feet on TEX_AY -- so the quad
+  -- has one anchor to hang from whichever side and whichever species it is
+  -- carrying. Outside that render both helpers answer exactly as they always
+  -- did.
+  local innerBack = BattleState.backPlacement
+  function BattleState.backPlacement(w, h, pad, padL, scale)
+    local x, y, s = innerBack(w, h, pad, padL, scale)
+    if not texturing then return x, y, s end
+    return TEX_AX - w * scale / 2, TEX_AY - (h - pad) * scale, s
+  end
+
+  local innerFront = BattleState.frontPlacement
+  function BattleState.frontPlacement(ex, ey, w, h, scale)
+    local x, y, s = innerFront(ex, ey, w, h, scale)
+    if not texturing then return x, y, s end
+    return TEX_AX - w * scale / 2, TEX_AY - h * scale, s
+  end
+
+  local innerDraw = BattleState.draw
+  function BattleState:draw()
+    local shot = OverworldBattle.shot()
+    -- AskName blanks the field on purpose (the nickname prompt is meant to
+    -- sit on nothing); leave that one alone.
+    if not shot or self.blankForAskName then
+      -- nil, not false: the class default is inherited again, so a battle
+      -- that loses its arena mid-fight goes back to white voids
+      self.letterboxWhite = nil
+      self.dramaticShapeShot = nil
+      return innerDraw(self)
+    end
+    self.dramaticShapeShot = shot
+    -- The world reaches the screen through the seam a render pipeline's
+    -- finished world image already uses: one window-resolution canvas,
+    -- blitted a pixel to a pixel, with the 160x144 UI canvas composited over
+    -- it in the classic letterbox afterwards. That is what makes the backdrop
+    -- as crisp as the free-roam diorama while the pics and text stay GB art.
+    local renderer = game().renderer
+    if renderer and renderer.setWorldOverride then
+      renderer:setWorldOverride(shot.canvas)
+    end
+    -- beginFrame clears the UI canvas white for an opaque state; the world is
+    -- under it now, so clear it back to nothing and let it through. Safe to
+    -- do here: an opaque battle is the lowest state drawn, so nothing has
+    -- drawn into this canvas yet.
+    love.graphics.clear(0, 0, 0, 0)
+    -- the white letterbox exists so the window matches the white battle
+    -- canvas; there is a world out to the window edges now
+    self.letterboxWhite = false
+    OverworldBattle.drawHudPanels(self)
+    withoutBackgroundFill(self, innerDraw)
+  end
+
+  -- The mons are geometry standing on the map now, drawn in the 3D pass
+  -- before this screen is composited at all, so the flat pics layer has
+  -- nothing left to do here. Skipped rather than left to draw underneath, or
+  -- every Pokemon would appear twice: once on its tile and once in its slot.
+  innerPics = BattleState.drawPicsLayer
+  function BattleState:drawPicsLayer(slide, sx, sy)
+    if self.dramaticShapeShot then return end
+    return innerPics(self, slide, sx, sy)
+  end
+
+  -- Move animations are authored against the pics' fixed slots, and a single
+  -- animation reaches across both sides, so there is no per-side offset to
+  -- give them. They ride the average, which is where the pair's centre went
+  -- -- a few pixels at most, and it keeps a hit landing on the mon it is
+  -- aimed at instead of drifting off it.
+  local innerAnim = BattleState.drawAnimLayer
+  function BattleState:drawAnimLayer(colorized)
+    local shot = self.dramaticShapeShot
+    if not shot then return innerAnim(self, colorized) end
+    -- Move animations are authored against the pics' old fixed slots, and one
+    -- animation reaches across both sides, so there is no per-side offset to
+    -- give them. They ride to where the PAIR went: the midpoint of the two
+    -- mons' projected positions, less the midpoint of the slots they used to
+    -- sit in. A hit still lands on the mon it is aimed at.
+    local a = OverworldBattle.ANCHOR
+    local dx = (shot.enemy[1] + shot.player[1]) / 2
+                 - (a.enemy[1] + a.player[1]) / 2
+    local dy = (shot.enemy[2] + shot.player[2]) / 2
+                 - (a.enemy[2] + a.player[2]) / 2
+    love.graphics.push()
+    love.graphics.translate(math.floor(dx + 0.5), math.floor(dy + 0.5))
+    local ok, err = pcall(innerAnim, self, colorized)
+    love.graphics.pop()
+    if not ok then error(err, 0) end
+  end
+
+  -- The engine's flash has a SECOND half, and it is the one that reaches the
+  -- menu. Beside the white rectangle (dropped above) the flash moves are
+  -- driven by a BGP palette fade -- BGP_LIGHT and friends -- which the
+  -- colorized pipeline applies in drawZonePass to the WHOLE background
+  -- canvas. That canvas carries the HUD glyphs and the text box, so a fade
+  -- meant for the two mons washed the menu out with them.
+  --
+  -- The fade is left switched on for the pics, which read it through
+  -- picImage, and switched off for the zone pass alone. So the mons flash
+  -- and the furniture around them does not.
+  --
+  -- The zone pass has a SECOND thing it paints, and this is the one that
+  -- reads as the menu box flashing. A screen shake makes it fill every zone
+  -- with the zone's own color 0 before it draws the offset copy -- the
+  -- hardware showing empty BG in the strip the shake vacated. On a white
+  -- battle field that fill is invisible; over a world it is an opaque white
+  -- sheet across the whole frame, and since a shake program alternates
+  -- offset and no-offset frames (SE_SHAKE_SCREEN steps dx 1, 0, 1, 0...) it
+  -- switches on and off a few times a second. It is dropped: the background
+  -- here is the map, so what the shake vacates should show the map.
+  local innerZone = BattleState.drawZonePass
+  function BattleState:drawZonePass(src, sx, sy)
+    if not self.dramaticShapeShot then return innerZone(self, src, sx, sy) end
+    -- shadow the method on the instance for this call only; putting the
+    -- field back to whatever it was (normally nil) lets the class method be
+    -- found again
+    local had = rawget(self, "activeBgp")
+    self.activeBgp = function() return nil end
+    local g = love.graphics
+    local rectangle = g.rectangle
+    g.rectangle = function(mode, ...)
+      -- the pass draws no other rectangle; the shake still shifts the copy
+      if mode == "fill" then return end
+      return rectangle(mode, ...)
+    end
+    local ok, err = pcall(innerZone, self, src, sx, sy)
+    g.rectangle = rectangle
+    self.activeBgp = had
+    if not ok then error(err, 0) end
+  end
+
+  -- Black glyphs on grass are not readable; over a frosted panel measured
+  -- dark they are not readable either, so they go white. Mapped rather than
+  -- rewritten: the HUD sets pure black for its text and nothing else, and in
+  -- the colorized pipeline this lands in the grayscale BG canvas, where
+  -- white IS shade 0 and the zone pass then colours it like every other
+  -- lightest-shade surface. One rule, both pipelines.
+  --
+  -- The HP bar is untouched: it is drawn in its own greens and reds, and
+  -- only an exactly-black set is remapped.
+  innerHUDs = BattleState.drawHUDs
+  function BattleState:drawHUDs(slide)
+    -- Normally the HUDs have already been drawn this frame, snapped out to the
+    -- window's edges and composited into the world image (snapHUDs). Drawing
+    -- them here as well would show each block twice, once in each place.
+    if self.dramaticShapeShot and snapped() then return end
+    if not (self.dramaticShapeShot and self.dramaticShapeDark) then
+      return innerHUDs(self, slide)
+    end
+    local battle = self
+    BattleHud.flipGlyphs(BattleScene.GB_W, BattleScene.GB_H, function()
+      innerHUDs(battle, slide)
+    end)
+  end
+
+  BattleState.dramaticShapeBattleHook = true
+end
+
+-- Whether each HUD block is on screen this frame.
+--
+-- READ-ONLY duplicates of drawHUDs' own two guards, because there is no seam
+-- that reports "the enemy HUD is up". A panel under a HUD that is not there
+-- would be a frosted slab floating in the arena, so it is worth mirroring;
+-- the worst a future engine change can do is show an empty one for a frame,
+-- never break a battle.
+function OverworldBattle.hudLive(battle, slide)
+  local enemy = battle.enemy and not battle.showEnemyTrainer
+                and not battle.enemySendingOut
+                and not battle:growInScale(battle.enemy) and slide == 0
+                and not battle.enemy.fainted
+  local player = battle.player and not (battle.safari or battle.demo)
+                 and not battle.showPlayerBack and slide == 0
+  return enemy and true or false, player and true or false
+end
+
+-- ------- the snapped composite
+--
+-- The engine's own HUD layer, rendered into a texture.
+--
+-- One thing is falsified for the render, and it is falsified because this layer
+-- never reaches the battle's zone pass -- it is composited into the world image,
+-- outside the frame that pass covers. In the colorized pipeline drawHUDs leaves
+-- the HP bar's fill as DMG gray for the zone pass to colour by region (#229);
+-- answered false, it tints its own greens and reds instead, exactly as it does
+-- on the flat path. The glyphs are pure black either way, which is what the
+-- flip in BattleHud.layerTexture is measured against.
+--
+-- Shadowed on the instance for this call only, the way drawZonePass shadows
+-- activeBgp: putting the field back to whatever it was (normally nil) lets the
+-- class method be found again.
+function OverworldBattle.hudTexture(battle, slide, dark)
+  if not (innerHUDs and battle) then return nil end
+  local had = rawget(battle, "colorMode")
+  battle.colorMode = function() return false end
+  local ok, layer = pcall(BattleHud.layerTexture,
+                          BattleScene.GB_W, BattleScene.GB_H, dark,
+                          function() innerHUDs(battle, slide) end)
+  battle.colorMode = had
+  return ok and layer or nil
+end
+
+-- Draw both HUD blocks into the world image at the window's edges, each on its
+-- own frosted panel. Returns true when the frame's HUDs are up there and the
+-- in-frame draw must be skipped; false leaves the battle screen's own HUD
+-- exactly as it was before any of this existed.
+--
+-- Both bands are blitted whether or not that side's HUD is LIVE, because a band
+-- carries more than the HUD: the pokeball rows of the intro and of an enemy
+-- faint, and the safari ball count, all draw in these rows and belong at the
+-- same edge as the block they share it with. The panels are the ones that
+-- follow hudLive -- frosted glass under nothing is a slab floating in the arena.
+function OverworldBattle.snapHUDs(battle, shot)
+  if not (battle and shot and shot.canvas and (shot.scale or 0) > 0) then
+    return false
+  end
+  local slide = (battle.introSlide or 0) * 4
+  local rects, bandX = OverworldBattle.snapRects(shot)
+  local enemy, player = OverworldBattle.hudLive(battle, slide)
+  local live = {}
+  if enemy then live.enemy = rects.enemy end
+  if player then live.player = rects.player end
+  -- measured under the SNAPPED rects: the panels are over whatever the world
+  -- shows at the window's edges now, which is not what was behind them in the
+  -- middle of the frame
+  local dark = BattleHud.verdict(live, shot, true)
+  local layer = OverworldBattle.hudTexture(battle, slide, dark)
+  if not layer then return false end
+
+  local g = love.graphics
+  local prevCanvas = g.getCanvas()
+  local prevBlend, prevAlpha = g.getBlendMode()
+  local ok, err = pcall(function()
+    g.setCanvas(shot.canvas)
+    g.setBlendMode("alpha")
+    for _, rect in pairs(live) do BattleHud.panel(rect, shot, dark, true) end
+    g.setColor(1, 1, 1, 1)
+    for side, band in pairs(OverworldBattle.HUD_BAND) do
+      local quad = g.newQuad(band[1], band[2], band[3], band[4],
+                             BattleScene.GB_W, BattleScene.GB_H)
+      g.draw(layer, quad, bandX[side] + band[1] * shot.scale,
+             shot.ly + band[2] * shot.scale, 0, shot.scale, shot.scale)
+    end
+  end)
+  if prevCanvas then g.setCanvas(prevCanvas) else g.setCanvas() end
+  g.setBlendMode(prevBlend or "alpha", prevAlpha)
+  g.setColor(1, 1, 1, 1)
+  if not ok then error(err, 0) end
+  return true
+end
+
+-- Lay the frosted glass down under whichever HUD is about to draw, and
+-- record which way the glyphs have to flip.
+--
+-- The fallback path only: with the HUDs snapped out to the window's edges their
+-- panels went with them, and there is nothing left inside the GB frame to lay
+-- glass under.
+function OverworldBattle.drawHudPanels(battle)
+  local shot = battle.dramaticShapeShot
+  battle.dramaticShapeDark = nil
+  if not shot or snapped() then return end
+  local slide = (battle.introSlide or 0) * 4
+  local enemy, player = OverworldBattle.hudLive(battle, slide)
+  if not (enemy or player) then return end
+  local rect = OverworldBattle.HUD_RECT
+  local live = {}
+  if enemy then live.enemy = rect.enemy end
+  if player then live.player = rect.player end
+  local dark = BattleHud.verdict(live, shot)
+  battle.dramaticShapeDark = dark
+  for _, r in pairs(live) do BattleHud.panel(r, shot, dark) end
+end
+
+return OverworldBattle

--- a/mods/dramatic_shape/lib/ShadowMap.lua
+++ b/mods/dramatic_shape/lib/ShadowMap.lua
@@ -1,0 +1,478 @@
+-- Voxel world mode: the sun's own pass -- a real shadow map.
+--
+-- The old drop shadows were decals: each character's sprite frame squashed
+-- flat onto the ground plane it stood on. That can only ever paint the
+-- FLOOR, so a shadow stopped dead at the foot of a wall, and nothing but a
+-- character cast one at all -- buildings, trees, signs and ledges threw
+-- nothing.
+--
+-- So render the scene once from the sun instead. An orthographic camera
+-- pointed down the sun line stores, per texel, how far the light travelled
+-- before it hit something; the main pass transforms each fragment into that
+-- same space and asks whether anything got there first. What the sun cannot
+-- see is in shadow, whatever surface it happens to be -- so a shadow climbs
+-- a wall, drapes over a roof and slides across a passing NPC without a
+-- single case in the code, and every caster is simply whatever the pass
+-- draws: the terrain mesh (buildings, trees, ledges, props -- all of it)
+-- plus one upright card per character.
+--
+-- Depth is stored in an ORDINARY color canvas, packed into two 8-bit
+-- channels (~16 bits over the frustum, well under a tenth of a world
+-- pixel). A readable depth texture would be tidier, but depth sampling is
+-- the least portable corner of the graphics API and this mod's whole
+-- contract is that an unsupported driver falls back rather than errors --
+-- everything here is pcall-guarded and `available()` reports the result,
+-- with VoxelScene dropping back to the flat decal shadows when it says no.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local Mat4 = V.require("Mat4")
+local Voxel = V.require("VoxelState")
+
+local ShadowMap = {}
+
+-- The sun, as the shear a shadow takes: a point `y` world-pixels above the
+-- ground drops its shadow (KX*y, KZ*y) away from the point under it. Both
+-- negative hangs the sun in the SOUTHEAST, so every shadow falls northwest
+-- -- up and to the left on screen, since the camera puts north at the top
+-- and east to the right at every tilt.
+--
+-- Their MAGNITUDE is how low the sun sits: hypot(KX, KZ) = 1.01 puts it
+-- about 45 degrees up, so a 16px character throws a shadow about as long
+-- as it is tall -- against the 62-degree noon these started at, which read
+-- as a smudge under everybody's feet.
+--
+-- Their RATIO is the compass bearing, and it leans WEST of northwest on
+-- purpose. A character is drawn as a slab leaning back away from the
+-- camera, which covers the ground directly north of its feet -- so a
+-- shadow thrown due north lands entirely underneath the figure casting it
+-- and is never seen. At 0.85 west the shadow reaches 13px out against the
+-- sprite's own 8px half-width, so it clears the slab and reads, while 0.55
+-- north still puts it a clear 23 degrees up from horizontal on screen.
+ShadowMap.KX = -0.85      -- west drift per pixel of height
+ShadowMap.KZ = -0.55      -- north drift per pixel of height
+
+-- Shadow map edge, in texels -- chosen per frame from this ladder, because
+-- the light frustum is sized to the WORLD VIEW and that swings by 3x
+-- between the closest zoom and a maximised window at the widest. A fixed
+-- edge is either wasteful at one end or a blur at the other.
+--
+-- TARGET is the world pixels per texel worth paying for: at a third of a
+-- pixel a shadow edge lands inside the pixel grid this whole mode exists
+-- to keep crisp, and finer buys nothing the grid can show. The smallest
+-- size that meets it wins, and the ladder tops out at 2048 (16 MB, and the
+-- depth buffer behind it matches) rather than chasing the target forever.
+ShadowMap.SIZES = { 1024, 1536, 2048 }
+ShadowMap.TARGET = 0.45
+ShadowMap.res = 1024      -- the rung in use; read by the main pass's filter
+
+-- The tallest geometry the pass covers: gabled buildings and border forest
+-- run well under this, and the margin it buys costs only resolution --
+-- with the sun this low the frustum has to widen by most of HEIGHT again
+-- on every side to catch what casts in from off-screen.
+ShadowMap.HEIGHT = 160
+
+-- Depth slack at the comparison, in world pixels. Too little and a lit
+-- surface shadows itself in a moire of acne; too much and a shadow detaches
+-- from the foot of what casts it. The frustum is ~400 world pixels deep and
+-- the packed depth resolves under 0.01 of one, so there is room.
+--
+-- It cannot be ONE number, because what the comparison has to forgive is
+-- not fixed: the map stores one depth for a whole texel, so a lit surface
+-- reads its own depth wrong by however far it RAMPS across that texel --
+-- the texel's world size times the surface's slope in the light's frame.
+-- The texel swings from a third of a world pixel at the closest zoom to
+-- well over one at a maximised window on the widest, so a constant bias is
+-- generous at one end of the ladder and short at the other. Short shows up
+-- as diagonal bands of acne across big lit surfaces -- diagonal because
+-- the moire runs along neither the world grid nor the screen's, but along
+-- the depth ramp in the sun's own frame, and the sun sits southeast.
+--
+-- So: a floor for what does not scale (the packed depth's quantisation,
+-- and the two passes reaching the same world point by different matrices),
+-- plus a term in texels for what does.
+ShadowMap.BIAS = 0.5
+
+-- World pixels of slack per world pixel of texel, for the steepest LIT
+-- surface here: a roof pitched 45 degrees and turned away from the sun,
+-- whose depth ramps about 3.1 world pixels per texel crossed on EITHER of
+-- the light frame's two axes (a vertical wall, by comparison, manages 1.7,
+-- flat ground 0.7, and anything steeper than that roof has its back to the
+-- sun and never reads the map at all). The 2x2 filter's taps sit half a
+-- texel out on both axes at once, so the worst a tap can disagree by is
+-- half the ramp along each -- which is where the halving that turns 6.2
+-- into 3.1 comes from, and why it is the SUM of the two components rather
+-- than their magnitude.
+--
+-- Measured against the artefact rather than trusted: the probe
+-- (tests/voxel_acne_probe.lua) counts isolated shadowed pixels on lit
+-- surfaces, and the banding stops at slack ~2.4 world px on the widest
+-- rung -- where this lands 3.1 * 0.83 + 0.5.
+ShadowMap.SLOPE = 3.1
+
+-- The slack `fit` last worked out, in world pixels -- BIAS + SLOPE*texel.
+-- Read by probes; `ShadowMap.bias` is the same number as the [0,1] depth
+-- the map actually stores.
+ShadowMap.slack = ShadowMap.BIAS
+
+local SHADER = [[
+  varying float vDepth;
+#ifdef VERTEX
+  uniform mat4 lightVP;
+  uniform mat4 model;
+  vec4 position(mat4 transform_projection, vec4 vertex_position) {
+    vec4 c = lightVP * (model * vertex_position);
+    // the projection is orthographic, so w is 1 and clip z IS the depth,
+    // linear in world units along the sun line
+    vDepth = c.z * 0.5 + 0.5;
+    return c;
+  }
+#endif
+#ifdef PIXEL
+  vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+    // the same alpha discard the main pass uses: a sprite card casts its
+    // silhouette, not its 16x16 bounding box
+    if (Texel(tex, tc).a < 0.5) discard;
+    // pack into two channels: the high byte in red, the low in green
+    float d = clamp(vDepth, 0.0, 1.0) * 255.0;
+    return vec4(floor(d) / 255.0, fract(d), 0.0, 1.0);
+  }
+#endif
+]]
+
+local shader = nil            -- nil = untried, false = unavailable
+local canvas = nil            -- nil = untried, false = unavailable
+local canvasRes = 0           -- the edge `canvas` was made at
+local blank = nil             -- 1x1 stand-in so the sampler is never unbound
+local drawing = false
+local ready = false
+local lastSig = nil
+local prevBlend, prevAlphaMode = nil, nil
+
+local IDENTITY = Mat4.identity()
+
+-- world -> [0,1] cube, applied on top of the clip matrix: the main pass
+-- samples the map with the xy and compares against the z
+local TO_UNIT = { 0.5, 0, 0, 0.5,
+                  0, 0.5, 0, 0.5,
+                  0, 0, 0.5, 0.5,
+                  0, 0, 0, 1 }
+
+-- world -> light clip space, for the pass that FILLS the map
+ShadowMap.clipVP = IDENTITY
+-- world -> the unit cube, for the pass that READS it
+ShadowMap.uvVP = IDENTITY
+-- ShadowMap.BIAS expressed in the [0,1] depth the map stores
+ShadowMap.bias = 0
+
+local function getShader()
+  if shader == nil then
+    local ok, sh = pcall(love.graphics.newShader, SHADER)
+    shader = (ok and sh) or false
+  end
+  return shader or nil
+end
+
+-- The map canvas at edge `res`, rebuilt when the rung changes (a zoom
+-- step, a window resize). `false` is sticky: a driver that could not make
+-- one at all is not asked again every frame.
+local function getCanvas(res)
+  if canvas == false then return nil end
+  if canvas and canvasRes == res then return canvas end
+  local ok, c = pcall(love.graphics.newCanvas, res, res)
+  if not (ok and c) then
+    canvas = false
+    return nil
+  end
+  -- nearest: the 2x2 filter in the main pass wants raw texels, and a
+  -- linearly blended PACKED depth is not a depth at all
+  c:setFilter("nearest", "nearest")
+  pcall(c.setWrap, c, "clamp", "clamp")
+  if canvas and canvas.release then pcall(canvas.release, canvas) end
+  canvas, canvasRes = c, res
+  ready = false
+  return canvas
+end
+
+-- A 1x1 opaque white image. The main pass's shader always declares the
+-- shadow sampler, so something has to be bound even on the frames (and the
+-- drivers) where there is no map -- unpacked it reads as depth 1 + 1/255,
+-- which is beyond the far plane and therefore "nothing occludes anything".
+local function getBlank()
+  if blank == nil then
+    local ok, img = pcall(function()
+      local data = love.image.newImageData(1, 1)
+      data:setPixel(0, 0, 1, 1, 1, 1)
+      return love.graphics.newImage(data)
+    end)
+    blank = (ok and img) or false
+  end
+  return blank or nil
+end
+
+-- Whether the sun pass can run at all. False headless, without shaders, or
+-- where the canvas cannot be made -- VoxelScene then keeps the flat decal
+-- shadows, which need nothing but a quad.
+function ShadowMap.available()
+  if not (love.graphics and love.graphics.newCanvas
+          and love.graphics.setDepthMode) then
+    return false
+  end
+  -- the smallest rung is enough to answer the question; fit() picks the
+  -- one this frame actually wants
+  return getShader() ~= nil and getCanvas(ShadowMap.SIZES[1]) ~= nil
+end
+
+-- The map to sample, or the blank stand-in. Never nil once the main pass
+-- has a shader at all, because an unbound sampler is a driver-dependent
+-- crash rather than a driver-dependent fallback.
+function ShadowMap.texture()
+  if ready and canvas then return canvas end
+  return getBlank()
+end
+
+-- True while the map holds a frame the main pass can read.
+function ShadowMap.active()
+  return ready and canvas ~= nil and canvas ~= false
+end
+
+-- The direction the light TRAVELS, normalized. The shear is the shadow a
+-- unit of height throws, so the displacement from a point to where its
+-- shadow lands is (KX, -1, KZ) -- which is the ray.
+local function sunDir()
+  local x, y, z = ShadowMap.KX, -1, ShadowMap.KZ
+  local l = math.sqrt(x * x + y * y + z * z)
+  return { x / l, y / l, z / l }
+end
+
+ShadowMap.sunDir = sunDir
+
+-- How far NORTH of the view centre the camera can still see ground, in
+-- world pixels: the top edge of the view frustum dropped onto the ground
+-- plane. The lower the camera the further that reaches, and past about 64
+-- degrees the ray clears the horizon and the honest answer is "forever" --
+-- hence the cap. Ground beyond it compresses into a few pixels near the
+-- skyline, and its shadows with it, so the border fade in the main pass
+-- eases them out rather than the frustum ending on a hard line.
+ShadowMap.FAR_CAP = 2.5     -- multiples of the view height
+
+local function groundReach(vh)
+  local a = Voxel.angle or 0
+  local cap = ShadowMap.FAR_CAP * vh
+  -- half the vertical field of view: the same FOCAL the camera projects
+  -- with, so the two frusta agree about what is on screen
+  local half = math.atan(1 / (2 * Voxel.FOCAL))
+  local below = (math.pi / 2 - a) - half     -- top ray, below horizontal
+  if below <= 0.02 then return cap end
+  local dist = Voxel.FOCAL * vh
+  local horizon = dist * math.cos(a) / math.tan(below)
+  return math.max(vh / 2, math.min(cap, horizon - dist * math.sin(a)))
+end
+
+-- Fit the light frustum to the ground the camera can see, plus the margin
+-- the casters for it stand in.
+--
+-- Both are ASYMMETRIC, and for opposite reasons. The camera sits south of
+-- its focus and looks north, so the ground it sees runs far north and
+-- barely south. The sun sits southeast, so the things whose shadows land
+-- on that ground stand south and east of it -- which means the caster
+-- margin is only ever needed on two of the four sides. Paying for it on
+-- all four (and for a view-sized box at every pitch) is what the first cut
+-- did, and at 75 degrees it covered about a third of what was on screen.
+--
+-- The box is snapped to whole texels. Without that, a frustum that slides
+-- continuously with the camera reprojects every shadow edge a fraction of a
+-- texel every frame and the whole world's shadows crawl and shimmer while
+-- you walk.
+local function fit(cx, cy, vw, vh)
+  local f = sunDir()
+  local view = Mat4.lookAt({ 0, 0, 0 }, f, { 0, 0, -1 })
+
+  local reach = ShadowMap.HEIGHT
+                * math.max(math.abs(ShadowMap.KX), math.abs(ShadowMap.KZ)) + 24
+  local north = groundReach(vh)
+  -- the view widens with distance, so the far ground spans more than the
+  -- near ground does; half the depth is a serviceable stand-in for the
+  -- frustum's true spread and costs a good deal less resolution
+  local spread = north * 0.5
+  local xs = { cx - vw / 2 - spread, cx + vw / 2 + spread + reach }
+  local ys = { -32, ShadowMap.HEIGHT }         -- -32 covers recessed water
+  local zs = { cy - north, cy + vh / 2 + reach }
+
+  local l, r, b, t, zn, zf
+  for _, x in ipairs(xs) do
+    for _, y in ipairs(ys) do
+      for _, z in ipairs(zs) do
+        local px = view[1] * x + view[2] * y + view[3] * z + view[4]
+        local py = view[5] * x + view[6] * y + view[7] * z + view[8]
+        local pz = view[9] * x + view[10] * y + view[11] * z + view[12]
+        l = l and math.min(l, px) or px
+        r = r and math.max(r, px) or px
+        b = b and math.min(b, py) or py
+        t = t and math.max(t, py) or py
+        zn = zn and math.min(zn, pz) or pz
+        zf = zf and math.max(zf, pz) or pz
+      end
+    end
+  end
+
+  local w, h = r - l, t - b
+
+  -- pick the resolution rung: the smallest that resolves TARGET world
+  -- pixels per texel across the wider side, else the largest there is
+  local res = ShadowMap.SIZES[#ShadowMap.SIZES]
+  for _, size in ipairs(ShadowMap.SIZES) do
+    if math.max(w, h) / size <= ShadowMap.TARGET then
+      res = size
+      break
+    end
+  end
+  ShadowMap.res = res
+
+  -- the box's SIZE is fixed (the sun and the view size are), so snapping
+  -- its corner to a texel multiple moves it in whole texels only
+  local tx, ty = w / res, h / res
+  l = math.floor(l / tx) * tx
+  b = math.floor(b / ty) * ty
+  r, t = l + w, b + h
+
+  -- view-space z runs NEGATIVE into the scene; ortho() wants distances,
+  -- and the slack keeps geometry taller than HEIGHT from being clipped
+  -- clean out of the pass instead of merely casting a truncated shadow
+  local near, far = -zf - 64, -zn + 64
+  local proj = Mat4.ortho(l, r, b, t, near, far)
+  -- flip clip-space Y for the same reason the camera does: we bypass
+  -- LOVE's transform_projection, and canvas coordinates run Y DOWN, so
+  -- without this the map is stored upside down relative to the uv the
+  -- main pass reads it with
+  proj = Mat4.mul(Mat4.scale(1, -1, 1), proj)
+
+  ShadowMap.clipVP = Mat4.mul(proj, view)
+  ShadowMap.uvVP = Mat4.mul(TO_UNIT, ShadowMap.clipVP)
+  -- what the frustum ended up covering, for probes: the lateral extent in
+  -- world pixels divided by RES is how fine a shadow edge can land
+  ShadowMap.extent = { r - l, t - b, far - near }
+  -- the slack the comparison needs, against the coarser of the two texel
+  -- axes (the box is asymmetric, and one number has to cover both)
+  ShadowMap.slack = ShadowMap.BIAS
+                    + ShadowMap.SLOPE * math.max(w, h) / res
+  -- the stored depth spans the frustum, so a world-pixel bias is that
+  -- fraction of it
+  ShadowMap.bias = ShadowMap.slack / math.max(1, far - near)
+end
+
+-- How much of the compare's forgiveness a snugged caster takes back, 0..1.
+-- Short of 1 on purpose: at exactly 1 the card's own fragments compare
+-- against their own stored depth on a float-equality knife edge and can
+-- speckle. The tenth left over is dozens of times the packed depth's
+-- quantization -- ample for that -- and leaves the contact gap around a
+-- quarter of a world pixel at any sun, which no zoom resolves.
+ShadowMap.SNUG = 0.9
+
+-- A CASTER snugged up the sun ray -- moved TOWARD the light -- before it is
+-- drawn into the map.
+--
+-- The depth compare forgives `slack` world pixels (BIAS + the SLOPE term)
+-- so lit surfaces do not acne against their own texels -- but that same
+-- forgiveness is what lets the ground right next to a standing figure read
+-- as lit: a receiver within `slack` of its blocker along the ray passes the
+-- test, so the first stretch of every shadow is forgiven away and on screen
+-- it starts that far from the feet, further the lower the sun. The classic
+-- peter-panning; unseen while the sun hung at a fixed 45 degrees, plain at
+-- a day/night golden hour or under the moon.
+--
+-- Moving the card ALONG ITS OWN RAY changes nothing about where its shadow
+-- falls -- every point stays on the same light ray -- but moving it toward
+-- the sun stores it SHALLOWER, so a ground point right at the foot is
+-- already `slack` deeper than the stored blocker and fails the lit test:
+-- the root lands back under the feet. Nothing else is touched -- no
+-- terrain moved, so the acne margin the slack exists for is intact where
+-- it matters. For sprite cards and other thin stand-ins only.
+--
+-- ONE OBLIGATION comes with it: the caster's LIT draw must hand this same
+-- snugged transform to its shadow lookup (Voxel3D.draw's `sunModel`).
+-- Stored and lookup then agree exactly, as they did before snugging, and
+-- the compare keeps its full acne margin. A caster stored snugged but read
+-- un-snugged is 0.9 of the margin short, and the loss shows up as diagonal
+-- moire bands crawling across the card.
+--
+-- Valid between begin() and the next begin(): `slack` and the sun hold
+-- still between redraws of the map, so a lit frame that reuses last
+-- frame's map computes the same displacement it was stored with.
+function ShadowMap.snug(model)
+  local f = sunDir()
+  local s = -ShadowMap.slack * ShadowMap.SNUG
+  return Mat4.mul(Mat4.translate(f[1] * s, f[2] * s, f[3] * s),
+                  model or IDENTITY)
+end
+
+-- Whether the map has to be redrawn for `sig` -- a caller-built stamp of
+-- everything the pass depends on (camera, terrain meshes, every pose). A
+-- frame that changes none of it reuses the map it already has, which is
+-- most of a dialog, a menu or any moment standing still.
+function ShadowMap.stale(sig)
+  return not ready or sig ~= lastSig
+end
+
+-- Begin the sun pass. Returns false when it could not start, in which case
+-- the caller must not draw into it or call finish.
+function ShadowMap.begin(cx, cy, vw, vh)
+  local sh = getShader()
+  if not sh then return false end
+  -- fit first: it is what decides which resolution rung this view wants
+  fit(cx, cy, vw, vh)
+  local c = getCanvas(ShadowMap.res)
+  if not c then return false end
+  local ok = pcall(love.graphics.setCanvas, { c, depth = true })
+  if not ok then
+    pcall(love.graphics.setCanvas)
+    return false
+  end
+  prevBlend, prevAlphaMode = love.graphics.getBlendMode()
+  -- white clears to depth 1 + 1/255, past the far plane: a texel nothing
+  -- was drawn into can never shadow anything
+  love.graphics.clear(1, 1, 0, 1, true, true)
+  love.graphics.setDepthMode("lequal", true)
+  love.graphics.setMeshCullMode("none")
+  -- replace, not alpha blend: these are packed numbers, not colors
+  love.graphics.setBlendMode("replace", "premultiplied")
+  love.graphics.setShader(sh)
+  love.graphics.setColor(1, 1, 1, 1)
+  pcall(sh.send, sh, "lightVP", "row", ShadowMap.clipVP)
+  drawing = true
+  ready = false
+  return true
+end
+
+-- Draw one caster. Same signature as Voxel3D.draw minus the camera-ward
+-- pull, which is a trick for the VIEW's depth buffer and would drag a
+-- shadow off whatever throws it.
+function ShadowMap.draw(mesh, texture, model)
+  if not (drawing and mesh) then return end
+  local sh = getShader()
+  if texture then mesh:setTexture(texture) end
+  pcall(sh.send, sh, "model", "row", model or IDENTITY)
+  love.graphics.draw(mesh)
+end
+
+-- Close the pass and stamp it with the signature it was drawn for.
+function ShadowMap.finish(sig)
+  if not drawing then return end
+  drawing = false
+  love.graphics.setShader()
+  love.graphics.setDepthMode()
+  love.graphics.setCanvas()
+  love.graphics.setBlendMode(prevBlend or "alpha", prevAlphaMode)
+  love.graphics.setColor(1, 1, 1, 1)
+  lastSig = sig
+  ready = true
+end
+
+-- Drop the GPU objects (window resize, hot reload).
+function ShadowMap.invalidate()
+  canvas, canvasRes, blank = nil, 0, nil
+  drawing, ready, lastSig = false, false, nil
+end
+
+return ShadowMap

--- a/mods/dramatic_shape/lib/Sky.lua
+++ b/mods/dramatic_shape/lib/Sky.lua
@@ -1,0 +1,466 @@
+-- The sky, generated rather than shipped.
+--
+-- The overworld's, on every VOXEL rung. Wherever the diorama is drawn the void
+-- behind it is sky rather than a black plate: at 75 degrees the horizon is
+-- genuinely in frame and the bands run down to meet it, and at the steeper rungs
+-- the void that shows is the ground running out past the map edge, which gets
+-- the same sky above the same haze. A battle's placed camera keeps the flat fill
+-- it has always had -- its horizon is above the frame and its look is not this
+-- rung's to change.
+--
+-- THE RECIPE is the 8-bit skybox one: a short palette of blues painted as flat
+-- horizontal bands, deepest overhead, with a CHECKERBOARD of the next band
+-- dithered into the bottom of each one. Alternating two colours on a pixel grid
+-- is how a machine with four colours to a palette got a fifth, sixth and seventh
+-- out of them, and it is what keeps four bands reading as a gradient rather than
+-- as four stripes. No clouds, nothing moving.
+--
+-- NOTHING IS RESAMPLED, which is the whole of why it is drawn this way. There is
+-- no baked 160x144 picture scaled up to the window and no downsized buffer blown
+-- back up: one full-region rectangle through a shader that answers every pixel
+-- from its own canvas coordinate. A pixel of sky is computed at the size it is
+-- displayed at, so there is nothing for a filter to soften and nothing to go
+-- stale when the window or the zoom changes. The shader does bind one texture,
+-- but it is a palette rather than an image -- the bands, one texel each, sampled
+-- nearest (see rampFor, and why it is not a uniform array).
+--
+-- THE PIXEL GRID follows the zoom for the same reason. Bands and dither cells
+-- are measured in DIORAMA pixels -- the pass's own pixels-per-world-pixel, handed
+-- in fresh every frame -- so a chunky sky at 4x is a chunky sky at 12x, band
+-- edges land on the same grid the world's own texels do, and a ZOOM keypress is
+-- reflected in the frame that follows it rather than whenever something else
+-- happened to rebuild.
+--
+-- PALETTE ORDER, which is easy to get wrong. Stored LIGHTEST FIRST, because that
+-- is shade order: a display mode transforms a four-colour palette by replacing it
+-- outright (PaletteFX.effectiveColors hands back GRAYS or CLASSIC), and those are
+-- written light to dark. So the sky reads the list backwards -- deepest shade
+-- overhead, shade 1 at the horizon -- and GRAY gets greys the right way up for
+-- nothing.
+--
+-- WHAT TIME IT IS decides the colours. The palette itself lives in DayNight
+-- (four phase palettes, blended along the clock and re-quantised to the
+-- lattice), and this file paints whatever the clock says: blue at noon, gold
+-- and violet through the twilights -- warmed further around the low sun by a
+-- dithered GLOW -- and deep navy under the moon. The sun and moon themselves
+-- hang here too: cell-art discs on the same grid as the dither, scissored to
+-- the sky's own region so a setting body slips below the horizon point and is
+-- gone, never wandering under the map.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local DayNight = V.require("DayNight")
+local PaletteFX = require("src.render.PaletteFX")
+
+local Sky = {}
+
+-- The most bands a phase palette may paint with. Eight leaves headroom over
+-- DayNight's six-band ones without paying for more; the ramp the shader reads
+-- them from is built at the width actually used, so the cap costs nothing.
+Sky.MAX_BANDS = 8
+
+-- The checkerboard between bands. DITHER_START is how far down a band it begins,
+-- as a fraction of that band: lower is a wider blend, and 1 switches it off. 0.6
+-- leaves the top of each band flat -- a band dithered all the way through reads
+-- as one averaged colour instead of as a step with a soft bottom edge.
+Sky.DITHER = true
+Sky.DITHER_START = 0.6
+
+-- How much of the frame the bands cover when the horizon is NOT in it, as a
+-- fraction of the canvas height.
+--
+-- At the steeper rungs the camera looks down far enough that the ground plane's
+-- vanishing line is above the top edge -- there is no horizon to hang the pale
+-- end on, but there is still void up there where the map runs out, and it should
+-- read as sky. So the bands take the same slice of the frame the top rung's own
+-- horizon gives them, which keeps the sky looking like one sky across the whole
+-- ladder instead of changing character rung by rung.
+Sky.SPAN = 0.23
+
+-- ------- the bands
+--
+-- Top first, each a { r, g, b } in 0..1, as the display mode has them.
+--
+-- Memoised, because this runs once a frame and the answer only moves when the
+-- mode does.
+local cache = { bands = nil, key = {}, ramp = nil }
+
+function Sky.bands()
+  local pal = DayNight.palette()
+  local shades = PaletteFX.effectiveColors(pal) or pal
+  local n = math.min(#shades, #pal, Sky.MAX_BANDS)
+  local key, k = cache.key, 0
+  local same = cache.bands ~= nil and #cache.bands == n
+  for i = 1, n do
+    local c = shades[i]
+    for ch = 1, 3 do
+      k = k + 1
+      if key[k] ~= c[ch] then same = false end
+      key[k] = c[ch]
+    end
+  end
+  if same then return cache.bands end
+
+  -- the ramp is these bands as a texture (see rampFor); a new list is a new
+  -- ramp, and the old one is nothing's to keep
+  if cache.ramp and cache.ramp.release then pcall(cache.ramp.release, cache.ramp) end
+  cache.ramp, cache.rampFor = nil, nil
+
+  local bands = {}
+  for i = 1, n do
+    -- backwards: the palette's darkest rung is the top band
+    local c = shades[n - i + 1]
+    bands[i] = { c[1] / 255, c[2] / 255, c[3] / 255 }
+  end
+  cache.bands = bands
+  return bands
+end
+
+-- The hour's haze -- the palest band, in 0..1 -- which is both the sky's
+-- bottom edge and the right flat fill for any outdoor void that wants to
+-- match the clock without painting bands (the battle arena's backdrop).
+function Sky.haze()
+  local bands = Sky.bands()
+  return bands and bands[#bands] or nil
+end
+
+-- Put the sky onto a flat descriptor: the bands to paint, plus the flat fill
+-- replaced by the palest of them. That fill is what the caller CLEARS to, so
+-- making it the bottom band's own colour means the haze below the sky and the
+-- bottom of the sky are one colour -- the join has no seam, and a frame that
+-- cannot paint the bands is a hazy sky rather than a wrong one.
+--
+-- Mutates the descriptor, which is a fresh table per frame from its caller.
+function Sky.dress(sky)
+  local bands = Sky.bands()
+  local haze = bands and bands[#bands]
+  if not (sky and haze) then return sky end
+  sky[1], sky[2], sky[3] = haze[1], haze[2], haze[3]
+  sky.bands = bands
+  return sky
+end
+
+-- Where the sky's bottom edge goes, in canvas pixels: the camera's own horizon
+-- when that is in frame, and SPAN of the frame when it is not (see SPAN). nil
+-- when there is no room for any of it.
+function Sky.region(h, horizonY)
+  if not (h and h > 0) then return nil end
+  local edge = horizonY
+  if not (edge and edge > 0) then edge = h * Sky.SPAN end
+  edge = math.min(edge, h)
+  if edge < 1 then return nil end
+  return edge
+end
+
+-- ------- the pass
+--
+-- One rectangle, one shader. Every pixel answers for itself from its canvas
+-- coordinate, so the sky is drawn at exactly the resolution it is displayed at
+-- -- there is no image being scaled and so nothing to be soft. The one texture
+-- bound is the band ramp, which is a PALETTE and not a picture: n texels wide,
+-- sampled nearest, one lookup per pixel (see rampFor).
+--
+-- `cell` quantises BOTH the band edges and the dither: the y a pixel is judged
+-- by is the top of its own cell row, so a whole cell row is one colour and every
+-- edge in the sky lands on the diorama's pixel grid.
+local SHADER_SRC = [[
+uniform Image ramp;     // the bands, one texel each, top of the sky first
+uniform float count;    // how many texels wide that ramp is
+uniform float edge;     // the sky's bottom, in canvas pixels
+uniform float cell;     // the diorama's pixel size, in canvas pixels
+uniform float start;    // where the checker begins inside a band
+uniform float alpha;
+uniform float glowAmt;  // twilight warmth around the low sun; 0 = none
+uniform vec2 glowPos;   // the sun disc, in canvas pixels
+uniform float glowInvR; // 1 / the glow's reach
+uniform vec3 glowColor;
+
+// Band `i`, read from its own texel centre. The index is clamped rather than
+// trusted: `pos` below can land exactly on `count` when the arithmetic is
+// carried at mediump -- which is the fragment default on GLSL ES -- and a
+// sample past the last band must be the last band, not whatever is off the
+// end of the image.
+vec3 bandAt(float i) {
+  return Texel(ramp, vec2((clamp(i, 0.0, count - 1.0) + 0.5) / count, 0.5)).rgb;
+}
+
+vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+  float row = floor(sc.y / cell) * cell;              // top of this cell row
+  float pos = min(row / max(edge, 1.0), 1.0) * count;
+  float base = min(floor(pos), count - 1.0);
+  vec3 c = bandAt(base);
+  float parity = mod(floor(sc.x / cell) + floor(sc.y / cell), 2.0);
+  if (base < count - 1.0 && (pos - base) > start) {
+    if (parity < 0.5) { c = bandAt(base + 1.0); }
+  }
+  // The sunset's warmth, radiating from the disc: posterised to a few rungs
+  // and checker-dithered between them -- the same 8-bit move as the bands,
+  // so the glow reads as painted light rather than as a smooth airbrush --
+  // and measured cell-to-cell, so its rings ride the diorama's own grid.
+  if (glowAmt > 0.0) {
+    vec2 cc = (floor(sc / cell) + 0.5) * cell;
+    float d = length(cc - glowPos) * glowInvR;
+    float g = glowAmt * pow(clamp(1.0 - d, 0.0, 1.0), 2.0);
+    float lvl = floor(g * 4.0);
+    if (g * 4.0 - lvl > 0.5 && parity < 0.5) { lvl += 1.0; }
+    c = mix(c, glowColor, min(lvl / 3.0, 1.0) * 0.65);
+  }
+  return vec4(c, alpha);
+}
+]]
+
+-- ------- the ramp
+--
+-- The bands as a one-texel-per-band TEXTURE rather than as a uniform array,
+-- which is what they used to be: `uniform vec3 bands[8]`, filled from Lua and
+-- read through a loop counter. On desktop GL that is as portable as it looks.
+-- On Android it was not. The sky's lower bands came back BLACK -- a hard-edged
+-- strip running from partway down the gradient to the horizon point, with the
+-- moon still drawn correctly over it, and with the haze BELOW the sky (the
+-- palest band again, but delivered by love.graphics.clear instead of by the
+-- array) landing in exactly the right colour. Same colour, two routes, one of
+-- them black: the fault was the array, not the palette.
+--
+-- Which of the ES failure modes it was hardly matters -- a driver that
+-- truncates a partially-filled array, a fragment uniform budget the guaranteed
+-- floor of which is sixteen vectors (eight bands plus the glow plus LOVE's own
+-- built-ins is over it), a reflection that finds bands[0] and nothing after --
+-- because they all have the same shape: slots past the first few read as zero,
+-- and zero is black.
+--
+-- A sampler has none of them. One texture unit replaces eight uniform vectors,
+-- there is no array to index and no budget to overrun, and a texel that does
+-- not exist cannot read as black because the image is built at exactly the
+-- width the shader divides by. Nearest and clamped, so a sample lands on one
+-- band's own colour and an out-of-range one lands on the end band rather than
+-- on nothing.
+--
+-- Rebuilt only when the bands move, which is when the clock or the display
+-- mode does; Sky.bands drops it as it rebuilds the list it is made from.
+local function rampFor(bands)
+  if cache.ramp and cache.rampFor == bands then return cache.ramp end
+  if not (love.image and love.image.newImageData
+          and love.graphics and love.graphics.newImage) then return nil end
+  local n = #bands
+  if n < 1 then return nil end
+  local ok, data = pcall(love.image.newImageData, n, 1)
+  if not (ok and data) then return nil end
+  for i = 1, n do
+    local c = bands[i]
+    pcall(data.setPixel, data, i - 1, 0, c[1], c[2], c[3], 1)
+  end
+  local built, img = pcall(love.graphics.newImage, data)
+  if not (built and img) then return nil end
+  -- nearest: a band is a flat colour, not something to interpolate between.
+  -- clamp: the shader clamps its index too, so this is the second of two
+  -- guards against ever sampling off the end -- and it returns the edge band.
+  pcall(img.setFilter, img, "nearest", "nearest")
+  pcall(img.setWrap, img, "clamp", "clamp")
+  cache.ramp, cache.rampFor = img, bands
+  return img
+end
+
+Sky._rampFor = rampFor            -- named for the suite
+
+local shader = nil            -- nil = untried, false = unavailable
+
+local function getShader()
+  if shader == nil then
+    shader = false
+    if love.graphics and love.graphics.newShader then
+      local ok, sh = pcall(love.graphics.newShader, SHADER_SRC)
+      if ok and sh then
+        shader = sh
+      elseif V and V.mod and V.mod.log then
+        -- once, and only where it can be read: the fallback below is a sky
+        -- without its dither, which is easy to look at and impossible to
+        -- diagnose without this line
+        V.mod.log:warn("sky shader did not compile: %s -- the bands draw flat, "
+                       .. "with no dither between them", tostring(sh))
+      end
+    end
+  end
+  return shader or nil
+end
+
+Sky._getShader = getShader        -- named for the suite
+
+-- The flat fallback: the same bands as solid rectangles, no checker, on the same
+-- quantised edges. For a driver that could not compile the shader -- which is
+-- also every headless run.
+local function paintFlat(w, h, bands, edge, alpha, cell)
+  local g = love.graphics
+  local n = #bands
+  local prev = 0
+  for i = 1, n do
+    local cut = (i == n) and math.min(h, math.ceil(edge))
+                         or math.floor(i / n * edge / cell + 0.5) * cell
+    cut = math.max(prev, math.min(cut, math.min(h, math.ceil(edge))))
+    if cut > prev then
+      local c = bands[i]
+      g.setColor(c[1], c[2], c[3], alpha)
+      g.rectangle("fill", 0, prev, w, cut - prev)
+    end
+    prev = cut
+  end
+end
+
+-- ------- the discs
+--
+-- The sun and moon, as cell art: a circle of whole diorama cells with a
+-- lighter core, a dithered rim, and -- for the moon -- a few fixed crater
+-- cells. Drawn as plain rectangles on the same grid as the sky's own dither,
+-- through the same display-mode transform as every palette here, and
+-- SCISSORED to the sky's region: the horizon point is where a setting body
+-- disappears, so it can never hang under the map at a high pitch.
+--
+-- SIZED BY THE FRAME, not by the world: a celestial body's apparent size is
+-- an angle, so zooming the ground in and out must not swell and shrink the
+-- sun with it. The radius is a fraction of the frame height, converted to
+-- whole cells so the disc still sits on the diorama's grid -- chunky cells
+-- up close, fine ones at survey zoom, the same size body either way.
+Sky.DISC_FRAC = 0.030     -- disc radius, as a fraction of the frame height
+Sky.DISC_MIN = 3          -- but never fewer cells than this across a radius
+
+-- crater centres as fractions of the radius, so they ride any disc size
+local MOON_CRATERS = { { -0.4, -0.2 }, { 0.2, 0.45 }, { 0.5, -0.4 },
+                       { -0.15, 0.7 }, { 0.05, 0.05 } }
+
+local function paintDisc(body, edge, cell, w, h)
+  local g = love.graphics
+  if not (body and body.y and g.setScissor) then return end
+  local src = body.moon and DayNight.MOON_COLORS or DayNight.SUN_COLORS
+  local shades = PaletteFX.effectiveColors(src) or src
+  local twilight = (body.glowAmt or 0) > 0.25 and not body.moon
+  local r = math.max(Sky.DISC_MIN,
+                     math.floor(h * Sky.DISC_FRAC / cell + 0.5))
+  -- the low sun looms: the classic sunset exaggeration, and it reads
+  if twilight then r = r + math.max(1, math.floor(r * 0.4)) end
+  -- snap the centre to the cell grid, like everything else in this sky
+  local bx = math.floor(body.x / cell) * cell + cell / 2
+  local by = math.floor(body.y / cell) * cell + cell / 2
+  if by - r * cell > edge then return end     -- wholly below the horizon point
+  local core = shades[1]
+  local main = shades[twilight and 3 or 2]
+  local sx, sy, sw, sh = g.getScissor()
+  g.setScissor(0, 0, math.ceil(w), math.floor(edge))
+  local craterR = math.max(1, math.floor(r / 5))
+  for dy = -r, r do
+    for dx = -r, r do
+      local d = math.sqrt(dx * dx + dy * dy)
+      if d <= r + 0.1 then
+        local c = d <= r * 0.5 and core or main
+        -- dithered rim: the outer ring keeps only one parity of its cells
+        local keep = d <= r - 0.9 or (dx + dy) % 2 == 0
+        if body.moon then
+          for _, cr in ipairs(MOON_CRATERS) do
+            local cdx = dx - math.floor(cr[1] * r + 0.5)
+            local cdy = dy - math.floor(cr[2] * r + 0.5)
+            if cdx * cdx + cdy * cdy <= craterR * craterR then
+              c = shades[3]
+            end
+          end
+        end
+        if keep then
+          g.setColor(c[1] / 255, c[2] / 255, c[3] / 255, 1)
+          g.rectangle("fill", bx + dx * cell - cell / 2,
+                      by + dy * cell - cell / 2, cell, cell)
+        end
+      end
+    end
+  end
+  if sx then g.setScissor(sx, sy, sw, sh) else g.setScissor() end
+  g.setColor(1, 1, 1, 1)
+end
+
+-- Paint the sky into the bound canvas, filling it from the top edge down to
+-- `horizonY` (or to SPAN of the frame when the horizon is out of it).
+--
+-- `cell` is the diorama's pixel size in canvas pixels -- the pass's own
+-- pixels-per-world-pixel, handed in every frame so a zoom lands immediately.
+--
+-- `body` is the sun or moon to hang, already projected to canvas pixels by
+-- the caller's own camera (Voxel3D.skyBody), with the twilight glow riding
+-- along; nil hangs nothing and warms nothing.
+--
+-- Returns false when there is nothing to paint, in which case the caller's flat
+-- fill is the whole sky. That fill is the palest band, so a frame that declines
+-- this looks like a hazy day rather than like a bug.
+function Sky.paint(w, h, sky, horizonY, cell, body)
+  local bands = sky and sky.bands
+  if not (bands and bands[1]) then return false end
+  if not (w and h and w > 0 and h > 0) then return false end
+  local g = love.graphics
+  if not (g and g.rectangle) then return false end
+  local edge = Sky.region(h, horizonY)
+  if not edge then return false end
+  local alpha = sky[4] or 1
+  cell = math.max(1, math.floor((cell or 1) + 0.5))
+
+  -- State to put aside. The scene's shader is one, and the blend mode another --
+  -- a pass that left "replace" behind would make the fade-in strength meaningless
+  -- -- but the DEPTH MODE is the one that would break the frame: a rectangle
+  -- drawn under the pass's own ("lequal", true) stamps itself across the depth
+  -- buffer at the near plane and hides the entire world behind the sky.
+  local prevShader = g.getShader and g.getShader() or nil
+  local cmp, write
+  if g.getDepthMode then cmp, write = g.getDepthMode() end
+  if g.setDepthMode then g.setDepthMode("always", false) end
+  local blend, blendAlpha
+  if g.getBlendMode then blend, blendAlpha = g.getBlendMode() end
+  if g.setBlendMode then g.setBlendMode("alpha") end
+
+  local glowAmt = body and not body.moon and (body.glowAmt or 0) or 0
+  local sh = getShader()
+  local ramp = sh and rampFor(bands)
+  if not ramp then sh = nil end       -- no ramp, no gradient: paint it flat
+  if sh then
+    local sent = pcall(function()
+      -- the bands arrive as a texture, one texel each, and `count` is that
+      -- texture's width -- see rampFor for why they are not a uniform array
+      sh:send("ramp", ramp)
+      sh:send("count", #bands)
+      sh:send("edge", edge)
+      sh:send("cell", cell)
+      sh:send("start", Sky.DITHER and Sky.DITHER_START or 2)
+      sh:send("alpha", alpha)
+      sh:send("glowAmt", glowAmt)
+      if glowAmt > 0 then
+        local gc = body.glowColor or { 248, 224, 168 }
+        sh:send("glowPos", { body.x, body.y })
+        sh:send("glowInvR", 1 / math.max(1, w * 0.55))
+        sh:send("glowColor", { gc[1] / 255, gc[2] / 255, gc[3] / 255 })
+      end
+    end)
+    if sent then
+      g.setShader(sh)
+      g.setColor(1, 1, 1, 1)
+      g.rectangle("fill", 0, 0, w, math.min(h, math.ceil(edge)))
+      g.setShader()
+    else
+      sh = nil
+    end
+  end
+  if not sh then paintFlat(w, h, bands, edge, alpha, cell) end
+  -- the disc goes over the glow, under nothing: plain rectangles, so it is
+  -- there whether or not the shader built
+  paintDisc(body, math.min(h, edge), cell, w, h)
+  g.setColor(1, 1, 1, 1)
+
+  if g.setBlendMode and blend then g.setBlendMode(blend, blendAlpha) end
+  if g.setDepthMode then g.setDepthMode(cmp or "always", write or false) end
+  if prevShader and g.setShader then g.setShader(prevShader) end
+  return true
+end
+
+-- Drop the compiled shader (window resize, hot reload), so a re-created graphics
+-- context builds a new one instead of drawing with a handle from the old. The
+-- ramp is a GPU object on the same context and goes with it.
+function Sky.invalidate()
+  shader = nil
+  if cache.ramp and cache.ramp.release then pcall(cache.ramp.release, cache.ramp) end
+  cache.ramp, cache.rampFor = nil, nil
+end
+
+return Sky

--- a/mods/dramatic_shape/lib/SpriteBillboards.lua
+++ b/mods/dramatic_shape/lib/SpriteBillboards.lua
@@ -1,0 +1,84 @@
+-- Voxel world mode: characters as flat forward-facing sprite billboards.
+--
+-- Every character -- the player, NPCs, the ghosts standing on a neighbour
+-- map -- is its CURRENT 2D sprite frame on a single flat quad. The sheets
+-- carry real alpha and the shader discards it, so the quad cuts the
+-- sprite's exact silhouette out of itself; no geometry is built from the
+-- pixels and nothing about a sprite is voxelized.
+--
+-- That is deliberate. A sprite is a DRAWING, not an object seen from one
+-- side: Gen 1's overworld figures are 16x16 icons with a fixed front-on
+-- reading, and turning one into a solid -- whether a contoured slab or a
+-- carved visual hull -- reconstructs a body the artist never drew and the
+-- game never implied. It also had the mod ship a description of the ROM
+-- art. One quad wearing the real frame is both more faithful and cheaper:
+-- it needs no pixel access at all, only the sheet's dimensions.
+--
+-- The card always faces SOUTH -- the direction the 2D game implies -- and
+-- only LEANS BACK, pivoting at its feet, by exactly the camera's pitch
+-- (VoxelScene's billboardMatrix), so at every tilt level it reads face-on
+-- like the flat game. Right-facing and the alternating walk step are
+-- matrix mirrors, not extra meshes. UVs point into the live sheet image,
+-- so RED++ OBP bakes, SGB palette bakes and sprite-replacing mods all
+-- texture it with no rebuild.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local Assets = require("src.render.Assets")
+local Voxel3D = V.require("Voxel3D")
+
+local SpriteBillboards = {}
+
+local meshes = {}
+
+-- One flat 16x16 quad UV-mapped to a whole frame. A hair of inset keeps
+-- the sampler inside this frame rather than picking up the neighbouring
+-- one along the shared edge.
+local function buildCard(def, frame)
+  local ok, img = pcall(Assets.image, def.image)
+  if not (ok and img) then return nil end
+  local iw, ih = img:getDimensions()
+  local fy = frame * 16
+  if fy + 16 > ih then fy = 0 end
+  local u0, u1 = 0.02 / iw, (16 - 0.02) / iw
+  local v0, v1 = (fy + 0.05) / ih, (fy + 15.95) / ih
+  local verts = {
+    { 0, 0, 0, u0, v1, 1 }, { 16, 0, 0, u1, v1, 1 },
+    { 16, 16, 0, u1, v0, 1 }, { 0, 16, 0, u0, v0, 1 },
+  }
+  local indices = {}
+  Voxel3D.pushQuad(indices, 0)
+  return Voxel3D.newMesh(verts, indices)
+end
+
+-- The card for one (sprite def, frame index), or nil (headless / no
+-- image), cached like every other derived GPU object.
+--
+-- The solid draw, the sun pass and the player's occlusion silhouette all
+-- take THIS mesh. That the three agree is load-bearing, not tidiness: the
+-- silhouette is drawn with the depth test INVERTED, so any self-overlap in
+-- the mesh would read as "behind something" and repaint the figure on open
+-- ground whether or not anything hides it; and the sun must see the same
+-- outline the camera does, or a shadow stops matching what casts it.
+function SpriteBillboards.mesh(def, frame)
+  local key = def.image .. "#" .. frame
+  if meshes[key] == nil then
+    local ok, m = pcall(buildCard, def, frame)
+    meshes[key] = (ok and m) or false
+  end
+  return meshes[key] or nil
+end
+
+-- Kept as its own name because the shadow and ghost passes read as their
+-- own thing at the call sites; it once carried a different mesh from the
+-- solid draw, and now deliberately does not.
+SpriteBillboards.shadowQuad = SpriteBillboards.mesh
+
+function SpriteBillboards.invalidate()
+  meshes = {}
+end
+
+Assets.register(SpriteBillboards.invalidate)
+
+return SpriteBillboards

--- a/mods/dramatic_shape/lib/Structures.lua
+++ b/mods/dramatic_shape/lib/Structures.lua
@@ -1,0 +1,2669 @@
+-- Voxel world mode: detect the map's structures and pick a 3D model for
+-- each -- the 3dSen idea applied to a tile map. 3dSen turns flat NES
+-- scenes into 3D by classifying every graphic into a geometry archetype
+-- (floor, wall, box, voxelized sprite) and building real geometry that
+-- keeps the original art as its texture; this module does the same with
+-- the map's tile layer as the scene description:
+--
+--   1. Flood-fill every connected region of solid (upright, unauthored)
+--      tiles -- a house with its mailbox, the potted plant, a fence row,
+--      a stretch of border forest.
+--
+--   2. Decide which pixels of the region's art are BACKGROUND. Tileset
+--      art carries no alpha and white is a paint color (window frames,
+--      wall stripes), so whiteness alone says nothing. The map does: the
+--      background is the white that CONNECTS TO WALKABLE GROUND in the
+--      assembled scene. Seeding a flood from the surrounding ground
+--      eats the air around a fence post or a plant's leaves but cannot
+--      reach an interior wall's white stripes sealed behind its dark
+--      trim -- exactly the distinction a human reads.
+--
+--   3. Tiles whose art turned out mostly background are SPRITE-LIKE;
+--      their connected clusters become per-pixel voxel OBJECTS at the
+--      art's real drawn height (a 2-row plant is a 16px silhouette, a
+--      fence a row of true posts with air between), thin voxel depth,
+--      standing on synthesized ground. This splits mixed regions: the
+--      mailbox voxelizes even where it touches the house.
+--
+--   4. Everything else becomes a VOLUME: each column rises to the height
+--      the structure is actually DRAWN. A column's run gives its extent,
+--      repetition caps it -- the border forest repeats a 2-row canopy
+--      for forty rows and must be rows of 16px trees, not a monolith --
+--      and columns answer to their region: the column above a doorway
+--      repeats internally but adopts its 48px house. The south face
+--      folds the artwork up (ChunkMesher's band rule).
+--
+-- data/voxel_heights.lua is the PROFILE over this: a tile authored there
+-- (ledges, or a mod pinning a shape) bypasses detection entirely, the way
+-- a 3dSen game profile pins a pattern to a geometry type.
+--
+-- Everything here is derived per map and cached; pixel access (object
+-- voxelization, void detection) degrades gracefully headless -- regions
+-- simply stay volumes and the geometry tests keep passing.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local Assets = require("src.render.Assets")
+local Map = require("src.world.Map")
+local Buildings = V.require("Buildings")
+local TileShape = V.require("TileShape")
+local Budget = V.require("BuildBudget")
+
+local Structures = {}
+
+-- must match ChunkMesher's ring (3 border blocks, in tiles)
+local RING = 12
+
+-- how far past the map body cells still get the hull. A route's ring is
+-- nearly as big as its body; modelling all of it costs hundreds of
+-- thousands of quads of border trees nobody walks near. Beyond this,
+-- pinned cells simply are not claimed and fall through to the mesher's
+-- plain box -- cheap distant scenery. (Declared up here rather than
+-- beside buildCylinders because forMap's grid resolve reads it too.)
+local ROUND_RING = 4
+
+-- object-mode gates
+local OBJECT_MAX_ROWS = 6          -- a prop is at most 48px of drawing
+local OBJECT_MAX_QUADS = 4096      -- safety cap per cluster
+local TILE_BG_RATIO = 0.20         -- art background for "sprite-like"
+local CLUSTER_MIN_BG = 0.05        -- a silhouette must actually exist
+local OBJECT_DEPTH = 6             -- voxel thickness of a detected prop
+-- thickness of profile-pinned standees per class: a TV is a deliberate
+-- object and reads better with body; `prop` doubles as the THIN pool
+-- (plants, stools -- mostly silhouette); `cutout` is paper: one voxel,
+-- pure profile; `post` matches the 6px the detector gives the fence
+-- rows it finds on its own, so pinned and detected fences look alike;
+-- `signpost` is a plate on a stick -- 2 voxels, the thinnest that still
+-- shows an edge
+local PINNED_DEPTH = { billboard = 10, prop = 5, stool = 10, cutout = 1,
+                       console = 10, post = 6, signpost = 2 }
+
+local MAX_ROWS = 6                 -- volume height cap: 48px
+
+local cache = {}
+
+-- ---------------------------------------------------------------- pixels --
+
+local atlasData = {}
+
+local function pixels(tileset)
+  local path = tileset.image
+  if atlasData[path] == nil then
+    local ok, data = pcall(Assets.imageData, path)
+    atlasData[path] = (ok and data and data.getPixel) and data or false
+  end
+  return atlasData[path] or nil
+end
+
+-- tiles whose art is entirely black or transparent (interior darkness):
+-- these never extrude, whatever class they resolved to
+local function voidTiles(tileset)
+  local data = pixels(tileset)
+  if not data then return nil end
+  local perRow = tileset.tilesPerRow or 16
+  local iw, ih = data:getDimensions()
+  local set = {}
+  for t = 0, (iw / 8) * (ih / 8) - 1 do
+    local ox = (t % perRow) * 8
+    local oy = math.floor(t / perRow) * 8
+    local void = true
+    for py = 0, 7 do
+      for px = 0, 7 do
+        local r, g, b, a = data:getPixel(ox + px, oy + py)
+        if a > 0 and math.max(r, g, b) > 0.17 then
+          void = false
+          break
+        end
+      end
+      if not void then break end
+    end
+    if void then set[t] = true end
+  end
+  return set
+end
+
+-- ----------------------------------------------------------------- build --
+
+local DIRS4 = { { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 } }
+
+local function keyOf(tx, ty)
+  return (ty + 64) * 4096 + (tx + 64)
+end
+
+function Structures.forMap(map)
+  local S = cache[map.id]
+  if S then return S end
+
+  local tileset = map.tileset
+  local shapes = TileShape.forMap(map)
+  local void = voidTiles(tileset)
+  local perRow = tileset.tilesPerRow or 16
+
+  local def = map.def
+  local tw, th = def.width * 4, def.height * 4
+  local x0, x1 = -RING, tw + RING - 1
+  local y0, y1 = -RING, th + RING - 1
+
+  -- resolve the whole grid once: shape + tile per key. Ring positions use
+  -- the same border override the 2D renderer draws with
+  -- (TileRenderer.borderBlockFor: outdoor maps ring with the solid tree
+  -- wall, NOT their own borderBlock) -- a route's borderBlock is the GRASS
+  -- block, and meshing that grew a 12-tile apron of tall grass past every
+  -- route edge, which leaked into the neighbouring town's plaza.
+  -- BLACK void fill is not a block at all: borderBlockFor answers `false`,
+  -- and there is simply nothing out there to build. tileLookup then returns
+  -- nil past the body and the ring keys are never written, which the whole
+  -- file already copes with -- every neighbour query reaches one step
+  -- outside the analysed range and reads nil for its trouble, so an absent
+  -- cell is the shape "nothing" has always had here. (It used to add 1 to
+  -- that `false`, which threw, failed the mesh build for every map on the
+  -- route, and dropped the mode to the flat 2D path entirely.)
+  local TileRenderer = require("src.render.TileRenderer")
+  local borderId = TileRenderer.borderBlockFor(map)
+  local borderBlk = borderId and tileset.blocks[borderId + 1] or nil
+  -- TREES fill stops at ROUND_RING instead of running the full RING.
+  -- Only that far out does a tree cell get carved into a hull; past it
+  -- the cells fall through to the mesher's plain box, and a slab of
+  -- flat-topped boxes beside the modelled wall reads as a painted-on
+  -- plateau -- the wall looking like it was cut off with scissors. So
+  -- the far ring is simply not built: beyond ROUND_RING tileLookup
+  -- answers nil, which is the same "nothing out there" BLACK already
+  -- produces and every pass below already copes with. The cut lands on
+  -- the carve boundary exactly -- the 2x2-cell canopy scan starts at
+  -- floor(-RING/2) and RING, ROUND_RING and the body are all multiples
+  -- of 4 tiles, so no group is left half-resolved at the edge.
+  --
+  -- WATER and the other tilesets' own borders keep the full ring: a flat
+  -- sheet of water is what water looks like from above anyway, and an
+  -- interior's border is black already.
+  local hullRingOnly = borderBlk and def.tileset == "OVERWORLD"
+                       and (TileRenderer.voidFill or "trees") == "trees"
+  local tw2, th2 = tw, th
+  local function tileLookup(tx, ty)
+    if tx >= 0 and ty >= 0 and tx < tw2 and ty < th2 then
+      return map:tileAt(tx, ty)
+    end
+    if not borderBlk then return nil end
+    if hullRingOnly and (tx < -ROUND_RING or ty < -ROUND_RING
+                         or tx >= tw2 + ROUND_RING
+                         or ty >= th2 + ROUND_RING) then
+      return nil
+    end
+    return borderBlk[(ty % 4) * 4 + (tx % 4) + 1] or 0
+  end
+  local shapeAt, tileAt = {}, {}
+  for ty = y0, y1 do
+    for tx = x0, x1 do
+      Budget.tick()
+      local tile = tileLookup(tx, ty)
+      if tile then
+        local k = keyOf(tx, ty)
+        local s = TileShape.at(map, shapes, tile, tx, ty)
+        if s and void and void[tile] and not s.authored then
+          s = shapes.classes.void
+        end
+        shapeAt[k], tileAt[k] = s, tile
+      end
+    end
+  end
+
+  -- ---- buildings: whole sprites voxelized band by band ----
+  --
+  -- Before anything else looks at this grid. A profiled building is a
+  -- drawing whose bands depict DIFFERENT 3D surfaces (roof from above,
+  -- facade face-on, ends sloped), and the passes below -- the door fold,
+  -- the region flood, the volume builder -- all assume one drawing is one
+  -- upright thing. Modelling the building first and claiming its tiles
+  -- keeps every one of them off it.
+  --
+  -- (grassQuads live apart from objectQuads: grass renders as its own mesh
+  -- AFTER the characters -- see VoxelScene -- so the southern tuft row
+  -- still overdraws a walker's feet even though characters stamp over
+  -- terrain.)
+  S = { shapeAt = shapeAt, tileAt = tileAt, outdoor = Map.isOutdoor(def),
+        hideBareRing = hullRingOnly or nil,
+        runs = {}, skip = {}, ground = {}, doorFold = {}, objectQuads = {},
+        grassQuads = {}, flowerQuads = {}, roundStamps = {}, figures = {} }
+  Buildings.build(S, map, pixels(tileset), perRow)
+
+  -- Fold doors into their buildings. A door cell is WALKABLE (the player
+  -- steps onto it to warp), so it resolves to ground and punches a hole in
+  -- the facade: the door lies flat, the rows above it recess, and -- worse
+  -- -- the hole lets the background flood into the building's interior
+  -- whites, shredding it into misdetected sprite clusters. Visually the
+  -- door is part of the facade, so mark the door cell's tiles structural:
+  -- the fold then shows the door art standing at ground level in the
+  -- building's front face. Door graphics only (the tileset's doorTiles);
+  -- interior stair/mat warps stay flat.
+  --
+  -- A PROFILE PIN WINS over the fold. The fold is detection, and rule 1
+  -- of the resolution order is that an authored tile bypasses detection
+  -- -- but this used to overwrite shapeAt unconditionally, so a pin on
+  -- any tile the tileset also lists in doorTiles was dead on arrival.
+  -- Celadon Mansion is the case that found it: all four of its
+  -- staircases are door tiles, so `stair_e` / `stair_down_w` pins there
+  -- silently did nothing and the flights stayed painted on the floor.
+  for cy = math.floor(y0 / 2), math.floor(y1 / 2) do
+    for cx = math.floor(x0 / 2), math.floor(x1 / 2) do
+      if map.doorTiles[map:cellTile(cx, cy)] then
+        local northK = keyOf(cx * 2, cy * 2 - 1)
+        local ns = shapeAt[northK]
+        if ns and ns.art == "upright" then
+          for dy = 0, 1 do
+            for dx = 0, 1 do
+              local dk = keyOf(cx * 2 + dx, cy * 2 + dy)
+              local ds = shapeAt[dk]
+              if not (ds and ds.authored) then
+                shapeAt[dk] = shapes.classes.wall
+                -- remembered for buildVolume: a folded doorway column
+                -- answers to its REGION for height and top, not to its
+                -- own drawn extent (see the door adoption there)
+                S.doorFold[dk] = true
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  -- a structure cell: solid art the detector may model (authored tiles are
+  -- profile-pinned and keep their authored shape)
+  local function structural(k)
+    local s = shapeAt[k]
+    return s and s.art == "upright" and not s.authored
+  end
+
+  -- ---- cylinders: profile-pinned round graphics, one per 16x16 cell ----
+  -- the flat ground tiles this map actually places, for the hull's
+  -- ground matching: the ball's own drawn background picks its floor
+  local groundTiles = {}
+  do
+    local seenG = {}
+    for k, s in pairs(shapeAt) do
+      if s and s.flat and s.class == "ground" then
+        local t = tileAt[k]
+        if t and not seenG[t] then
+          seenG[t] = true
+          groundTiles[#groundTiles + 1] = t
+        end
+      end
+    end
+  end
+  Structures.buildCylinders(S, map, x0, x1, y0, y1, groundTiles)
+
+  -- ---- stairs: profile-pinned cells that render as real steps ----
+  Structures.buildStairs(S, map, x0, x1, y0, y1)
+
+  -- ---- bookcases: pinned shelves collapsed to one cell of depth ----
+  Structures.buildBookcases(S, map, x0, x1, y0, y1)
+
+  -- ---- figures: a person drawn INTO furniture, lifted off it ----
+  -- Before the region flood and the volume pass, so everything after this
+  -- reads the tiles the profile says are there once the figure is gone.
+  -- (Its own tiles are authored furniture or walkable floor either way, so
+  -- no pass below would have claimed them -- but the repaint is what those
+  -- passes should see, and this needs no pixel access to do it.)
+  Structures.buildFigures(S, map, x0, x1, y0, y1)
+
+  -- ---- flood-fill regions of structural tiles ----
+  local seen = {}
+  local regions = {}
+  for ty = y0, y1 do
+    for tx = x0, x1 do
+      local k = keyOf(tx, ty)
+      if structural(k) and not seen[k] then
+        local region = { tiles = {}, minX = tx, maxX = tx,
+                         minY = ty, maxY = ty }
+        local queue = { { tx, ty } }
+        seen[k] = true
+        while #queue > 0 do
+          Budget.tick()
+          local c = table.remove(queue)
+          local cx, cy = c[1], c[2]
+          region.tiles[#region.tiles + 1] = c
+          region.minX = math.min(region.minX, cx)
+          region.maxX = math.max(region.maxX, cx)
+          region.minY = math.min(region.minY, cy)
+          region.maxY = math.max(region.maxY, cy)
+          for _, d in ipairs(DIRS4) do
+            local nx, ny = cx + d[1], cy + d[2]
+            if nx >= x0 and nx <= x1 and ny >= y0 and ny <= y1 then
+              local nk = keyOf(nx, ny)
+              if structural(nk) and not seen[nk] then
+                seen[nk] = true
+                queue[#queue + 1] = { nx, ny }
+              end
+            end
+          end
+        end
+        regions[#regions + 1] = region
+      end
+    end
+  end
+
+  -- ---- model each region: carve out per-pixel objects, volume the rest --
+  local data = pixels(tileset)
+  for _, region in ipairs(regions) do
+    local leftover = region.tiles
+    if data then
+      leftover = Structures.extractObjects(S, map, region, data, perRow)
+    end
+    if #leftover > 0 then
+      Structures.buildVolume(S, map, leftover)
+    end
+  end
+
+  -- ---- profile-pinned billboards (signs): forced per-pixel slabs ----
+  if data then
+    local seenB = {}
+    for ty = y0, y1 do
+      for tx = x0, x1 do
+        local k = keyOf(tx, ty)
+        local s = shapeAt[k]
+        if s and s.art == "billboard" and not seenB[k] then
+          local reg = { tiles = {}, minX = tx, maxX = tx,
+                        minY = ty, maxY = ty }
+          local queue = { { tx, ty } }
+          seenB[k] = true
+          while #queue > 0 do
+            local c = table.remove(queue)
+            reg.tiles[#reg.tiles + 1] = c
+            reg.minX = math.min(reg.minX, c[1])
+            reg.maxX = math.max(reg.maxX, c[1])
+            reg.minY = math.min(reg.minY, c[2])
+            reg.maxY = math.max(reg.maxY, c[2])
+            for _, d in ipairs(DIRS4) do
+              local nk = keyOf(c[1] + d[1], c[2] + d[2])
+              local ns = shapeAt[nk]
+              -- same CLASS, not just billboard art: `billboard` and
+              -- `prop` are two pools precisely so touching drawings (a TV
+              -- behind its console) become two standing objects instead
+              -- of one stacked cutout
+              if ns and ns.art == "billboard" and ns.class == s.class
+                 and not seenB[nk] then
+                seenB[nk] = true
+                queue[#queue + 1] = { c[1] + d[1], c[2] + d[2] }
+              end
+            end
+          end
+          Structures.extractObjects(S, map, reg, data, perRow, true)
+        end
+      end
+    end
+
+    -- ---- profile-pinned fence posts: per-CELL standee slabs ----
+    -- A fence line repeats one drawing for a dozen cells, and its art
+    -- touches across cell seams. Pooled like a billboard the whole line
+    -- would stand as ONE drawing-tall tower at one depth (the detector's
+    -- vertical-repetition guard exists precisely to refuse that, which
+    -- is why undetected fence columns fell to the volume path as boxes).
+    -- Each CELL extracts alone instead: its posts stand in their own row
+    -- band and the fence marches north cell by cell.
+    local postCells = {}
+    for ty = y0, y1 do
+      for tx = x0, x1 do
+        local s = shapeAt[keyOf(tx, ty)]
+        if s and s.art == "post" then
+          local ck = keyOf(math.floor(tx / 2), math.floor(ty / 2))
+          postCells[ck] = postCells[ck] or {}
+          local list = postCells[ck]
+          list[#list + 1] = { tx, ty }
+        end
+      end
+    end
+    for _, tiles in pairs(postCells) do
+      local reg = { tiles = tiles,
+                    minX = tiles[1][1], maxX = tiles[1][1],
+                    minY = tiles[1][2], maxY = tiles[1][2] }
+      for _, c in ipairs(tiles) do
+        reg.minX = math.min(reg.minX, c[1])
+        reg.maxX = math.max(reg.maxX, c[1])
+        reg.minY = math.min(reg.minY, c[2])
+        reg.maxY = math.max(reg.maxY, c[2])
+      end
+      Structures.extractObjects(S, map, reg, data, perRow, "opaque")
+    end
+
+    -- ---- profile-pinned relief props: top-down drawings that extrude ----
+    local seenR = {}
+    for ty = y0, y1 do
+      for tx = x0, x1 do
+        local k = keyOf(tx, ty)
+        local s = shapeAt[k]
+        if s and s.art == "relief" and not seenR[k] then
+          local reg = { tiles = {}, minX = tx, maxX = tx,
+                        minY = ty, maxY = ty }
+          local queue = { { tx, ty } }
+          seenR[k] = true
+          while #queue > 0 do
+            local c = table.remove(queue)
+            reg.tiles[#reg.tiles + 1] = c
+            reg.minX = math.min(reg.minX, c[1])
+            reg.maxX = math.max(reg.maxX, c[1])
+            reg.minY = math.min(reg.minY, c[2])
+            reg.maxY = math.max(reg.maxY, c[2])
+            for _, d in ipairs(DIRS4) do
+              local nk = keyOf(c[1] + d[1], c[2] + d[2])
+              local ns = shapeAt[nk]
+              if ns and ns.art == "relief" and ns.class == s.class
+                 and not seenR[nk] then
+                seenR[nk] = true
+                queue[#queue + 1] = { c[1] + d[1], c[2] + d[2] }
+              end
+            end
+          end
+          for _, c in ipairs(reg.tiles) do
+            local ck = keyOf(c[1], c[2])
+            S.skip[ck] = true
+            S.ground[ck] = false
+          end
+          Structures.buildRelief(S, map, reg, data, perRow, s.h or 5)
+        end
+      end
+    end
+
+    -- ---- tall grass: two standing tuft rows per tile. BODY only: the 2D
+    -- renderer never draws a neighbour's ring, and standing scenery past a
+    -- map's edge would poke into the map next door ----
+    Structures.buildGrass(S, map, 0, tw - 1, 0, th - 1, data)
+
+    -- ---- flowers: the animated meadow tile stands as a 1px cutout ----
+    Structures.buildFlowers(S, map, tw, th, x0, x1, y0, y1, data)
+  end
+
+  -- ---- authored ground under pinned props ----
+  -- The profile can name the tile a pinned prop stands on (a tileset
+  -- entry's prop_ground: prop tile id -> ground tile id), overriding
+  -- the neighbour vote. The cuttable bush stands on the plain grass
+  -- Cut itself leaves behind, not on whatever path its neighbours
+  -- happen to vote in.
+  do
+    local okP, prof = pcall(V.data, "voxel_heights")
+    local entry = okP and type(prof) == "table" and prof.tilesets
+                  and prof.tilesets[tileset.id]
+    local pg = entry and entry.prop_ground
+    if type(pg) == "table" then
+      for k, skipped in pairs(S.skip) do
+        if skipped then
+          local g = pg[S.tileAt[k]]
+          if g then S.ground[k] = g end
+        end
+      end
+    end
+  end
+
+  -- unresolved claimed ground (a hull with no art match, headless
+  -- cylinders): no flat neighbour to vote with, so fall back to the
+  -- map's commonest ground tile
+  local votes, best, bestN = {}, nil, 0
+  for k, s in pairs(shapeAt) do
+    if s and s.flat and s.class == "ground" then
+      local t = tileAt[k]
+      votes[t] = (votes[t] or 0) + 1
+      if votes[t] > bestN then best, bestN = t, votes[t] end
+    end
+  end
+  for k, g in pairs(S.ground) do
+    if g == false then S.ground[k] = best end
+  end
+
+  cache[map.id] = S
+  return S
+end
+
+-- ---- round scenery: outline-hulled voxel balls ----
+
+-- Cells the profile pins as round (tree canopies -- the class keeps its
+-- historical `cylinder` name in the data file) render as a VOXEL HULL cut
+-- from the drawing itself. The first shipped attempt was a lathe -- the
+-- per-row silhouette width revolved into a 12-segment column with the art
+-- wrapped by sin(angle) -- and it read exactly like what it was: the
+-- sprite pasted on a cylinder, with the wrap smearing the pixels into
+-- vertical stripes. This replaces it with real voxels.
+--
+-- Segmentation first, silhouette-width second: the tree cell's art is a
+-- ball drawn over background grass, and the background's mid greens pass
+-- any brightness test (they inflated every lathe row to full width). The
+-- ball's own DARKEST pixels are what bound it, so the mask is "the
+-- darkest-shade outline plus everything it encloses": flood from the cell
+-- border through every non-black pixel; what the flood cannot reach is
+-- the tree, and the cast shadow under the canopy (dark but not enclosed)
+-- floods away with the grass. Art with no closed black outline -- the
+-- border tree wall is a dither of black and canopy with no drawn ring --
+-- encloses nothing; there the flood passes only through the LIGHT shades
+-- (the methodology doc's rule: black and dark together form the
+-- boundary), and the dither mass itself becomes the mask, checker holes
+-- and all, because a 4-connected flood cannot thread a diagonal checker.
+--
+-- Volume: each mask row is a disc. The row's span gives a center and
+-- half-width, and every mask pixel's column runs that circle's chord in
+-- z, quantized to whole voxels -- the front view IS the sprite, the plan
+-- view is the sprite's own width profile turned in depth, and both step
+-- pixel by pixel. Rows below the mask (the drawn shadow) repeat the
+-- bottom row's discs down to the ground so the canopy stands on a short
+-- dark foot instead of floating.
+--
+-- Skin: front and back faces carry the drawing per-pixel (the back reads
+-- mirrored, sprite-pure); side and step faces take their column's own
+-- texel, which puts the drawn outline exactly on the silhouette's rim;
+-- and a fully exposed cap keeps its outline only on the rim cells while
+-- the interior samples the canopy a couple of rows deeper -- painting the
+-- whole cap with the outline row blacked out every dome on the first
+-- attempt (the lathe hit the same bug with its top discs).
+--
+-- Tree walls repeat the same four tiles for hundreds of cells, so the
+-- hull is built once per distinct art signature and stamped per cell.
+local ROUND_SHADE = { front = 1.0, back = 0.68, side = 0.78,
+                      top = 1.0, bottom = 0.55 }
+
+local function roundTemplate(S, map, data, cx, cy, groundTiles, N, capRows)
+  N = N or 16                  -- art canvas: 16 = one cell, 32 = 2x2 cells
+  local N2 = N / 2
+  local perRow = map.tileset.tilesPerRow or 16
+  local atlasW = map.tileset.imageWidth or 128
+  local atlasH = map.tileset.imageHeight or 48
+
+  -- cell-space art access (NxN, row 0 = top), anchored at cell (cx, cy)
+  local function tileOf(px, py)
+    return S.tileAt[keyOf(cx * 2 + math.floor(px / 8),
+                          cy * 2 + math.floor(py / 8))]
+  end
+  local function texel(px, py)
+    local tile = tileOf(px, py)
+    return (tile % perRow) * 8 + px % 8,
+           math.floor(tile / perRow) * 8 + py % 8
+  end
+
+  -- shade class of every canvas pixel, indexed py * N + px
+  local cls = {}
+  for py = 0, N - 1 do
+    for px = 0, N - 1 do
+      local ax, ay = texel(px, py)
+      local r, g, b, a = data:getPixel(ax, ay)
+      cls[py * N + px] = a == 0 and "off"
+                         or Structures.shadeClass(math.min(r, g, b))
+    end
+  end
+
+  -- 4-connected flood from the canvas border through `passable` classes
+  local function floodOutside(passable)
+    local out, stack = {}, {}
+    local function seed(i)
+      if not out[i] and passable[cls[i]] then
+        out[i] = true
+        stack[#stack + 1] = i
+      end
+    end
+    for i = 0, N - 1 do
+      seed(i); seed(N * (N - 1) + i); seed(i * N); seed(i * N + N - 1)
+    end
+    while #stack > 0 do
+      local i = table.remove(stack)
+      local px = i % N
+      if px > 0 then seed(i - 1) end
+      if px < N - 1 then seed(i + 1) end
+      if i >= N then seed(i - N) end
+      if i < N * (N - 1) then seed(i + N) end
+    end
+    return out
+  end
+
+  -- the mask: darkest-pixel outline plus its enclosure; dither fallback
+  local out = floodOutside({ off = true, dark = true,
+                             light = true, white = true })
+  local mask, enclosed = {}, 0
+  for i = 0, N * N - 1 do
+    if not out[i] then
+      mask[i] = true
+      if cls[i] ~= "black" then enclosed = enclosed + 1 end
+    end
+  end
+  if enclosed < N * N / 8 then
+    out = floodOutside({ off = true, light = true, white = true })
+    mask = {}
+    for i = 0, N * N - 1 do
+      if not out[i] and cls[i] ~= "off" then mask[i] = true end
+    end
+  end
+  local any = nil
+  for i = 0, N * N - 1 do any = any or mask[i] end
+  if not any then return {} end
+
+  -- a CAPPED hull (the stump): the top capRows rows of the mask are the
+  -- drawn cut face -- a surface seen at an angle, not body. Strip them
+  -- from the mask and remember their art span; the top-face quads below
+  -- project that ellipse across the round cap.
+  local capY0, capY1 = nil, nil
+  if capRows and capRows > 0 then
+    local top = nil
+    for iy = 0, N - 1 do
+      for ix = 0, N - 1 do
+        if mask[iy * N + ix] then top = iy break end
+      end
+      if top then break end
+    end
+    if top then
+      capY0 = top
+      capY1 = math.min(top + capRows - 1, N - 2)
+      for iy = capY0, capY1 do
+        for ix = 0, N - 1 do mask[iy * N + ix] = nil end
+      end
+      any = nil
+      for i = 0, N * N - 1 do any = any or mask[i] end
+      if not any then return {} end
+    end
+  end
+
+  -- the ground the ball stands on: the drawing's own background names
+  -- it. Score every flat ground tile the map places against the cell's
+  -- unmasked light pixels and keep the closest -- mid-forest trees have
+  -- no flat neighbour to vote with, and the commonest-ground fallback
+  -- paints pale path under trees whose art sits on grass. Dark unmasked
+  -- pixels (the drawn cast shadow) stay out of the score: no ground
+  -- tile carries a shadow, and their darks would drag every match.
+  local bg = nil
+  if groundTiles and #groundTiles > 0 then
+    local bestScore = nil
+    for _, t in ipairs(groundTiles) do
+      local ox = (t % perRow) * 8
+      local oy = math.floor(t / perRow) * 8
+      local score, n = 0, 0
+      for py = 0, N - 1 do
+        for px = 0, N - 1 do
+          local i = py * N + px
+          local c = cls[i]
+          if not mask[i] and (c == "light" or c == "white") then
+            local ax, ay = texel(px, py)
+            local r1, g1, b1 = data:getPixel(ax, ay)
+            local r2, g2, b2 = data:getPixel(ox + px % 8, oy + py % 8)
+            local dr, dg, db = r1 - r2, g1 - g2, b1 - b2
+            score = score + dr * dr + dg * dg + db * db
+            n = n + 1
+          end
+        end
+      end
+      if n > 0 then
+        score = score / n
+        if not bestScore or score < bestScore then bestScore, bg = score, t end
+      end
+    end
+  end
+
+  -- discs: per mask pixel a z chord [z0, z1), from its row's span circle
+  local z0, z1, src = {}, {}, {}
+  local loRow, hiRow = {}, {}
+  local yBot = nil
+  for iy = 0, N - 1 do
+    local lo, hi = nil, nil
+    for ix = 0, N - 1 do
+      if mask[iy * N + ix] then
+        lo = lo or ix
+        hi = ix
+      end
+    end
+    if lo then
+      loRow[iy], hiRow[iy] = lo, hi
+      yBot = iy
+      local c = (lo + hi + 1) / 2
+      local hw = (hi - lo + 1) / 2
+      for ix = lo, hi do
+        local i = iy * N + ix
+        if mask[i] then
+          local dx = ix + 0.5 - c
+          local n = 1
+          if hw * hw > dx * dx then
+            n = math.max(1, math.floor(2 * math.sqrt(hw * hw - dx * dx)
+                                       + 0.5))
+          end
+          z0[i] = math.floor(N2 - n / 2 + 0.5)
+          z1[i] = z0[i] + n
+          src[i] = iy
+        end
+      end
+    end
+  end
+
+  -- foot: rows under the mask repeat the bottom row's discs, wearing the
+  -- bottom row's (outline-dark) pixels
+  for iy = yBot + 1, N - 1 do
+    loRow[iy], hiRow[iy] = loRow[yBot], hiRow[yBot]
+    for ix = loRow[yBot], hiRow[yBot] do
+      local b = yBot * N + ix
+      if z0[b] then
+        local i = iy * N + ix
+        z0[i], z1[i], src[i] = z0[b], z1[b], yBot
+      end
+    end
+  end
+
+  -- the round cap's top row and z extent, for the stump's ring
+  -- projection below
+  local capTopRow, capZ0, capZ1 = nil, nil, nil
+  if capY0 then
+    for iy = 0, N - 1 do
+      if loRow[iy] then capTopRow = iy break end
+    end
+    if capTopRow then
+      for ix = loRow[capTopRow], hiRow[capTopRow] do
+        local i = capTopRow * N + ix
+        if z0[i] then
+          capZ0 = math.min(capZ0 or z0[i], z0[i])
+          capZ1 = math.max(capZ1 or z1[i], z1[i])
+        end
+      end
+    end
+  end
+
+  local function solidAt(ix, iy, iz)
+    if ix < 0 or ix > N - 1 or iy < 0 or iy > N - 1 then return false end
+    local i = iy * N + ix
+    return z0[i] ~= nil and iz >= z0[i] and iz < z1[i]
+  end
+
+  -- cap interiors sample the canopy a couple of rows below the rim,
+  -- skipping outline-dark pixels
+  local function deepTexel(ix, iy)
+    for iy2 = iy + 2, math.min(N - 1, iy + 4) do
+      local i = iy2 * N + ix
+      if mask[i] and cls[i] ~= "black" then return texel(ix, iy2) end
+    end
+    return texel(ix, iy)
+  end
+
+  -- side walls read as material, not outline: walk inward past black
+  -- pixels (the building extruder's de-outline rule). The silhouette's
+  -- edge columns are all outline, and without this every flank of the
+  -- ball paints solid black the moment the camera turns. The foot rows
+  -- stay dark on purpose: their whole source row is outline-black.
+  local function sideTexel(ix, iy)
+    local r = src[iy * N + ix]
+    local dir = ix + ix < loRow[iy] + hiRow[iy] and 1 or -1
+    for step = 0, 3 do
+      local x2 = ix + dir * step
+      local i2 = r * N + x2
+      if x2 < 0 or x2 > N - 1 or not mask[i2] then break end
+      if cls[i2] ~= "black" then return texel(x2, r) end
+    end
+    return texel(ix, r)
+  end
+
+  local quads = {}
+
+  for iy = 0, N - 1 do
+    if loRow[iy] then
+      local yB, yT = N - 1 - iy, N - iy
+
+      -- front and back: the drawing per-pixel, columns merged where they
+      -- share a chord plane; a run never crosses the 8px atlas tile seam
+      -- (its u range must interpolate inside one tile)
+      local ix = loRow[iy]
+      while ix <= hiRow[iy] do
+        local i = iy * N + ix
+        if z0[i] then
+          local ix2 = ix
+          while ix2 + 1 <= hiRow[iy] do
+            local j = iy * N + ix2 + 1
+            if z0[j] == z0[i] and z1[j] == z1[i]
+               and math.floor((ix2 + 1) / 8) == math.floor(ix / 8) then
+              ix2 = ix2 + 1
+            else
+              break
+            end
+          end
+          local ax0, ay = texel(ix, src[i])
+          local ax1 = (texel(ix2, src[i]))
+          local u0, u1 = (ax0 + 0.05) / atlasW, (ax1 + 0.95) / atlasW
+          local v0, v1 = (ay + 0.05) / atlasH, (ay + 0.95) / atlasH
+          local x0, x1 = ix - N2, ix2 - N2 + 1
+          local zF, zB = z1[i] - N2, z0[i] - N2
+          quads[#quads + 1] = {
+            { x0, yB, zF }, { x1, yB, zF }, { x1, yT, zF }, { x0, yT, zF },
+            uv = { { u0, v1 }, { u1, v1 }, { u1, v0 }, { u0, v0 } },
+            shade = ROUND_SHADE.front,
+          }
+          quads[#quads + 1] = {
+            { x1, yB, zB }, { x0, yB, zB }, { x0, yT, zB }, { x1, yT, zB },
+            uv = { { u1, v1 }, { u0, v1 }, { u0, v0 }, { u1, v0 } },
+            shade = ROUND_SHADE.back,
+          }
+          ix = ix2 + 1
+        else
+          ix = ix + 1
+        end
+      end
+
+      -- sides, steps, undersides: constant-texel quads over the z runs a
+      -- neighbour doesn't cover
+      for ix = loRow[iy], hiRow[iy] do
+        local i = iy * N + ix
+        if z0[i] then
+          local ax, ay = texel(ix, src[i])
+          local u, v = (ax + 0.5) / atlasW, (ay + 0.5) / atlasH
+          local x0, x1 = ix - N2, ix - N2 + 1
+
+          -- exposed z pieces against one neighbouring column
+          local function pieces(nx, ny, emit)
+            local iz = z0[i]
+            while iz < z1[i] do
+              if not solidAt(nx, ny, iz) then
+                local iz2 = iz
+                while iz2 + 1 < z1[i] and not solidAt(nx, ny, iz2 + 1) do
+                  iz2 = iz2 + 1
+                end
+                emit(iz - N2, iz2 - N2 + 1, iz, iz2)
+                iz = iz2 + 1
+              else
+                iz = iz + 1
+              end
+            end
+          end
+
+          local sax, say = sideTexel(ix, iy)
+          local su, sv = (sax + 0.5) / atlasW, (say + 0.5) / atlasH
+          pieces(ix - 1, iy, function(zA, zB)
+            quads[#quads + 1] = {
+              { x0, yB, zA }, { x0, yB, zB }, { x0, yT, zB }, { x0, yT, zA },
+              u = su, v = sv, shade = ROUND_SHADE.side,
+            }
+          end)
+          pieces(ix + 1, iy, function(zA, zB)
+            quads[#quads + 1] = {
+              { x1, yB, zB }, { x1, yB, zA }, { x1, yT, zA }, { x1, yT, zB },
+              u = su, v = sv, shade = ROUND_SHADE.side,
+            }
+          end)
+          pieces(ix, iy - 1, function(zA, zB, izA, izB)
+            local function top(za, zb, tu, tv)
+              quads[#quads + 1] = {
+                { x0, yT, za }, { x1, yT, za }, { x1, yT, zb }, { x0, yT, zb },
+                u = tu, v = tv, shade = ROUND_SHADE.top,
+              }
+            end
+            if capTopRow and iy == capTopRow and capZ1 then
+              -- the CUT FACE (a capped hull's top): project the drawn
+              -- ellipse across the round cap voxel row by voxel row --
+              -- its top arc at the cap's north rim, its bottom arc at
+              -- the south, the perspective the 2D art already implies
+              for iz = izA, izB do
+                local t = capZ1 - 1 > capZ0
+                          and (iz - capZ0) / (capZ1 - 1 - capZ0) or 0
+                local ry = capY0 + math.floor(t * (capY1 - capY0) + 0.5)
+                local cax, cay = texel(ix, ry)
+                top(iz - N2, iz - N2 + 1,
+                    (cax + 0.5) / atlasW, (cay + 0.5) / atlasH)
+              end
+            elseif izA == z0[i] and izB == z1[i] - 1 and izB - izA >= 2 then
+              -- the dome cap: outline on the rim cells, canopy inside
+              local du, dv = deepTexel(ix, iy)
+              top(zA, zA + 1, u, v)
+              top(zA + 1, zB - 1, (du + 0.5) / atlasW, (dv + 0.5) / atlasH)
+              top(zB - 1, zB, u, v)
+            else
+              top(zA, zB, u, v)
+            end
+          end)
+          if iy < N - 1 then
+            pieces(ix, iy + 1, function(zA, zB)
+              quads[#quads + 1] = {
+                { x0, yB, zB }, { x1, yB, zB }, { x1, yB, zA }, { x0, yB, zA },
+                u = u, v = v, shade = ROUND_SHADE.bottom,
+              }
+            end)
+          end
+        end
+      end
+    end
+  end
+  return quads, bg
+end
+
+-- Hull templates dedupe GLOBALLY per (tileset, four tiles, ground set):
+-- the same four-tile tree repeats for hundreds of cells on a map and
+-- across every route of its tileset, so the carve runs once per distinct
+-- drawing per session.  What a map keeps is a STAMP LIST -- (template,
+-- cell offset) pairs the mesher expands while packing vertices -- rather
+-- than materialized per-cell quad tables, which retained ~500 quads x
+-- hundreds of tree cells x six Lua tables each PER MAP (the multi-GB
+-- heap growth on a cross-region trek).
+local roundCache = {}
+
+function Structures.buildCylinders(S, map, x0, x1, y0, y1, groundTiles)
+  local data = pixels(map.tileset)
+  local tw, th = map.def.width * 4, map.def.height * 4
+
+  -- ground-set fingerprint: the template's art-matched floor depends on
+  -- which ground tiles this map places, so maps sharing a tileset but
+  -- not a palette of floors carve separately
+  local gsig
+  do
+    local g = {}
+    for i, t in ipairs(groundTiles or {}) do g[i] = t end
+    table.sort(g)
+    gsig = table.concat(g, ",")
+  end
+  local tsid = tostring(map.tileset.id or map.tileset.image or "?")
+
+  -- the stump class's drawn-ellipse height, hand-authored per tileset
+  -- (the profile's stump_cap, in art rows)
+  local stumpCap = 6
+  do
+    local okP, prof = pcall(V.data, "voxel_heights")
+    local entry = okP and type(prof) == "table" and prof.tilesets
+                  and prof.tilesets[map.tileset.id]
+    if entry and type(entry.stump_cap) == "number" then
+      stumpCap = entry.stump_cap
+    end
+  end
+
+  -- cells consumed by a 2x2 `canopy` group; the scan runs north to
+  -- south, west to east, so an anchor always claims its partners
+  -- before they are visited
+  local grouped = {}
+  for cy = math.floor(y0 / 2), math.floor(y1 / 2) do
+    for cx = math.floor(x0 / 2), math.floor(x1 / 2) do
+      Budget.tick()
+      local ckey = cy * 8192 + cx
+      local k = keyOf(cx * 2, cy * 2)
+      local s = (not grouped[ckey]) and S.shapeAt[k] or nil
+      local near = cx * 2 >= -ROUND_RING and cx * 2 < tw + ROUND_RING
+               and cy * 2 >= -ROUND_RING and cy * 2 < th + ROUND_RING
+      if s and s.art == "canopy" and near then
+        -- ONE 32px hull over the 2x2-cell drawing. The partner cells
+        -- must be round-pinned too, or the drawing is partial (a map
+        -- edit, a mod's stray anchor tile) and the anchor is left
+        -- alone rather than carved into a half-empty giant.
+        local whole = true
+        for _, d in ipairs({ { 1, 0 }, { 0, 1 }, { 1, 1 } }) do
+          local ps = S.shapeAt[keyOf((cx + d[1]) * 2, (cy + d[2]) * 2)]
+          if not (ps and (ps.art == "cylinder" or ps.art == "canopy")) then
+            whole = false
+          end
+        end
+        if whole then
+          local ground = false
+          if data then
+            local ids = {}
+            for dy = 0, 3 do
+              for dx = 0, 3 do
+                ids[#ids + 1] = S.tileAt[keyOf(cx * 2 + dx, cy * 2 + dy)]
+              end
+            end
+            local sig = tsid .. "|g32|" .. gsig .. "|"
+                        .. table.concat(ids, ":")
+            local tpl = roundCache[sig]
+            if not tpl then
+              local tq, tbg = roundTemplate(S, map, data, cx, cy,
+                                            groundTiles, 32)
+              tpl = { quads = tq, bg = tbg }
+              roundCache[sig] = tpl
+            end
+            ground = tpl.bg or false
+            S.roundStamps[#S.roundStamps + 1] =
+              { quads = tpl.quads, mx = cx * 16 + 16, mz = cy * 16 + 16,
+                r = 16 }
+          end
+          for dy = 0, 3 do
+            for dx = 0, 3 do
+              local tk = keyOf(cx * 2 + dx, cy * 2 + dy)
+              S.skip[tk] = true
+              S.ground[tk] = ground
+            end
+          end
+          grouped[ckey + 1] = true
+          grouped[ckey + 8192] = true
+          grouped[ckey + 8193] = true
+        end
+      elseif s and s.art == "cylinder" and near then
+        -- a `stump`-class cell is the same hull with a cut face: its
+        -- top capRows of drawing project onto the round top
+        local cap = s.class == "stump" and stumpCap or nil
+        local ground = false
+        if data then
+          local sig = tsid .. (cap and ("|c" .. cap) or "") .. "|"
+            .. gsig .. "|" .. table.concat({
+            S.tileAt[k], S.tileAt[keyOf(cx * 2 + 1, cy * 2)],
+            S.tileAt[keyOf(cx * 2, cy * 2 + 1)],
+            S.tileAt[keyOf(cx * 2 + 1, cy * 2 + 1)] }, ":")
+          local tpl = roundCache[sig]
+          if not tpl then
+            local tq, tbg = roundTemplate(S, map, data, cx, cy,
+                                          groundTiles, 16, cap)
+            tpl = { quads = tq, bg = tbg }
+            roundCache[sig] = tpl
+          end
+          ground = tpl.bg or false
+          S.roundStamps[#S.roundStamps + 1] =
+            { quads = tpl.quads, mx = cx * 16 + 8, mz = cy * 16 + 8 }
+        end
+        -- headless (no pixels): no hull, but still claim the tiles so
+        -- the volume path never boxes a pinned cell. Ground is the
+        -- template's own art-matched tile; `false` (no match, headless)
+        -- falls to the commonest-ground pass below.
+        for dy = 0, 1 do
+          for dx = 0, 1 do
+            local tk = keyOf(cx * 2 + dx, cy * 2 + dy)
+            S.skip[tk] = true
+            S.ground[tk] = ground
+          end
+        end
+      end
+    end
+  end
+end
+
+-- ---- relief props: top-down drawings lying on their surface ----
+
+-- A cell pinned `relief` is a prop DRAWN FROM ABOVE (a game console on
+-- the floor): standing it up would be wrong, and a solid box would carry
+-- the drawn floor around it.  The drawing is segmented like any forced
+-- prop (black outline; the shades touching the cluster's edge are the
+-- background) and the object pixels extrude straight up a few voxels,
+-- art on the top face -- a piece of the drawing pushed out of the
+-- ground.  The floor the flood removed is repainted by the claimed
+-- tiles' common-ground fill.
+local RELIEF_SHADE = { top = 1.0, south = 0.9, north = 0.62, side = 0.75 }
+
+function Structures.buildRelief(S, map, region, data, perRow, h)
+  local atlasW = map.tileset.imageWidth or 128
+  local atlasH = map.tileset.imageHeight or 48
+  local bw = (region.maxX - region.minX + 1) * 8
+  local bh = (region.maxY - region.minY + 1) * 8
+  local member = {}
+  for _, c in ipairs(region.tiles) do member[keyOf(c[1], c[2])] = true end
+
+  local cls, srcU, srcV = {}, {}, {}
+  for py = 0, bh - 1 do
+    for px = 0, bw - 1 do
+      local i = py * bw + px
+      local k = keyOf(region.minX + math.floor(px / 8),
+                      region.minY + math.floor(py / 8))
+      if member[k] then
+        local tile = S.tileAt[k]
+        local ax = (tile % perRow) * 8 + px % 8
+        local ay = math.floor(tile / perRow) * 8 + py % 8
+        srcU[i], srcV[i] = ax, ay
+        local r, g, b, a = data:getPixel(ax, ay)
+        cls[i] = a == 0 and "off" or Structures.shadeClass(math.min(r, g, b))
+      end
+    end
+  end
+
+  local bg = {}
+  for py = 0, bh - 1 do
+    for px = 0, bw - 1 do
+      if px == 0 or px == bw - 1 or py == 0 or py == bh - 1 then
+        local c = cls[py * bw + px]
+        if c and c ~= "black" and c ~= "off" then bg[c] = true end
+      end
+    end
+  end
+
+  local flooded, queue = {}, {}
+  local function seed(i)
+    local c = cls[i]
+    if c and c ~= "black" and (c == "off" or bg[c]) and not flooded[i] then
+      flooded[i] = true
+      queue[#queue + 1] = i
+    end
+  end
+  for px = 0, bw - 1 do
+    seed(px)
+    seed((bh - 1) * bw + px)
+  end
+  for py = 0, bh - 1 do
+    seed(py * bw)
+    seed(py * bw + bw - 1)
+  end
+  while #queue > 0 do
+    local i = table.remove(queue)
+    local px, py = i % bw, math.floor(i / bw)
+    for _, d in ipairs(DIRS4) do
+      local nx, ny = px + d[1], py + d[2]
+      if nx >= 0 and nx < bw and ny >= 0 and ny < bh then
+        seed(ny * bw + nx)
+      end
+    end
+  end
+
+  local function on(px, py)
+    if px < 0 or px >= bw or py < 0 or py >= bh then return false end
+    local i = py * bw + px
+    return cls[i] ~= nil and cls[i] ~= "off" and not flooded[i]
+  end
+
+  local quads = S.objectQuads
+  local wx0, wz0 = region.minX * 8, region.minY * 8
+  for py = 0, bh - 1 do
+    for px = 0, bw - 1 do
+      if on(px, py) then
+        local i = py * bw + px
+        local u = (srcU[i] + 0.5) / atlasW
+        local v = (srcV[i] + 0.5) / atlasH
+        local x, z = wx0 + px, wz0 + py
+        local function quad(c1, c2, c3, c4, shade)
+          quads[#quads + 1] = { c1, c2, c3, c4, u = u, v = v, shade = shade }
+        end
+        quad({ x, h, z }, { x + 1, h, z }, { x + 1, h, z + 1 },
+             { x, h, z + 1 }, RELIEF_SHADE.top)
+        if not on(px, py + 1) then
+          quad({ x, 0, z + 1 }, { x + 1, 0, z + 1 }, { x + 1, h, z + 1 },
+               { x, h, z + 1 }, RELIEF_SHADE.south)
+        end
+        if not on(px, py - 1) then
+          quad({ x + 1, 0, z }, { x, 0, z }, { x, h, z },
+               { x + 1, h, z }, RELIEF_SHADE.north)
+        end
+        if not on(px - 1, py) then
+          quad({ x, 0, z }, { x, 0, z + 1 }, { x, h, z + 1 },
+               { x, h, z }, RELIEF_SHADE.side)
+        end
+        if not on(px + 1, py) then
+          quad({ x + 1, 0, z + 1 }, { x + 1, 0, z }, { x + 1, h, z },
+               { x + 1, h, z + 1 }, RELIEF_SHADE.side)
+        end
+      end
+    end
+  end
+end
+
+-- ---- bookcases: free-standing shelves collapsed to true depth ----
+
+-- A drawn bookcase is TALL, not deep: the graphic spans two cell rows
+-- because the shelf is 32px high, while the object stands one cell
+-- (16px) deep.  Columns of tiles pinned `bookcase` collapse in ranks
+-- (at most four drawn rows each, measured from the south): every rank
+-- raises one box over its front two tile rows -- the drawing folded up
+-- its south face band by band -- and its back rows become hidden floor.
+-- When the row just above a rank is undetected structure (a shared trim
+-- tile the profile cannot pin), the rank adopts it as its CAP: one more
+-- band of height and the art its top face wears.
+local BOOK_SHADE = { south = 1.0, north = 0.68, flank = 0.8, top = 0.85 }
+
+local function bookcaseRank(S, map, tx, northTy, frontTy, capTile)
+  local quads = S.objectQuads
+  local perRow = map.tileset.tilesPerRow or 16
+  local atlasW = map.tileset.imageWidth or 128
+  local atlasH = map.tileset.imageHeight or 48
+  local function uvRect(tile)
+    local ax = (tile % perRow) * 8
+    local ay = math.floor(tile / perRow) * 8
+    return (ax + 0.5) / atlasW, (ax + 7.5) / atlasW,
+           (ay + 0.5) / atlasH, (ay + 7.5) / atlasH
+  end
+
+  local size = frontTy - northTy + 1
+  local bands = size + (capTile and 1 or 0)
+  local h = bands * 8
+  local depth = math.min(2, size) * 8
+  local x0, x1 = tx * 8, tx * 8 + 8
+  local z1 = frontTy * 8 + 8
+  local z0 = z1 - depth
+
+  -- does the neighbouring column continue this shelf? (flanks only cap
+  -- the ends of a run of bookcases standing side by side)
+  local function joined(nx)
+    local ns = S.shapeAt[keyOf(nx, frontTy)]
+    return ns ~= nil and ns.art == "bookcase"
+  end
+
+  for band = 0, bands - 1 do
+    local tile = band < size and map:tileAt(tx, frontTy - band) or capTile
+    local u0, u1, v0, v1 = uvRect(tile)
+    local y0, y1 = band * 8, band * 8 + 8
+    quads[#quads + 1] = { { x0, y0, z1 }, { x1, y0, z1 },
+      { x1, y1, z1 }, { x0, y1, z1 },
+      uv = { { u0, v1 }, { u1, v1 }, { u1, v0 }, { u0, v0 } },
+      shade = BOOK_SHADE.south }
+    quads[#quads + 1] = { { x1, y0, z0 }, { x0, y0, z0 },
+      { x0, y1, z0 }, { x1, y1, z0 },
+      uv = { { u0, v1 }, { u1, v1 }, { u1, v0 }, { u0, v0 } },
+      shade = BOOK_SHADE.north }
+    if not joined(tx - 1) then
+      quads[#quads + 1] = { { x0, y0, z0 }, { x0, y0, z1 },
+        { x0, y1, z1 }, { x0, y1, z0 },
+        uv = { { u0, v1 }, { u1, v1 }, { u1, v0 }, { u0, v0 } },
+        shade = BOOK_SHADE.flank }
+    end
+    if not joined(tx + 1) then
+      quads[#quads + 1] = { { x1, y0, z1 }, { x1, y0, z0 },
+        { x1, y1, z0 }, { x1, y1, z1 },
+        uv = { { u0, v1 }, { u1, v1 }, { u1, v0 }, { u0, v0 } },
+        shade = BOOK_SHADE.flank }
+    end
+  end
+
+  local topTile = capTile or map:tileAt(tx, northTy)
+  local u0, u1, v0, v1 = uvRect(topTile)
+  for seg = 0, depth / 8 - 1 do
+    local sz0 = z0 + seg * 8
+    quads[#quads + 1] = { { x0, h, sz0 }, { x1, h, sz0 },
+      { x1, h, sz0 + 8 }, { x0, h, sz0 + 8 },
+      uv = { { u0, v0 }, { u1, v0 }, { u1, v1 }, { u0, v1 } },
+      shade = BOOK_SHADE.top }
+  end
+end
+
+function Structures.buildBookcases(S, map, x0, x1, y0, y1)
+  -- What to do with the rows a rank VACATES (see TileShape.bookcaseBackfill).
+  -- Read once: it is a property of the tileset, not of the column.
+  local backfill = TileShape.bookcaseBackfill(map.tileset.id)
+  for tx = x0, x1 do
+    local ty = y1
+    while ty >= y0 do
+      local s = S.shapeAt[keyOf(tx, ty)]
+      if s and s.art == "bookcase" then
+        -- the contiguous pinned run above this front row
+        local north = ty
+        while north > y0 do
+          local ns = S.shapeAt[keyOf(tx, north - 1)]
+          if ns and ns.art == "bookcase" then north = north - 1 else break end
+        end
+        -- ranks of at most four drawn rows, southmost first
+        local front = ty
+        while front >= north do
+          local top = math.max(north, front - 3)
+          -- adopt the trim row just above as the cap: either undetected
+          -- structure the profile could not pin, or a row pinned `table`
+          -- because the same trim tiles cap other furniture too
+          local capTile = nil
+          if top == north then
+            local ck = keyOf(tx, north - 1)
+            local cs = S.shapeAt[ck]
+            if cs and not cs.flat and not S.skip[ck] and not S.runs[ck]
+               and (not cs.authored or cs.class == "table") then
+              capTile = S.tileAt[ck]
+            end
+          end
+          -- The box is one cell deep, so it covers only the run's southmost
+          -- rows; everything north of that is vacated.  By default a vacated
+          -- row is skipped and painted with synthesized ground -- right for a
+          -- shelf standing in a room.  `bookcase_backfill = "above"` hands it
+          -- the cell above the run instead, shape and art, so a wall cut into
+          -- a terrace has more terrace behind it rather than a trench.
+          local covered = math.min(2, front - top + 1)
+          local srcK = keyOf(tx, top - 1)
+          local src = backfill == "above" and S.shapeAt[srcK] or nil
+          for cy = top, front do
+            local tk = keyOf(tx, cy)
+            if src and cy <= front - covered then
+              S.shapeAt[tk] = src
+              S.tileAt[tk] = S.tileAt[srcK]
+            else
+              S.skip[tk] = true
+              S.ground[tk] = false
+            end
+          end
+          bookcaseRank(S, map, tx, top, front, capTile)
+          front = top - 1
+        end
+        ty = north - 1
+      else
+        ty = ty - 1
+      end
+    end
+  end
+end
+
+-- ---- stairs: pinned cells that render as real steps ----
+
+-- A cell the profile pins stair_e / stair_w (art "stair") becomes a
+-- flight of STAIR_STEPS boxes rising evenly across the cell toward the
+-- named side, each the full cell deep.  stair_down_e / stair_down_w is
+-- the same flight EXCAVATED: the cell opens into a stairwell and the
+-- steps descend below floor level toward the named side -- the shape a
+-- staircase leading down a floor actually has.  The 2D staircase is
+-- drawn from the side, so vertical faces (step fronts and stairwell
+-- walls) wear the matching slice of that drawing -- the railing's
+-- diagonal lands along the stepped silhouette -- while treads sample the
+-- art band drawn at their own height.
+local STAIR_STEPS = 4
+
+local STAIR_SHADE = { south = 1.0, north = 0.68, tread = 1.0,
+                      riser = 0.82, cap = 0.78,
+                      wellN = 0.9, wellS = 0.55, wellEnd = 0.15,
+                      wellTread = 0.8 }
+
+local function stairCell(S, map, data, cx, cy, s)
+  local perRow = map.tileset.tilesPerRow or 16
+  local atlasW = map.tileset.imageWidth or 128
+  local atlasH = map.tileset.imageHeight or 48
+  local quads = S.objectQuads
+  local down = s.class == "stair_down_e" or s.class == "stair_down_w"
+  local east = s.class == "stair_e" or s.class == "stair_down_e"
+  local mx, mz = cx * 16, cy * 16
+  local h = s.h or 16
+  local rise = h / STAIR_STEPS
+  local runW = 16 / STAIR_STEPS
+  local z0, z1 = mz, mz + 16
+
+  -- cell-space art coords (16x16, row 0 the top) -> atlas uv; callers keep
+  -- a quad's range inside one 8px tile so it never samples across a seam
+  local function uv(px, py)
+    px = math.max(0.05, math.min(15.95, px))
+    py = math.max(0.05, math.min(15.95, py))
+    local tile = S.tileAt[keyOf(cx * 2 + (px >= 8 and 1 or 0),
+                                cy * 2 + (py >= 8 and 1 or 0))]
+    return ((tile % perRow) * 8 + px % 8) / atlasW,
+           (math.floor(tile / perRow) * 8 + py % 8) / atlasH
+  end
+  -- corners run bottom-left, bottom-right, top-right, top-left as seen
+  -- from outside (the mesher's side convention); art rect in cell space
+  local function face(c1, c2, c3, c4, ax0, ay0, ax1, ay1, shade)
+    local u0, v0 = uv(ax0, ay0)
+    local u1, v1 = uv(ax1, ay1)
+    quads[#quads + 1] = { c1, c2, c3, c4,
+      uv = { { u0, v1 }, { u1, v1 }, { u1, v0 }, { u0, v0 } },
+      shade = shade }
+  end
+  -- a vertical face spanning heights [fy0, fy1] wearing art rows
+  -- [ay0, ay1], emitted per 8-row art band so no quad crosses the seam
+  local function banded(z, ax0, ax1, fy0, fy1, ay0, ay1, shade, flip)
+    local scale = (fy1 - fy0) / math.max(ay1 - ay0, 0.001)
+    for _, band in ipairs({ { ay0, math.min(8, ay1) },
+                            { math.max(ay0, 8), ay1 } }) do
+      local a0, a1 = band[1], band[2]
+      if a1 > a0 then
+        local by1 = fy1 - (a0 - ay0) * scale
+        local by0 = fy1 - (a1 - ay0) * scale
+        local xa, xb = mx + ax0, mx + ax1
+        if flip then
+          face({ xb, by0, z }, { xa, by0, z }, { xa, by1, z },
+               { xb, by1, z }, ax0, a0, ax1, a1, shade)
+        else
+          face({ xa, by0, z }, { xb, by0, z }, { xb, by1, z },
+               { xa, by1, z }, ax0, a0, ax1, a1, shade)
+        end
+      end
+    end
+  end
+
+  for i = 0, STAIR_STEPS - 1 do
+    local sx0 = east and (i * runW) or (16 - (i + 1) * runW)
+    local sx1 = sx0 + runW
+    local x0, x1 = mx + sx0, mx + sx1
+
+    if down then
+      -- stairwell: tread i sits (i+1) rises below the floor; the walls
+      -- above it are the excavation, wearing the drawing at its depth
+      local yTop = -(i + 1) * rise
+      local dep = (i + 1) * rise
+
+      face({ x0, yTop, z0 }, { x1, yTop, z0 },
+           { x1, yTop, z1 }, { x0, yTop, z1 },
+           sx0, dep - 1.4, sx1, dep, STAIR_SHADE.wellTread)
+
+      -- stairwell walls above this tread: north wall faces the camera
+      banded(z0, sx0, sx1, yTop, 0, 0, dep, STAIR_SHADE.wellN)
+      banded(z1, sx0, sx1, yTop, 0, 0, dep, STAIR_SHADE.wellS, true)
+
+      -- riser dropping to this tread from the shallower step
+      local rx = east and x0 or x1
+      local ry1 = -i * rise
+      local rax = east and (sx0 + 0.1) or (sx1 - 1.3)
+      if east then
+        face({ rx, yTop, z0 }, { rx, yTop, z1 },
+             { rx, ry1, z1 }, { rx, ry1, z0 },
+             rax, i * rise, rax + 1.2, dep, STAIR_SHADE.riser)
+      else
+        face({ rx, yTop, z1 }, { rx, yTop, z0 },
+             { rx, ry1, z0 }, { rx, ry1, z1 },
+             rax, i * rise, rax + 1.2, dep, STAIR_SHADE.riser)
+      end
+
+      -- the deep end: a dark opening under the wall the flight leaves by
+      if i == STAIR_STEPS - 1 then
+        local px = east and (mx + 16) or mx
+        local cax = east and 14.7 or 0.1
+        if east then
+          face({ px, -h, z1 }, { px, -h, z0 }, { px, 0, z0 }, { px, 0, z1 },
+               cax, 0, cax + 1.2, 16, STAIR_SHADE.wellEnd)
+        else
+          face({ px, -h, z0 }, { px, -h, z1 }, { px, 0, z1 }, { px, 0, z0 },
+               cax, 0, cax + 1.2, 16, STAIR_SHADE.wellEnd)
+        end
+      end
+    else
+      -- rising flight
+      local yTop = (i + 1) * rise
+      local py0 = 16 - yTop
+
+      -- south + north faces: the drawn flight sliced at this step's column
+      banded(z1, sx0, sx1, 0, yTop, py0, 16, STAIR_SHADE.south)
+      banded(z0, sx0, sx1, 0, yTop, py0, 16, STAIR_SHADE.north, true)
+
+      -- tread: the step's top, wearing the art band drawn at its height
+      face({ x0, yTop, z0 }, { x1, yTop, z0 },
+           { x1, yTop, z1 }, { x0, yTop, z1 },
+           sx0, py0, sx1, py0 + 1.4, STAIR_SHADE.tread)
+
+      -- riser: the vertical strip exposed above the previous step
+      local rx = east and x0 or x1
+      local ry0 = i * rise
+      local rax = east and (sx0 + 0.1) or (sx1 - 1.3)
+      if east then
+        face({ rx, ry0, z0 }, { rx, ry0, z1 },
+             { rx, yTop, z1 }, { rx, yTop, z0 },
+             rax, 16 - yTop, rax + 1.2, 16 - ry0, STAIR_SHADE.riser)
+      else
+        face({ rx, ry0, z1 }, { rx, ry0, z0 },
+             { rx, yTop, z0 }, { rx, yTop, z1 },
+             rax, 16 - yTop, rax + 1.2, 16 - ry0, STAIR_SHADE.riser)
+      end
+
+      -- cap the tall end of the flight so it never shows a hole
+      if i == STAIR_STEPS - 1 then
+        local px = east and (mx + 16) or mx
+        local cax = east and 14.7 or 0.1
+        if east then
+          face({ px, 0, z1 }, { px, 0, z0 }, { px, h, z0 }, { px, h, z1 },
+               cax, 0, cax + 1.2, 16, STAIR_SHADE.cap)
+        else
+          face({ px, 0, z0 }, { px, 0, z1 }, { px, h, z1 }, { px, h, z0 },
+               cax, 0, cax + 1.2, 16, STAIR_SHADE.cap)
+        end
+      end
+    end
+  end
+end
+
+function Structures.buildStairs(S, map, x0, x1, y0, y1)
+  local data = pixels(map.tileset)
+  for cy = math.floor(y0 / 2), math.floor(y1 / 2) do
+    for cx = math.floor(x0 / 2), math.floor(x1 / 2) do
+      local s = S.shapeAt[keyOf(cx * 2, cy * 2)]
+      if s and s.art == "stair" then
+        -- claim the cell whichever way the quads go: the mesher must not
+        -- box or floor it.  A rising flight stands on the map's common
+        -- floor; a stairwell IS the hole, so nothing is painted under it
+        local down = s.class == "stair_down_e" or s.class == "stair_down_w"
+        for dy = 0, 1 do
+          for dx = 0, 1 do
+            local tk = keyOf(cx * 2 + dx, cy * 2 + dy)
+            S.skip[tk] = true
+            if not down then S.ground[tk] = false end
+          end
+        end
+        if data then stairCell(S, map, data, cx, cy, s) end
+      end
+    end
+  end
+end
+
+-- ---- volume mode: per-column runs with real drawn heights ----
+
+-- `tiles` is a list of {tx, ty} forming one region (or what is left of one
+-- after object extraction); runs are column-local, heights are measured
+-- per column and reconciled per region.
+function Structures.buildVolume(S, map, tiles)
+  local cols = {}
+  for _, c in ipairs(tiles) do
+    cols[c[1]] = cols[c[1]] or {}
+    cols[c[1]][c[2]] = true
+  end
+
+  local runs = {}
+  local heightVotes = {}
+  local repeatVotes = {}
+  for tx, ys in pairs(cols) do
+    -- visit each contiguous vertical run in this column
+    local sorted = {}
+    for y in pairs(ys) do sorted[#sorted + 1] = y end
+    table.sort(sorted)
+    local i = 1
+    while i <= #sorted do
+      local north = sorted[i]
+      local front = north
+      while i + 1 <= #sorted and sorted[i + 1] == front + 1 do
+        i = i + 1
+        front = sorted[i]
+      end
+      i = i + 1
+      local extent = front - north + 1
+
+      -- the column's own reading: its extent, unless its tile sequence
+      -- repeats -- then the repeat period is the drawn unit. Both readings
+      -- cap at MAX_ROWS (a long-period repeat is still not one column of
+      -- drawing).
+      local unit, repeatRead = math.min(extent, MAX_ROWS), false
+      if extent > 1 then
+        local t0 = map:tileAt(tx, front)
+        for k = 1, extent - 1 do
+          if map:tileAt(tx, front - k) == t0 then
+            unit = math.min(math.max(k, 2), MAX_ROWS)
+            repeatRead = true
+            break
+          end
+        end
+        -- A one-row TRIM at the column's foot hides a repeat from the
+        -- scan above, which anchors at the front tile: a cliff plateau
+        -- ends its south edge in a rounded corner tile, the corner
+        -- never recurs, and the column read its whole capped extent --
+        -- a 48px fin (or a whole tent of them) sticking out of a 16px
+        -- mesa on Routes 3 and 4. When the two rows directly above the
+        -- front are IDENTICAL, the column is that repeat wearing a trim
+        -- foot: one course plus the trim is its drawn unit. Doorway
+        -- columns are untouched -- their run answers to the region
+        -- (see below) before the unit matters.
+        if not repeatRead and extent > 2
+           and map:tileAt(tx, front - 1) == map:tileAt(tx, front - 2) then
+          unit = 2
+          repeatRead = true
+        end
+      end
+      local isDoor = false
+      for ty = north, front do
+        if S.doorFold[keyOf(tx, ty)] then
+          isDoor = true
+          break
+        end
+      end
+      local run = { front = front, north = north, extent = extent,
+                    unit = unit, fromRepeat = repeatRead, door = isDoor }
+      runs[#runs + 1] = { tx = tx, run = run }
+      local h = unit * 8
+      heightVotes[h] = (heightVotes[h] or 0) + 1
+      if repeatRead then repeatVotes[h] = (repeatVotes[h] or 0) + 1 end
+    end
+  end
+
+  -- region consensus: the dominant height. A column whose reading came
+  -- from a repeat adopts it when taller (the column above a doorway
+  -- repeats internally but belongs to a 48px house); a column that read
+  -- its full extent keeps it (an attached low wing stays low).
+  local modeH, modeN = 16, 0
+  for h, n in pairs(heightVotes) do
+    if n > modeN or (n == modeN and h > modeH) then modeH, modeN = h, n end
+  end
+  -- whether the region's dominant columns are flat repeats (a cliff
+  -- mound's plateau) rather than drawn facades (a house's front)
+  local modeRepeat = (repeatVotes[modeH] or 0) * 2 > modeN
+  for _, r in ipairs(runs) do
+    local run = r.run
+    local h = run.unit * 8
+    local adopted = false
+    local flatDoor = false
+    if run.door then
+      -- A folded doorway column answers to its region ENTIRELY. Its own
+      -- reading spans the door plus everything drawn above it -- a
+      -- house's full height when the door is a house's, but a 32px
+      -- tower over a 16px plateau when the door is a cave mouth cut
+      -- into a cliff mound (Diglett's Cave: the entrance jumped a block
+      -- above the mound around it). Height and top both come from the
+      -- region: the mode height, roofed like a facade when the mode
+      -- columns are drawn facades, flat when they are flat repeats.
+      h = modeH
+      adopted = not modeRepeat
+      flatDoor = modeRepeat
+    elseif run.fromRepeat and modeH > h then
+      h = modeH
+      adopted = true
+    end
+    -- Outdoors, a structure's top rows are its ROOF: the drawn height
+    -- splits into a vertical facade and a slope rising north to the drawn
+    -- peak (the mesher builds it; hips close the exposed flanks). Repeat
+    -- patterns (a border wall) stay flat-topped -- unless they adopted
+    -- their region's height, which means they are part of a building (the
+    -- column above a doorway) and roof with it. Total height is always
+    -- the drawn height: facade + rise = extent rows * 8.
+    --
+    -- But only PITCHED roofs slope. Gen 1 draws two kinds: a pitched roof
+    -- has distinct ridge and eaves rows (the houses' stripes), while a
+    -- flat ROOFTOP (the lab, the mart) repeats one texture tile over the
+    -- whole roof area -- and a rooftop tilted into a 48px ramp reads
+    -- wrong instantly. Distinct top rows -> slope; repeated -> level top.
+    local roofRows = 0
+    if S.outdoor and (not run.fromRepeat or adopted) and h >= 16
+       and not flatDoor then
+      roofRows = math.min(2, math.floor(h / 8) - 1)
+      if roofRows > 0 and map:tileAt(r.tx, run.north)
+                         == map:tileAt(r.tx, run.north + 1) then
+        roofRows = 0
+      end
+    end
+    run.roofRows = roofRows
+    run.rise = roofRows * 8
+    run.peak = h
+    run.h = h - run.rise               -- facade height: what sides build to
+    for ty = run.north, run.front do
+      S.runs[keyOf(r.tx, ty)] = run
+    end
+  end
+end
+
+-- ---- object mode: per-pixel voxelization of drawn props ----
+
+local OBJ_SHADE = { front = 1.0, back = 0.68, side = 0.78,
+                    top = 1.0, bottom = 0.55 }
+
+-- The four GB shades, by a pixel's darkest channel.  Force-mode
+-- segmentation reasons in these: black is always outline/object, the
+-- other three are background only where they touch the cluster's edge.
+function Structures.shadeClass(v)
+  if v <= 0.25 then return "black" end
+  if v <= 0.55 then return "dark" end
+  if v <= 0.85 then return "light" end
+  return "white"
+end
+
+-- Analyze one region's art against its surroundings, voxelize the
+-- sprite-like clusters, and return the tiles that remain for volume mode.
+-- `force` (profile-pinned billboards) voxelizes every tile of the region
+-- unconditionally -- the pin IS the classification. `force = "opaque"`
+-- (the `post` pool) keeps the decree -- every tile is a prop, aprons
+-- seed the flood, validation is skipped -- but classifies pixels the way
+-- the DETECTOR does (everything non-white is solid) instead of by
+-- outline shade: a fence's mid browns are its body, and the outline
+-- rule would strip the posts to black skeletons.
+function Structures.extractObjects(S, map, region, data, perRow, force)
+  local bw = (region.maxX - region.minX + 1) * 8
+  local bh = (region.maxY - region.minY + 1) * 8
+
+  local member = {}
+  for _, c in ipairs(region.tiles) do member[keyOf(c[1], c[2])] = true end
+
+  -- Image over the region bbox plus a 1px ground apron. Pixel states:
+  --   solid   opaque member art (non-white, or white that survives)
+  --   cand    member white: background candidate, the flood decides
+  --   air     ground the flood may travel: INSIDE the bbox (the gaps
+  --           between fence posts), or the SOUTH apron row. This is the
+  --           direction the viewer reads background from -- a prop's
+  --           white meets the ground at its feet. OUTDOORS the other
+  --           aprons are barriers on purpose: a building's roof stripes
+  --           touch the grass BEHIND it, and a flood allowed to walk
+  --           around the sides would pour in from the north and shred the
+  --           roof into misdetected sprite clusters (it did). INDOORS all
+  --           four aprons seed: furniture backs onto walls and bottom-row
+  --           props meet the void ring, so the south row alone often
+  --           cannot reach the background at all -- and there are no
+  --           roofs inside to protect.
+  --   barrier everything else
+  local W, H = bw + 2, bh + 2
+  local state = {}
+  local srcU, srcV = {}, {}
+  for iy = 0, H - 1 do
+    for ix = 0, W - 1 do
+      Budget.tick()
+      local i = iy * W + ix
+      local px, py = ix - 1, iy - 1
+      local tx = region.minX + math.floor(px / 8)
+      local ty = region.minY + math.floor(py / 8)
+      local k = keyOf(tx, ty)
+      local inside = px >= 0 and px < bw and py >= 0 and py < bh
+      -- a forced (pinned) prop floods from every apron even when the
+      -- neighbours are solid: the pin itself declares the art a prop
+      -- whose whites are background -- a monitor pinned atop its desk has
+      -- no flat neighbour anywhere to seed from
+      local apron = iy == H - 1
+        or ((force or not S.outdoor)
+            and (iy == 0 or ix == 0 or ix == W - 1))
+      if inside and member[k] then
+        local tile = S.tileAt[k]
+        local ax = (tile % perRow) * 8 + px % 8
+        local ay = math.floor(tile / perRow) * 8 + py % 8
+        srcU[i], srcV[i] = ax, ay
+        local r, g, b, a = data:getPixel(ax, ay)
+        if a == 0 then
+          state[i] = "cand"
+        elseif force and force ~= "opaque" then
+          state[i] = Structures.shadeClass(math.min(r, g, b))
+        else
+          state[i] = math.min(r, g, b) > 0.83 and "cand" or "solid"
+        end
+      elseif inside or apron then
+        if force then
+          -- a pinned prop's surroundings are background BY DECREE -- the
+          -- pin declares the drawing a prop even when every neighbour is
+          -- solid furniture (a vase boxed in by its table).  Ring pixels
+          -- seed the flood outright; interior non-member pixels ("iair")
+          -- seed it too but never drain paint whites -- only a white run
+          -- reaching the RING is background white.
+          state[i] = inside and "iair" or "air"
+        else
+          local s = S.shapeAt[k]
+          state[i] = (s and s.flat and s.class ~= "void") and "air"
+                     or "barrier"
+        end
+      else
+        state[i] = "barrier"
+      end
+    end
+  end
+
+  -- Forced (pinned) props are segmented the way the art is authored:
+  -- objects wear a BLACK OUTLINE, and the background is whatever shades
+  -- actually touch the cluster's edge -- the white floor around a TV,
+  -- the grey tabletop around a vase.  Only those shades flood; the
+  -- outline, its interior, the drawing's paint whites and anything they
+  -- enclose all survive as the object.
+  --
+  -- The `cutout` pool is STRICTER, per the pure-profile contract: mid
+  -- shades are always background (a drawn cast shadow must not ring the
+  -- object in brown), and whites flood only along white runs from the
+  -- edge -- a background white sheet drains away, but paint whites the
+  -- flood could only reach through grey are the object.
+  if force and force ~= "opaque" then
+    local strict = false
+    do
+      local fs = S.shapeAt[keyOf(region.tiles[1][1], region.tiles[1][2])]
+      strict = fs ~= nil and fs.class == "cutout"
+    end
+    -- The rim vote reads the shades on the DRAWING'S OWN bounding box, so a
+    -- prop whose body reaches its own edge votes itself out. The Center's
+    -- potted plants are the case: the pot's olive base is drawn flush on the
+    -- bottom row of the block, so "dark" came back as background and every
+    -- dark pixel in the whole plant drained with it -- the pots rendered as
+    -- hollow black frames while the 2D art has solid olive bodies.
+    --
+    -- Where the vote misreads the art, the profile can name the background
+    -- shades outright (a tileset entry's prop_bg). Keyed BY TILE rather than
+    -- per tileset, because the answer is per drawing: the healing consoles'
+    -- screens really do stand on a dark wall band and really do need dark
+    -- voted out, and the PC really does need light kept.
+    local bg = {}
+    do
+      local named = TileShape.propBg(map.tileset.id)
+      if named then
+        for _, c in ipairs(region.tiles) do
+          local rule = named[S.tileAt[keyOf(c[1], c[2])]]
+          if rule then
+            for shadeName in pairs(rule) do bg[shadeName] = true end
+            break
+          end
+        end
+      end
+    end
+    if not next(bg) then
+      for iy = 0, H - 1 do
+        for ix = 0, W - 1 do
+          local px, py = ix - 1, iy - 1
+          local edge = px == 0 or px == bw - 1 or py == 0 or py == bh - 1
+          local st = state[iy * W + ix]
+          if edge and (st == "dark" or st == "light" or st == "white") then
+            bg[st] = true
+          end
+        end
+      end
+      if not (bg.dark or bg.light or bg.white) then bg.white = true end
+    end
+    for i, st in pairs(state) do
+      if strict then
+        if st == "dark" or st == "light" then
+          state[i] = "cand"
+        elseif st == "white" then
+          state[i] = "wcand"
+        elseif st == "black" then
+          state[i] = "solid"
+        end
+      elseif st == "dark" or st == "light" or st == "white" then
+        state[i] = bg[st] and "cand" or "solid"
+      elseif st == "black" then
+        state[i] = "solid"
+      end
+    end
+  end
+
+  -- flood background in from the ground at the structure's feet
+  local flooded = {}
+  local queue = {}
+  for i, st in pairs(state) do
+    if st == "air" or st == "iair" then
+      flooded[i] = true
+      queue[#queue + 1] = i
+    end
+  end
+  while #queue > 0 do
+    Budget.tick()
+    local i = table.remove(queue)
+    local ix, iy = i % W, math.floor(i / W)
+    for _, d in ipairs(DIRS4) do
+      local nx, ny = ix + d[1], iy + d[2]
+      if nx >= 0 and nx < W and ny >= 0 and ny < H then
+        local ni = ny * W + nx
+        if not flooded[ni] then
+          local ns = state[ni]
+          -- "wcand" (a strict cutout's white) drains only along a white
+          -- run that reaches the RING: entered from the outer apron or
+          -- from another flooded white, never through grey or through
+          -- interior air
+          if ns == "cand" or ns == "air" or ns == "iair"
+             or (ns == "wcand"
+                 and (state[i] == "air" or state[i] == "wcand")) then
+            flooded[ni] = true
+            queue[#queue + 1] = ni
+          end
+        end
+      end
+    end
+  end
+
+  -- per-tile background ratio -> sprite-like tiles (a pinned billboard is
+  -- sprite-like by decree)
+  local sprite = {}
+  for _, c in ipairs(region.tiles) do
+    Budget.tick()
+    if force then
+      sprite[keyOf(c[1], c[2])] = true
+    else
+      local bx = (c[1] - region.minX) * 8
+      local by = (c[2] - region.minY) * 8
+      local bg = 0
+      for py = 0, 7 do
+        for px = 0, 7 do
+          if flooded[(by + py + 1) * W + (bx + px + 1)] then bg = bg + 1 end
+        end
+      end
+      if bg / 64 >= TILE_BG_RATIO then sprite[keyOf(c[1], c[2])] = true end
+    end
+  end
+
+  -- cluster sprite-like tiles; validate each cluster as one prop
+  local leftover, claimed = {}, {}
+  local clusterSeen = {}
+  for _, c in ipairs(region.tiles) do
+    local k = keyOf(c[1], c[2])
+    if sprite[k] and not clusterSeen[k] then
+      local cluster = { tiles = {}, minX = c[1], maxX = c[1],
+                        minY = c[2], maxY = c[2] }
+      local queue2 = { c }
+      clusterSeen[k] = true
+      while #queue2 > 0 do
+        local cc = table.remove(queue2)
+        cluster.tiles[#cluster.tiles + 1] = cc
+        cluster.minX = math.min(cluster.minX, cc[1])
+        cluster.maxX = math.max(cluster.maxX, cc[1])
+        cluster.minY = math.min(cluster.minY, cc[2])
+        cluster.maxY = math.max(cluster.maxY, cc[2])
+        for _, d in ipairs(DIRS4) do
+          local nk = keyOf(cc[1] + d[1], cc[2] + d[2])
+          if sprite[nk] and not clusterSeen[nk] then
+            clusterSeen[nk] = true
+            queue2[#queue2 + 1] = { cc[1] + d[1], cc[2] + d[2] }
+          end
+        end
+      end
+      if Structures.buildObject(S, map, region, cluster,
+                                state, flooded, srcU, srcV, W, force) then
+        for _, cc in ipairs(cluster.tiles) do
+          claimed[keyOf(cc[1], cc[2])] = true
+        end
+      end
+    end
+  end
+
+  for _, c in ipairs(region.tiles) do
+    if not claimed[keyOf(c[1], c[2])] then leftover[#leftover + 1] = c end
+  end
+  return leftover
+end
+
+-- One sprite-like cluster -> a per-pixel voxel prism, or false when it
+-- fails validation (too tall, vertically repeating, too big) and should
+-- stay part of the volume.
+function Structures.buildObject(S, map, region, cluster,
+                                state, flooded, srcU, srcV, W, force)
+  local rows = cluster.maxY - cluster.minY + 1
+  if not force then
+    if rows > OBJECT_MAX_ROWS then return false end
+
+    -- a prop stands ON the ground: somewhere the cluster must meet flat
+    -- ground to its south. A cluster carved out of a structure's middle
+    -- (roof rows whose whites leaked) fails this and stays in the volume.
+    -- Indoors any side will do -- furniture backs onto walls and bottom-row
+    -- props meet the void ring, so south alone is too strict.
+    local dirs = S.outdoor and { { 0, 1 } } or DIRS4
+    local touchesGround = false
+    for _, c in ipairs(cluster.tiles) do
+      for _, d in ipairs(dirs) do
+        local ss = S.shapeAt[keyOf(c[1] + d[1], c[2] + d[2])]
+        if ss and ss.flat and ss.class ~= "void" then
+          touchesGround = true
+          break
+        end
+      end
+      if touchesGround then break end
+    end
+    if not touchesGround then return false end
+
+    -- a vertically repeating cluster (tree wall edge) is scenery, not a
+    -- prop
+    local cols = {}
+    for _, c in ipairs(cluster.tiles) do
+      cols[c[1]] = cols[c[1]] or {}
+      cols[c[1]][c[2]] = true
+    end
+    for tx, ys in pairs(cols) do
+      local front = nil
+      for y in pairs(ys) do front = math.max(front or y, y) end
+      local extent = 0
+      while ys[front - extent] do extent = extent + 1 end
+      if extent > 1 then
+        local t0 = map:tileAt(tx, front)
+        for k = 1, extent - 1 do
+          if map:tileAt(tx, front - k) == t0 then return false end
+        end
+      end
+    end
+  end
+
+  local memberC = {}
+  for _, c in ipairs(cluster.tiles) do memberC[keyOf(c[1], c[2])] = true end
+
+  -- solid pixels of this cluster (art minus flooded background)
+  local solidPx, count, bgCount = {}, 0, 0
+  local bw = (cluster.maxX - cluster.minX + 1) * 8
+  local bh = (cluster.maxY - cluster.minY + 1) * 8
+  for _, c in ipairs(cluster.tiles) do
+    local rx = (c[1] - region.minX) * 8
+    local ry = (c[2] - region.minY) * 8
+    for py = 0, 7 do
+      Budget.tick()
+      for px = 0, 7 do
+        local i = (ry + py + 1) * W + (rx + px + 1)
+        local on = state[i] ~= nil and state[i] ~= "air"
+                   and state[i] ~= "iair" and state[i] ~= "barrier"
+                   and not flooded[i]
+        if on then
+          local lx = (c[1] - cluster.minX) * 8 + px
+          local ly = (c[2] - cluster.minY) * 8 + py
+          solidPx[ly * bw + lx] = i
+          count = count + 1
+        else
+          bgCount = bgCount + 1
+        end
+      end
+    end
+  end
+  if count == 0 or count > OBJECT_MAX_QUADS then return false end
+  if not force and bgCount / (count + bgCount) < CLUSTER_MIN_BG then
+    return false
+  end
+
+  -- geometry: each solid pixel is one voxel column deep enough to read as
+  -- a body, standing at the cluster's south row, base on the ground plane
+  local depth = OBJECT_DEPTH
+  if force then
+    local cs = S.shapeAt[keyOf(cluster.tiles[1][1], cluster.tiles[1][2])]
+    depth = (cs and PINNED_DEPTH[cs.class]) or PINNED_DEPTH.billboard
+  end
+  local wx0 = cluster.minX * 8
+
+  -- A pinned prop drawn directly above an authored box stands ON it -- a
+  -- monitor on its desk, a flower pot on the table.  The prism rises from
+  -- the box's top with its feet on the box's north row, and the claimed
+  -- tiles keep rendering as that box (wearing its plain art) instead of
+  -- punching a floor-level hole through it.
+  --
+  -- Only when the prop's OWN CELL IS BLOCKED, though.  "Is something
+  -- drawn above me?" is not the same question as "am I standing on it":
+  -- a chair drawn against the north side of a table is above the table's
+  -- trim row too, and it was being lifted onto the tabletop -- three
+  -- chairs standing on the furniture in Cinnabar's trade room and
+  -- Fuchsia's meeting room, with the claimed cells re-tiled as tabletop
+  -- so the table marched two rows north with them.  The world already
+  -- knows which is which: a thing that sits ON furniture occupies a
+  -- blocked cell (you cannot walk through the gym statue, Red's plant,
+  -- the PC), while a seat you walk up to is in a walkable one.
+  --
+  -- FENCE POSTS (the `post` pool, force == "opaque") never take the lift
+  -- at all. A post stands in the ground by definition -- it is not a
+  -- thing set down on top of something -- and its cell is blocked like
+  -- any other post, so the test above cannot tell it apart. Lavender
+  -- Town is where it showed: pinning the cliff's slope chain gave the
+  -- posts along the cliff edge an authored 16px box to their south, and
+  -- they were hoisted to stand on the clifftop instead of the path.
+  local baseY, support = 0, nil
+  if force and force ~= "opaque" then
+    local bs = S.shapeAt[keyOf(cluster.minX, cluster.maxY + 1)]
+    local blocked = not map:isWalkableCell(math.floor(cluster.minX / 2),
+                                           math.floor(cluster.maxY / 2))
+    -- `bookcase` supports as well as `upright`.  A prop drawn above an
+    -- authored box stands ON it whatever art the box renders with, and a
+    -- stacked box is still a box: the Plateau's gate pilasters carry a
+    -- statue on 48 of their tops, and collapsing the pilaster to a stacked
+    -- run made every one of them fail this test and drop to ground level.
+    if blocked and bs and bs.authored and (bs.h or 0) > 0
+       and (bs.art == "upright" or bs.art == "bookcase") then
+      baseY, support = bs.h, bs
+    end
+  end
+  local atlasW = map.tileset.imageWidth or 128
+  local atlasH = map.tileset.imageHeight or 48
+  local quads = S.objectQuads
+
+  local function at(lx, ly)
+    if lx < 0 or lx >= bw or ly < 0 or ly >= bh then return nil end
+    return solidPx[ly * bw + lx]
+  end
+
+  -- Connected components: one cluster can hold several OBJECTS -- two
+  -- stools stacked in adjacent cells, a loose leaf beside a vase.  Each
+  -- component stands on its own feet (base on the ground or the support
+  -- box, never floating at its bbox height) in the depth band of the
+  -- tile row its lowest pixel is drawn in, so stacked drawings become
+  -- separate standees in their own cells instead of one tower.
+  -- 8-connectivity keeps diagonal strokes whole.
+  local comp, comps = {}, {}
+  for ly = 0, bh - 1 do
+    Budget.tick()
+    for lx = 0, bw - 1 do
+      local idx = ly * bw + lx
+      if solidPx[idx] and not comp[idx] then
+        local c = { lowY = ly, n = 0 }
+        comps[#comps + 1] = c
+        local stack = { idx }
+        comp[idx] = c
+        while #stack > 0 do
+          local p = table.remove(stack)
+          local px, py = p % bw, math.floor(p / bw)
+          c.n = c.n + 1
+          if py > c.lowY then c.lowY = py end
+          for dy = -1, 1 do
+            for dx = -1, 1 do
+              local nx, ny = px + dx, py + dy
+              if (dx ~= 0 or dy ~= 0) and nx >= 0 and nx < bw
+                 and ny >= 0 and ny < bh then
+                local ni = ny * bw + nx
+                if solidPx[ni] and not comp[ni] then
+                  comp[ni] = c
+                  stack[#stack + 1] = ni
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+  for _, c in ipairs(comps) do
+    c.z0 = cluster.minY * 8 + math.floor(c.lowY / 8) * 8
+           + (support and 8 or 0) + (8 - depth) / 2
+    c.z1 = c.z0 + depth
+  end
+
+  -- A `cutout` or `console` pin is ONE object by contract: keep only
+  -- the largest connected drawing.  Loose black scraps -- a cast
+  -- shadow's drawn edge, a seam, the vertical rules the surrounding
+  -- furniture draws down its own edges -- are background even though
+  -- black pixels always survive the shade flood, and this is what
+  -- removes them.  Every other pool may hold several objects per
+  -- cluster (two stools side by side, a leaf beside a vase), so this
+  -- cannot be the default.
+  if force then
+    local cs = S.shapeAt[keyOf(cluster.tiles[1][1], cluster.tiles[1][2])]
+    if cs and (cs.class == "cutout" or cs.class == "console")
+       and #comps > 1 then
+      local biggest = comps[1]
+      for _, c in ipairs(comps) do
+        if c.n > biggest.n then biggest = c end
+      end
+      for idx, c in pairs(comp) do
+        if c ~= biggest then solidPx[idx] = nil end
+      end
+    end
+  end
+
+  for ly = 0, bh - 1 do
+    Budget.tick()
+    for lx = 0, bw - 1 do
+      local i = at(lx, ly)
+      if i then
+        local c = comp[ly * bw + lx]
+        local z0, z1 = c.z0, c.z1
+        local x, y = wx0 + lx, baseY + c.lowY - ly
+        local u = (srcU[i] + 0.5) / atlasW
+        local v = (srcV[i] + 0.5) / atlasH
+        local function quad(c1, c2, c3, c4, shade)
+          quads[#quads + 1] = { c1, c2, c3, c4, u = u, v = v, shade = shade }
+        end
+        quad({ x, y, z1 }, { x + 1, y, z1 }, { x + 1, y + 1, z1 },
+             { x, y + 1, z1 }, OBJ_SHADE.front)
+        quad({ x + 1, y, z0 }, { x, y, z0 }, { x, y + 1, z0 },
+             { x + 1, y + 1, z0 }, OBJ_SHADE.back)
+        if not at(lx, ly - 1) then
+          quad({ x, y + 1, z0 }, { x + 1, y + 1, z0 }, { x + 1, y + 1, z1 },
+               { x, y + 1, z1 }, OBJ_SHADE.top)
+        end
+        if y > baseY and not at(lx, ly + 1) then
+          quad({ x, y, z1 }, { x + 1, y, z1 }, { x + 1, y, z0 },
+               { x, y, z0 }, OBJ_SHADE.bottom)
+        end
+        if not at(lx - 1, ly) then
+          quad({ x, y, z0 }, { x, y, z1 }, { x, y + 1, z1 },
+               { x, y + 1, z0 }, OBJ_SHADE.side)
+        end
+        if not at(lx + 1, ly) then
+          quad({ x + 1, y, z1 }, { x + 1, y, z0 }, { x + 1, y + 1, z0 },
+               { x + 1, y + 1, z1 }, OBJ_SHADE.side)
+        end
+      end
+    end
+  end
+
+  -- the ground the prop stands on: the commonest flat tile touching the
+  -- cluster, painted under every cluster tile (the art that was there is
+  -- now standing up as the object)
+  local votes, best, bestN = {}, nil, 0
+  for _, c in ipairs(cluster.tiles) do
+    for _, d in ipairs(DIRS4) do
+      local nk = keyOf(c[1] + d[1], c[2] + d[2])
+      local ns = S.shapeAt[nk]
+      if ns and ns.flat and ns.class ~= "void" and not memberC[nk] then
+        local t = S.tileAt[nk]
+        votes[t] = (votes[t] or 0) + 1
+        if votes[t] > bestN then best, bestN = t, votes[t] end
+      end
+    end
+  end
+  for _, c in ipairs(cluster.tiles) do
+    local k = keyOf(c[1], c[2])
+    if support and (support.class == "wall" or support.class == "cliff"
+                    or support.art == "bookcase") then
+      -- a figure drawn above a FULL-HEIGHT block (the gym statue on its
+      -- plinth) is a statue on a pillar with ONE cell of footprint: the
+      -- block below already carries the whole base, so the drawn cell
+      -- becomes synthesized floor rather than a second block marching
+      -- the base backwards. Furniture supports (a monitor on its desk)
+      -- keep the box-extension below -- their drawn cell is the
+      -- furniture's own upper rows, and floor there would amputate it.
+      --
+      -- STRUCTURE, not height, decides which: `cliff` and `bookcase` are
+      -- full-height blocks like `wall` and belong here, while `desk` is
+      -- 24px and still furniture.  The Plateau's statues on stacked
+      -- pilasters found this -- taking the furniture branch turned each
+      -- statue's own two rows into a 32px box wearing the pilaster's art,
+      -- so every one of them stood inside a slab of its own plinth.
+      S.skip[k] = true
+      S.ground[k] = best
+    elseif support then
+      -- the claimed tile keeps rendering as the box the prop stands on,
+      -- wearing the art its own ROW would have without the drawing (the
+      -- trim row stays trim); only when the whole row is the prop does
+      -- it fall back to the row below
+      S.shapeAt[k] = support
+      local src = keyOf(c[1], cluster.maxY + 1)
+      for dx = 1, 3 do
+        for _, sx in ipairs({ c[1] - dx, c[1] + dx }) do
+          local nk = keyOf(sx, c[2])
+          local ns = S.shapeAt[nk]
+          if not memberC[nk] and ns and ns.authored
+             and ns.class == support.class then
+            src = nk
+            break
+          end
+        end
+        if src ~= keyOf(c[1], cluster.maxY + 1) then break end
+      end
+      S.tileAt[k] = S.tileAt[src]
+    else
+      S.skip[k] = true
+      S.ground[k] = best
+    end
+  end
+  return true
+end
+
+-- ---- figures: a person drawn INTO furniture, cut out and stood up ----
+
+-- One authored figure at one matched position.
+--
+-- The mask IS the classification: no flood, no shade segmentation, no
+-- validation gate.  Every automatic route in this file asks the art where
+-- the object ends, and a figure painted into its own furniture has no
+-- answer to give -- so the profile answers instead, and this only has to
+-- believe it.  Which also means figures build HEADLESS: unlike every
+-- other standee here, nothing below reads a pixel.
+--
+-- A figure is a SPRITE, not a prop.  It gets exactly the treatment
+-- SpriteBillboards gives a character: one flat plane of the drawing's own
+-- pixels, no thickness, standing at its feet and leaned back by the
+-- camera's pitch at draw time so it always reads face-on -- because that
+-- is what the artwork is.  A seated man drawn face-on is a 2D icon like
+-- every other Gen 1 figure; extruding him into a slab reconstructs a body
+-- nobody drew (the ten-voxel version read as a wedge of furniture, and
+-- even one voxel showed an edge the sprites never show).
+--
+-- So the quads are emitted in the card's OWN LOCAL SPACE -- x from the
+-- mask's west edge, y from his feet, all at z = 0 -- and the placement
+-- (`wx`, `wz`, `y`) rides along for VoxelScene to build the lean matrix
+-- from.  One quad per pixel rather than one alpha-keyed texture: the
+-- tileset atlas has no alpha to key on, and per-pixel quads cut the exact
+-- same silhouette straight out of the live atlas, so every palette bake
+-- (SGB, RED++ per-tile groups, a mod's own art) textures him for free.
+local function buildFigure(S, map, fig, tx, ty, perRow)
+  local bw, bh = fig.w * 8, fig.h * 8
+
+  local function at(lx, ly)
+    if lx < 0 or lx >= bw or ly < 0 or ly >= bh then return false end
+    return fig.mask[ly * bw + lx] or false
+  end
+
+  -- his feet and his west edge: the card's own origin
+  local lowY, minX = 0, bw - 1
+  for ly = 0, bh - 1 do
+    for lx = 0, bw - 1 do
+      if at(lx, ly) then
+        if ly > lowY then lowY = ly end
+        if lx < minX then minX = lx end
+      end
+    end
+  end
+
+  -- He stands ON the furniture he was drawn into -- the same lift a pinned
+  -- prop above a pinned box takes (see buildObject), and gated the same
+  -- way: a thing set down on furniture occupies a BLOCKED cell, while a
+  -- seat you merely walk up to is in a walkable one.
+  local baseY = 0
+  local bs = S.shapeAt[keyOf(tx, ty + fig.h)]
+  local blocked = not map:isWalkableCell(math.floor(tx / 2),
+                                         math.floor((ty + fig.h - 1) / 2))
+  if blocked and bs and bs.authored and bs.art == "upright"
+     and (bs.h or 0) > 0 then
+    baseY = bs.h
+  end
+
+  local atlasW = map.tileset.imageWidth or 128
+  local atlasH = map.tileset.imageHeight or 48
+  local quads = {}
+  for ly = 0, bh - 1 do
+    Budget.tick()
+    for lx = 0, bw - 1 do
+      if at(lx, ly) then
+        local tile = fig.tiles[math.floor(ly / 8) * fig.w
+                               + math.floor(lx / 8) + 1]
+        local u = ((tile % perRow) * 8 + lx % 8 + 0.5) / atlasW
+        local v = (math.floor(tile / perRow) * 8 + ly % 8 + 0.5) / atlasH
+        local x, y = lx - minX, lowY - ly
+        quads[#quads + 1] = { { x, y, 0 }, { x + 1, y, 0 },
+                              { x + 1, y + 1, 0 }, { x, y + 1, 0 },
+                              u = u, v = v, shade = 1 }
+      end
+    end
+  end
+
+  -- Where the card stands.  `wz` is the MIDDLE of the tile row his feet are
+  -- drawn in, which is the same convention a character card uses (its feet
+  -- plane sits at its cell's middle) -- so he sorts against the couch and
+  -- against a player walking past exactly the way an NPC standing there
+  -- would.
+  S.figures[#S.figures + 1] = {
+    quads = quads,
+    wx = tx * 8 + minX,
+    wz = ty * 8 + math.floor(lowY / 8) * 8 + 4,
+    y = baseY,
+  }
+
+  -- What each covered tile wears now that he is off it.  Only the ART
+  -- changes: the couch tiles keep their `counter` box (they ARE the
+  -- couch) and the floor tiles he overhung stay flat floor -- the
+  -- profile just names the version of each drawing without him in it,
+  -- so nothing has to be synthesized or repainted from a neighbour vote.
+  for i = 1, #fig.tiles do
+    local dx, dy = (i - 1) % fig.w, math.floor((i - 1) / fig.w)
+    S.tileAt[keyOf(tx + dx, ty + dy)] = fig.under[i]
+  end
+end
+
+-- Every authored figure, wherever the map draws it.
+--
+-- Matched by TILE PATTERN rather than by coordinates: one blockset entry
+-- places this couch once in each of the eleven Pokemon Centers (and the
+-- Celadon Hotel), so the pattern finds all of them without the profile
+-- naming a single map or cell.  The repaint above replaces the pattern's
+-- own tiles, so a match can never fire twice on the same drawing.
+function Structures.buildFigures(S, map, x0, x1, y0, y1)
+  local figures = TileShape.figures(map.tileset.id)
+  if not figures then return end
+  local perRow = map.tileset.tilesPerRow or 16
+  for _, fig in ipairs(figures) do
+    for ty = y0, y1 - fig.h + 1 do
+      for tx = x0, x1 - fig.w + 1 do
+        Budget.tick()
+        local hit = true
+        for i = 1, #fig.tiles do
+          local dx, dy = (i - 1) % fig.w, math.floor((i - 1) / fig.w)
+          if S.tileAt[keyOf(tx + dx, ty + dy)] ~= fig.tiles[i] then
+            hit = false
+            break
+          end
+        end
+        if hit then buildFigure(S, map, fig, tx, ty, perRow) end
+      end
+    end
+  end
+end
+
+-- ---- tall grass ----
+
+-- A tall-grass CELL is four tufts: 2x2 tiles, and each 8x8 tile is one
+-- whole clump of grass. Each tile stands as its own thin per-pixel slab
+-- at ITS OWN depth -- the cell's north tile row in the north half of the
+-- cell, the south row in the south half -- over the flat grass base the
+-- tile already renders. So the player walks BETWEEN the two rows, and
+-- the southern row occludes their feet the way the 2D grass overdraw
+-- did. Transparency respected: only the tuft strokes stand. Runs of
+-- adjacent pixels merge into single quads, and one template per grass
+-- tile id is stamped across the map (grass comes in fields).
+--
+-- One tile is ONE standing piece, full height. The first cut split each
+-- tile again into its top and bottom four art rows and stood those at
+-- two different depths, which cut every blade that runs down the tile
+-- clean in half -- the two halves ended up 4px tall and 4px apart in
+-- depth, so a clump read as two stubs rather than one tuft.
+local GRASS_THICK = 2
+
+local function grassTemplate(map, data, tileId)
+  local perRow = map.tileset.tilesPerRow or 16
+  local atlasW = map.tileset.imageWidth or 128
+  local atlasH = map.tileset.imageHeight or 48
+  local ax0 = (tileId % perRow) * 8
+  local ay0 = math.floor(tileId / perRow) * 8
+
+  local function opaque(px, py)
+    if px < 0 or px > 7 or py < 0 or py > 7 then return false end
+    local r, g, b, a = data:getPixel(ax0 + px, ay0 + py)
+    return a > 0 and math.min(r, g, b) <= 0.83
+  end
+
+  local quads = {}
+  -- the slab stands across the middle of its own tile, so the two tile
+  -- rows of a cell are half a cell apart in depth
+  local zMid = 4
+  local zB, zF = zMid - GRASS_THICK / 2, zMid + GRASS_THICK / 2
+  for iy = 0, 7 do
+    local yTop = 8 - iy
+    local yBot = yTop - 1
+    local ix = 0
+    while ix < 8 do
+      if opaque(ix, iy) then
+        local ix2 = ix
+        while ix2 + 1 < 8 and opaque(ix2 + 1, iy) do
+          ix2 = ix2 + 1
+        end
+        local u0 = (ax0 + ix + 0.05) / atlasW
+        local u1 = (ax0 + ix2 + 0.95) / atlasW
+        local v0 = (ay0 + iy + 0.05) / atlasH
+        local v1 = (ay0 + iy + 0.95) / atlasH
+        quads[#quads + 1] = {           -- front
+          { ix, yBot, zF }, { ix2 + 1, yBot, zF },
+          { ix2 + 1, yTop, zF }, { ix, yTop, zF },
+          uv = { { u0, v1 }, { u1, v1 }, { u1, v0 }, { u0, v0 } },
+          shade = 1,
+        }
+        quads[#quads + 1] = {           -- back
+          { ix2 + 1, yBot, zB }, { ix, yBot, zB },
+          { ix, yTop, zB }, { ix2 + 1, yTop, zB },
+          uv = { { u1, v1 }, { u0, v1 }, { u0, v0 }, { u1, v0 } },
+          shade = 0.68,
+        }
+        -- blade tips: a top strip where the row above is clear
+        if not opaque(ix, iy - 1) then
+          quads[#quads + 1] = {
+            { ix, yTop, zB }, { ix2 + 1, yTop, zB },
+            { ix2 + 1, yTop, zF }, { ix, yTop, zF },
+            uv = { { u0, v0 }, { u1, v0 }, { u1, v0 }, { u0, v0 } },
+            shade = 1,
+          }
+        end
+        ix = ix2 + 1
+      else
+        ix = ix + 1
+      end
+    end
+  end
+  return quads
+end
+
+function Structures.buildGrass(S, map, x0, x1, y0, y1, data)
+  local templates = {}
+  local quads = S.grassQuads
+  for ty = y0, y1 do
+    for tx = x0, x1 do
+      Budget.tick()
+      local k = keyOf(tx, ty)
+      local s = S.shapeAt[k]
+      -- tufts only where the CELL is tall grass by the engine's own rule
+      -- (isGrassCell: the cell's collision tile). The grass GRAPHIC also
+      -- appears as decorative filler inside ordinary ground blocks, and a
+      -- tile-level test sprouted tufts all over town plazas.
+      if s and s.art == "grass"
+         and map:isGrassCell(math.floor(tx / 2), math.floor(ty / 2)) then
+        local tileId = S.tileAt[k]
+        local tpl = templates[tileId]
+        if not tpl then
+          tpl = grassTemplate(map, data, tileId)
+          templates[tileId] = tpl
+        end
+        local wx, wz = tx * 8, ty * 8
+        for _, q in ipairs(tpl) do
+          quads[#quads + 1] = {
+            { q[1][1] + wx, q[1][2], q[1][3] + wz },
+            { q[2][1] + wx, q[2][2], q[2][3] + wz },
+            { q[3][1] + wx, q[3][2], q[3][3] + wz },
+            { q[4][1] + wx, q[4][2], q[4][3] + wz },
+            uv = q.uv, shade = q.shade,
+          }
+        end
+      end
+    end
+  end
+end
+
+-- ---- flowers ----
+
+-- The animated flower tile stands up as a billboard ONE VOXEL deep, cut
+-- to the drawing's darkest tones PLUS everything they enclose -- the
+-- round-scenery hull's rule: flood the tile border through every
+-- non-dark pixel, and what the flood cannot reach is the flower, its
+-- pale petal insides included. The mesh is static and the flower is
+-- not, so the geometry spans the UNION of that mask over the base art
+-- and every animation frame, and TerrainAtlas rewrites the tile's slot
+-- each step with only the CURRENT frame's mask opaque -- the rest keyed
+-- to alpha, which the voxel shader discards. The standing silhouette
+-- trims itself frame by frame in texture space; the sway animates
+-- without a vertex moving, off the same engine clock as the flat path.
+--
+-- The ground beneath is synthesized from the commonest flat neighbour,
+-- like the ground under a detected prop: the tile's own slot no longer
+-- holds art anyone can draw flat.
+local FLOWER_THICK = 1
+
+local function flowerFrames(tileset, tileId)
+  local out = {}
+  local ok, declared = pcall(function()
+    if tileset.animatedTiles then return tileset.animatedTiles end
+    local TileRenderer = require("src.render.TileRenderer")
+    return TileRenderer.defaultAnimatedTiles(tileset)
+  end)
+  if not ok then return out end
+  for _, spec in ipairs(type(declared) == "table" and declared or {}) do
+    if spec.kind == "frames" and spec.tile == tileId then
+      for _, path in pairs(spec.images or {}) do
+        local okF, frame = pcall(Assets.imageData, path)
+        if okF and frame then out[#out + 1] = frame end
+      end
+    end
+  end
+  return out
+end
+
+local function flowerTemplate(map, data, tileId)
+  local tileset = map.tileset
+  local perRow = tileset.tilesPerRow or 16
+  local atlasW = tileset.imageWidth or 128
+  local atlasH = tileset.imageHeight or 48
+  local ax0 = (tileId % perRow) * 8
+  local ay0 = math.floor(tileId / perRow) * 8
+
+  -- per image: dark tones, then the border flood that finds what they
+  -- enclose. Each image closes over ITS OWN outline before the union --
+  -- a pocket two frames only enclose together is not part of either.
+  local dark = {}
+  local function markMask(img, ox, oy)
+    local d, reach, stack = {}, {}, {}
+    for py = 0, 7 do
+      for px = 0, 7 do
+        local r, g, b, a = img:getPixel(ox + px, oy + py)
+        if a > 0 and math.min(r, g, b) <= 0.5 then
+          d[py * 8 + px] = true
+        end
+      end
+    end
+    for i = 0, 7 do
+      for _, s in ipairs({ i, 56 + i, i * 8, i * 8 + 7 }) do
+        if not d[s] and not reach[s] then
+          reach[s] = true
+          stack[#stack + 1] = s
+        end
+      end
+    end
+    while #stack > 0 do
+      local p = table.remove(stack)
+      local px, py = p % 8, math.floor(p / 8)
+      for _, dir in ipairs(DIRS4) do
+        local nx, ny = px + dir[1], py + dir[2]
+        if nx >= 0 and nx < 8 and ny >= 0 and ny < 8 then
+          local ni = ny * 8 + nx
+          if not d[ni] and not reach[ni] then
+            reach[ni] = true
+            stack[#stack + 1] = ni
+          end
+        end
+      end
+    end
+    for i = 0, 63 do
+      if d[i] or not reach[i] then dark[i] = true end
+    end
+  end
+  markMask(data, ax0, ay0)
+  for _, frame in ipairs(flowerFrames(tileset, tileId)) do
+    pcall(markMask, frame, 0, 0)
+  end
+
+  local function on(px, py)
+    if px < 0 or px > 7 or py < 0 or py > 7 then return false end
+    return dark[py * 8 + px] == true
+  end
+
+  local quads = {}
+  local zB = 4 - FLOWER_THICK / 2      -- one slab at the tile's middle
+  local zF = zB + FLOWER_THICK
+  for py = 0, 7 do
+    Budget.tick()
+    local yTop, yBot = 8 - py, 7 - py
+    local ix = 0
+    while ix < 8 do
+      if on(ix, py) then
+        local ix2 = ix
+        while ix2 + 1 < 8 and on(ix2 + 1, py) do ix2 = ix2 + 1 end
+        local u0 = (ax0 + ix + 0.05) / atlasW
+        local u1 = (ax0 + ix2 + 0.95) / atlasW
+        local v0 = (ay0 + py + 0.05) / atlasH
+        local v1 = (ay0 + py + 0.95) / atlasH
+        quads[#quads + 1] = {           -- front
+          { ix, yBot, zF }, { ix2 + 1, yBot, zF },
+          { ix2 + 1, yTop, zF }, { ix, yTop, zF },
+          uv = { { u0, v1 }, { u1, v1 }, { u1, v0 }, { u0, v0 } },
+          shade = OBJ_SHADE.front,
+        }
+        quads[#quads + 1] = {           -- back
+          { ix2 + 1, yBot, zB }, { ix, yBot, zB },
+          { ix, yTop, zB }, { ix2 + 1, yTop, zB },
+          uv = { { u1, v1 }, { u0, v1 }, { u0, v0 }, { u1, v0 } },
+          shade = OBJ_SHADE.back,
+        }
+        -- petal tips: a top strip where the row above is clear. The
+        -- strip samples its own row's texel, so a tip that is not in
+        -- the current frame discards with the face beneath it
+        if not on(ix, py - 1) then
+          quads[#quads + 1] = {
+            { ix, yTop, zB }, { ix2 + 1, yTop, zB },
+            { ix2 + 1, yTop, zF }, { ix, yTop, zF },
+            uv = { { u0, v0 }, { u1, v0 }, { u1, v0 }, { u0, v0 } },
+            shade = OBJ_SHADE.top,
+          }
+        end
+        ix = ix2 + 1
+      else
+        ix = ix + 1
+      end
+    end
+  end
+  return quads
+end
+
+function Structures.buildFlowers(S, map, tw, th, x0, x1, y0, y1, data)
+  local templates = {}
+  -- flowerQuads, not objectQuads: flowers sit on WALKABLE cells, so
+  -- their mesh draws after the characters with the character pull
+  -- (ChunkMesher's flower mesh) -- terrain-baked they lose the depth
+  -- fight against the pulled card whenever the player stands among them
+  local quads = S.flowerQuads
+  for ty = y0, y1 do
+    for tx = x0, x1 do
+      Budget.tick()
+      local k = keyOf(tx, ty)
+      local s = S.shapeAt[k]
+      if s and s.art == "flower" then
+        -- the tile's atlas slot carries only the standing cutout now, so
+        -- EVERY flower position -- ring included -- paints synthesized
+        -- ground instead of its own art: the commonest flat neighbour
+        -- that is not itself a flower, else the map's commonest ground
+        -- (forMap's end-of-build vote resolves the `false`)
+        S.skip[k] = true
+        local votes, best, bestN = {}, nil, 0
+        for _, d in ipairs(DIRS4) do
+          local nk = keyOf(tx + d[1], ty + d[2])
+          local ns = S.shapeAt[nk]
+          if ns and ns.flat and ns.class ~= "void"
+             and ns.class ~= "flower" then
+            local t = S.tileAt[nk]
+            votes[t] = (votes[t] or 0) + 1
+            if votes[t] > bestN then best, bestN = t, votes[t] end
+          end
+        end
+        S.ground[k] = best or false
+
+        -- standee BODY only, like grass: standing scenery past a map's
+        -- edge would poke into the map next door
+        if tx >= 0 and ty >= 0 and tx < tw and ty < th then
+          local tileId = S.tileAt[k]
+          local tpl = templates[tileId]
+          if not tpl then
+            tpl = flowerTemplate(map, data, tileId)
+            templates[tileId] = tpl
+          end
+          local wx, wz = tx * 8, ty * 8
+          for _, q in ipairs(tpl) do
+            quads[#quads + 1] = {
+              { q[1][1] + wx, q[1][2], q[1][3] + wz },
+              { q[2][1] + wx, q[2][2], q[2][3] + wz },
+              { q[3][1] + wx, q[3][2], q[3][3] + wz },
+              { q[4][1] + wx, q[4][2], q[4][3] + wz },
+              uv = q.uv, shade = q.shade,
+            }
+          end
+        end
+      end
+    end
+  end
+end
+
+-- Drop one map's analysis (Cut changed the block layer) or everything.
+-- Hull templates key on art content (tileset + tiles), which a block edit
+-- cannot change, so only the full drop clears them (atlas reload).
+function Structures.invalidate(mapId)
+  if mapId then
+    cache[mapId] = nil
+  else
+    cache = {}
+    atlasData = {}
+    roundCache = {}
+    Buildings.invalidate()
+  end
+end
+
+Assets.register(function() Structures.invalidate() end)
+
+return Structures

--- a/mods/dramatic_shape/lib/TerrainAtlas.lua
+++ b/mods/dramatic_shape/lib/TerrainAtlas.lua
@@ -1,0 +1,643 @@
+-- Voxel world mode: the texture terrain samples.
+--
+-- Voxel terrain is textured from the tileset atlas, so a map's colors have
+-- to live IN that atlas. Two of the three color paths already do:
+--
+--   RED++      TileRenderer.new bakes a fully recolored per-map atlas
+--              (getGbcAtlas) and hands it over as renderer.image -- nothing
+--              to do here, true GBC terrain color comes through untouched.
+--   trueColor  a mod's full-color atlas is already its own colors.
+--
+-- The SGB modes are the gap. There the atlas is raw 4-shade grayscale and
+-- the color normally arrives as a screen-space shade-remap pass over
+-- rectangular zones (PaletteFX) -- which has no meaning once the ground is
+-- geometry rather than a rectangle. So bake instead: one atlas copy per
+-- (atlas, palette), remapped through the same cutoffs the shader uses.
+--
+-- A map has exactly one world palette, so this is a handful of 128x48
+-- images for a whole session, built once and cached.
+--
+-- ANIMATED TILES (water, flowers) are the other thing this file owns. The
+-- 2D path animates them by OVERDRAWING the animated cells on top of the
+-- static tile layer each frame, which a single static mesh has no
+-- equivalent of -- the geometry samples one texture and that is that. So
+-- animate the texture: rewrite the animated tile's slot in a private copy
+-- of the atlas whenever the step advances, and every instance of that tile
+-- across the whole mesh moves at once. Which is what the Game Boy does in
+-- the first place (home/vcopy.asm rewrites the tile's VRAM bytes); the 2D
+-- overdraw is the port's workaround, not the original.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local Assets = require("src.render.Assets")
+local TileRenderer = require("src.render.TileRenderer")
+local PaletteFX = require("src.render.PaletteFX")
+
+local TerrainAtlas = {}
+
+local cache = {}
+local cacheData = {}    -- the pixels behind the atlases we baked ourselves
+local animated = {}     -- key -> one map's private, mutable animated atlas
+                        -- false = given up on; nil = not built (or retrying)
+local attempts = {}     -- key -> consecutive failures, for the retry budget
+
+-- A failure that might not repeat -- a driver refusing one readback, an
+-- asset briefly unreadable, a patch that threw once mid-reload -- must not
+-- cost the animation for the rest of the session. It used to: the key was
+-- condemned to `false` on the first miss and nothing ever rebuilt it, so
+-- water stopped moving and stayed stopped until a hot reload.
+--
+-- Retry a few times, then give up for good so a genuinely broken atlas is
+-- not rebuilt on every frame forever.
+local MAX_ATTEMPTS = 3
+
+local function attemptFailed(key)
+  local n = (attempts[key] or 0) + 1
+  attempts[key] = n
+  if n >= MAX_ATTEMPTS then return false end   -- condemn it
+  return nil                                    -- rebuild next frame
+end
+
+local function paletteKey(colors)
+  local parts = {}
+  for i = 1, 4 do
+    local c = colors[i]
+    parts[i] = c and (c[1] .. "," .. c[2] .. "," .. c[3]) or "-"
+  end
+  return table.concat(parts, ";")
+end
+
+-- The atlas image `map`'s terrain should sample, given the 4-color world
+-- palette it sits under (nil to leave the atlas as-is). Falls back to the
+-- renderer's own image whenever a bake is impossible -- headless, or no
+-- pixel access -- which just means grayscale terrain rather than no
+-- terrain.
+-- The static atlas for `map` under `colors`: the answer this file gave
+-- before animation existed, and the base every animated frame is patched
+-- over. Returns the image and, when we baked it ourselves, its pixels.
+local function staticAtlas(map, colors)
+  local renderer = map.renderer
+  local base = renderer and renderer.image
+  if not base then return nil end
+  -- already true color: RED++'s baked per-map atlas, or a mod's own art
+  if not colors or renderer.gbcAtlas or map.tileset.trueColor then
+    return base, false
+  end
+  if not (love.image and love.image.newImageData) then return base, false end
+
+  local path = map.tileset.image
+  local key = path .. "#" .. paletteKey(colors)
+  if cache[key] ~= nil then return cache[key] or base, cacheData[key] end
+
+  local data
+  local ok, img = pcall(function()
+    local src = Assets.imageData(path)
+    local w, h = src:getDimensions()
+    local out = love.image.newImageData(w, h)
+    for y = 0, h - 1 do
+      for x = 0, w - 1 do
+        local r, g, b, a = src:getPixel(x, y)
+        r, g, b, a = TileRenderer.recolorSample(r, g, b, a, colors)
+        out:setPixel(x, y, r, g, b, a)
+      end
+    end
+    local image = love.graphics.newImage(out)
+    image:setFilter("nearest", "nearest")
+    data = out
+    return image
+  end)
+  cache[key] = ok and img or false
+  cacheData[key] = (ok and data) or false
+  return cache[key] or base, cacheData[key]
+end
+
+-- ------------------------------------------------------------ animation --
+
+-- The four GB shades as the ORIGINAL art carries them, by the same cutoffs
+-- TileRenderer.recolorSample splits on -- so a shade learned here and a
+-- shade recolored there are the same shade.
+local function shadeOf(r)
+  if r > 0.83 then return 1 end
+  if r > 0.5 then return 2 end
+  if r > 0.17 then return 3 end
+  return 4
+end
+
+-- How this atlas recolored one tile, learned by reading the tile's slot in
+-- the raw art and in the finished atlas side by side: shade -> the colour
+-- it became.
+--
+-- Learned rather than recomputed because the two recolour paths do not
+-- share a rule -- SGB bakes one world palette over everything, RED++ picks
+-- a palette group per tile GRAPHIC -- and a flower frame arrives as its own
+-- little grayscale file that never went through either. Asking "what
+-- happened to the tile I am replacing" gets the right answer from both
+-- without this file knowing which one ran.
+local function learnShades(raw, baked, tile, perRow)
+  local sx, sy = (tile % perRow) * 8, math.floor(tile / perRow) * 8
+  local map = {}
+  for y = 0, 7 do
+    for x = 0, 7 do
+      local k = shadeOf(raw:getPixel(sx + x, sy + y))
+      if not map[k] then
+        local r, g, b, a = baked:getPixel(sx + x, sy + y)
+        map[k] = { r, g, b, a }
+      end
+    end
+  end
+  return map
+end
+
+local DIRS4 = { { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 } }
+
+-- One animated entry's tile slot, written into `out` at step `step`.
+local function patch(out, entry, spec, step)
+  local perRow, tile = entry.perRow, spec.tile
+  local dx, dy = (tile % perRow) * 8, math.floor(tile / perRow) * 8
+  if spec.kind == "hshift" then
+    -- the water rotate (the asm's rrca/rlca run): the tile's own pixels,
+    -- rolled sideways. Read from the UNANIMATED base, or each step would
+    -- compound on the last one's shift.
+    local o = spec.offsets[step % #spec.offsets + 1]
+    for y = 0, 7 do
+      for x = 0, 7 do
+        local r, g, b, a = entry.base:getPixel(dx + x, dy + y)
+        out:setPixel(dx + (x + o) % 8, dy + y, r, g, b, a)
+      end
+    end
+  elseif spec.kind == "frames" then
+    local path = spec.images[spec.sequence[step % #spec.sequence + 1]]
+    if not path then return end
+    local ok, frame = pcall(Assets.imageData, path)
+    if not ok or not frame then return end
+    local shades = entry.shades and entry.shades[tile]
+    -- a `cut` tile is the flower billboard's slot (Structures'
+    -- buildFlowers): only the frame's darkest tones AND what they
+    -- enclose stay opaque -- the round-scenery hull's rule, flooding
+    -- the frame border through every non-dark pixel so the pale petal
+    -- insides survive with the outline. The true background is keyed
+    -- to alpha; nothing else samples this slot (the ground under a
+    -- flower is synthesized), and the shader's discard is what lets
+    -- the billboard's silhouette change per frame under geometry that
+    -- never moves.
+    local mask = nil
+    if entry.cut and entry.cut[tile] then
+      local dark, reach, stack = {}, {}, {}
+      for y = 0, 7 do
+        for x = 0, 7 do
+          local r, _, _, a = frame:getPixel(x, y)
+          if a > 0 and shadeOf(r) >= 3 then dark[y * 8 + x] = true end
+        end
+      end
+      for i = 0, 7 do
+        for _, s in ipairs({ i, 56 + i, i * 8, i * 8 + 7 }) do
+          if not dark[s] and not reach[s] then
+            reach[s] = true
+            stack[#stack + 1] = s
+          end
+        end
+      end
+      while #stack > 0 do
+        local p = table.remove(stack)
+        local px, py = p % 8, math.floor(p / 8)
+        for _, d in ipairs(DIRS4) do
+          local nx, ny = px + d[1], py + d[2]
+          if nx >= 0 and nx < 8 and ny >= 0 and ny < 8 then
+            local ni = ny * 8 + nx
+            if not dark[ni] and not reach[ni] then
+              reach[ni] = true
+              stack[#stack + 1] = ni
+            end
+          end
+        end
+      end
+      mask = {}
+      for i = 0, 63 do mask[i] = dark[i] or not reach[i] end
+    end
+    for y = 0, 7 do
+      for x = 0, 7 do
+        local r, g, b, a = frame:getPixel(x, y)
+        if mask and not mask[y * 8 + x] then
+          out:setPixel(dx + x, dy + y, 0, 0, 0, 0)
+        else
+          local col = shades and shades[shadeOf(r)]
+          if col and a > 0 then r, g, b = col[1], col[2], col[3] end
+          out:setPixel(dx + x, dy + y, r, g, b, a)
+        end
+      end
+    end
+  end
+end
+
+-- The animation specs this file can serve: the two that rewrite a tile's
+-- pixels. "toggle" (the spinner-puzzle blur) is a whole-atlas swap gated on
+-- a gameplay state, and is left to the 2D path -- voxel mode does not draw
+-- the spinner rooms' tile layer any differently for it.
+local function specsFor(tileset)
+  local declared = tileset.animatedTiles
+                   or TileRenderer.defaultAnimatedTiles(tileset)
+  local out = nil
+  for _, spec in ipairs(declared or {}) do
+    local usable = spec.tile
+      and ((spec.kind == "hshift" and spec.offsets and #spec.offsets > 0)
+           or (spec.kind == "frames" and spec.images and spec.sequence
+               and #spec.sequence > 0))
+    if usable then
+      out = out or {}
+      out[#out + 1] = spec
+    end
+  end
+  return out
+end
+
+-- Pixels back off a texture the engine built on the GPU and kept no copy
+-- of. LOVE 11 hands out no ImageData for an Image, so the only route is a
+-- round trip: draw it 1:1 into a canvas and read that back.
+--
+-- This runs inside the world pass, with the pipeline's own canvas bound, so
+-- the previous target is captured and put back rather than unbound -- the
+-- usual setCanvas() would drop the rest of the frame on the floor. One
+-- readback per map, cached with the entry it feeds; the atlas is a couple
+-- of hundred pixels square, so the GPU sync costs far less than the mesh
+-- build it happens alongside. Every step is guarded: a driver that refuses
+-- canvas readback costs the animation and nothing else.
+local function readback(image)
+  if not (image and love.graphics and love.graphics.newCanvas
+          and love.graphics.getCanvas) then
+    return nil
+  end
+  local prev = love.graphics.getCanvas()
+  local ok, data = pcall(function()
+    local w, h = image:getDimensions()
+    local canvas = love.graphics.newCanvas(w, h)
+    love.graphics.setCanvas(canvas)
+    love.graphics.clear(0, 0, 0, 0)
+    -- straight copy: no blending against the cleared target, no tint from
+    -- whatever colour the pass left set, or the atlas comes back wrong
+    love.graphics.setBlendMode("replace", "premultiplied")
+    love.graphics.setColor(1, 1, 1, 1)
+    love.graphics.draw(image, 0, 0)
+    love.graphics.setBlendMode("alpha", "alphamultiply")
+    -- LOVE refuses newImageData on the currently-active canvas, so the
+    -- previous target has to come back BEFORE the read, not just after
+    love.graphics.setCanvas(prev)
+    local out = canvas:newImageData()
+    if canvas.release then canvas:release() end
+    return out
+  end)
+  pcall(love.graphics.setCanvas, prev)
+  return ok and data or nil
+end
+
+-- RED++'s per-map atlas, rebuilt on the CPU.
+--
+-- This is the case that has no pixels anywhere: `getGbcAtlas` bakes one
+-- ImageData per map, hands the texture to the renderer and drops the
+-- pixels on the floor. Without them the animated tiles cannot be patched,
+-- which is why water and flowers stood still under RED++ and nowhere else.
+--
+-- The readback below can recover them from the texture, but it is at the
+-- mercy of whether the driver will read a canvas back, and it costs a GPU
+-- sync mid-frame. Everything the engine baked FROM is public, so bake it
+-- again instead: the raw art, the per-tile palette group, the group's
+-- colours, and the same recolorSample cutoffs. Deterministic, no driver
+-- involved, and it can be tested without a GPU.
+--
+-- It does mirror engine logic and could drift from getGbcAtlas if that
+-- changes -- the readback stays behind it as the exact-but-fragile route.
+local function gbcPixels(map)
+  local renderer, tileset = map.renderer, map.tileset
+  local data = renderer and renderer.data
+  if not (data and tileset and love.image and love.image.newImageData) then
+    return nil
+  end
+  local ok, out = pcall(function()
+    local groupColors = PaletteFX.worldGroupColors(data, tileset.id, map.id, nil)
+    if not groupColors then return nil end
+    local src = Assets.imageData(tileset.image)
+    local iw, ih = src:getDimensions()
+    local perRow = tileset.tilesPerRow or 16
+    local total = (iw / 8) * (ih / 8)
+    local dst = love.image.newImageData(iw, ih)
+
+    local function bake(from, to, colors)
+      local sxo, syo = (from % perRow) * 8, math.floor(from / perRow) * 8
+      local dxo, dyo = (to % perRow) * 8, math.floor(to / perRow) * 8
+      for py = 0, 7 do
+        for px = 0, 7 do
+          local r, g, b, a = src:getPixel(sxo + px, syo + py)
+          r, g, b, a = TileRenderer.recolorSample(r, g, b, a, colors)
+          dst:setPixel(dxo + px, dyo + py, r, g, b, a)
+        end
+      end
+    end
+
+    local tileColors = {}
+    for t = 0, total - 1 do
+      local colors = tileColors[t]
+      if colors == nil then
+        local group = PaletteFX.worldGroupAt(tileset.id, map.id, t)
+        colors = (group and groupColors[group + 1]) or false
+        tileColors[t] = colors
+      end
+      bake(t, t, colors)
+    end
+    -- duplicate-tile aliases: the same graphic baked into a spare slot
+    -- under a second palette group, so cells drawing the alias colour apart
+    for _, al in ipairs(PaletteFX.TILE_ALIASES
+                        and PaletteFX.TILE_ALIASES[map.id] or {}) do
+      if al.alias < total then
+        bake(al.tile, al.alias, groupColors[al.group + 1])
+      end
+    end
+    return dst
+  end)
+  return ok and out or nil
+end
+
+-- The pixels behind the atlas texture the engine is drawing with, for the
+-- frames where we did not bake one ourselves (staticAtlas returns `false`
+-- for its own bake whenever the palette is absent, RED++ already baked, or
+-- the tileset is trueColor).
+--
+-- TileRenderer.atlasImageData is the engine's own accessor for exactly this
+-- and is preferred wherever the build offers it -- but like the sibling
+-- clock TileRenderer.animFrame it is an OPTIONAL seam, and a build without
+-- it has to cost us the animation, not the whole render pipeline. Reading
+-- it unguarded is what took the pass down for the session.
+--
+-- Without the seam the pixels are still recoverable, by two different
+-- routes. An atlas neither we nor RED++ replaced is the tileset art itself,
+-- so the art on disk IS what it was built from. RED++'s per-map bake exists
+-- only on the GPU -- getGbcAtlas throws its ImageData away once the texture
+-- is made -- so that one has to come back off the texture (readback below).
+local function rendererPixels(map)
+  local renderer = map.renderer
+  if not renderer then return nil end
+  if TileRenderer.atlasImageData then
+    local ok, data = pcall(TileRenderer.atlasImageData, renderer)
+    if ok and data then return data end
+  end
+  if renderer.gbcAtlas then
+    return gbcPixels(map) or readback(renderer.image)
+  end
+  local ok, data = pcall(Assets.imageData, map.tileset.image)
+  return ok and data or nil
+end
+
+-- The engine's tile-animation clock: TileRenderer's 60Hz counter, by
+-- whatever route this build offers.
+--
+-- It matters that this is the ENGINE's number and not one of our own. The
+-- 2D tile layer and this texture animate the same water off the same
+-- counter, so toggling voxel mode mid-cycle continues the animation instead
+-- of restarting or jumping it. A clock of our own would free-run against
+-- the one the flat path is drawing from.
+--
+--   1. TileRenderer.animFrame(), where the build exports it.
+--   2. else the counter itself, off tick()'s upvalues. It is a plain local
+--      in that module, so this is exact and live -- the same number, not an
+--      approximation of it. Reading engine internals is what this mod's
+--      "engine_internals" permission is declared for, and this one is
+--      read-only and entirely optional.
+--   3. else wall time in 60Hz steps. Free-running, but the water moves,
+--      which beats a frozen pond. Derived from absolute time rather than
+--      accumulated deltas because animate() is called once per map in the
+--      neighbourhood, so a per-call accumulator would run several times
+--      too fast.
+local clockUpvalue = nil        -- nil = not looked for yet, false = absent
+
+local function findClockUpvalue()
+  if not (debug and debug.getupvalue) then return false end
+  if type(TileRenderer.tick) ~= "function" then return false end
+  for i = 1, 32 do
+    local ok, name, value = pcall(debug.getupvalue, TileRenderer.tick, i)
+    if not (ok and name) then break end
+    if name == "animFrame" and type(value) == "number" then return i end
+  end
+  return false
+end
+
+local function animFrame()
+  if TileRenderer.animFrame then
+    local ok, f = pcall(TileRenderer.animFrame)
+    if ok and type(f) == "number" then return f end
+  end
+  if clockUpvalue == nil then clockUpvalue = findClockUpvalue() end
+  if clockUpvalue then
+    local ok, _, value = pcall(debug.getupvalue, TileRenderer.tick, clockUpvalue)
+    if ok and type(value) == "number" then return value end
+  end
+  if love.timer and love.timer.getTime then
+    return math.floor(love.timer.getTime() * 60)
+  end
+  return 0
+end
+
+TerrainAtlas._animFrame = animFrame   -- named for the suite
+
+-- false = this can never work and asking again is waste; nil = it did not
+-- work THIS time and might next. The caller latches the first and retries
+-- the second (see attemptFailed).
+local function newEntry(map, base, baked)
+  local tileset = map.tileset
+  local specs = specsFor(tileset)
+  if not specs then return false end        -- nothing on this tileset animates
+  if not (love.image and love.image.newImageData
+          and base.replacePixels) then
+    return false                            -- no pixel access on this machine
+  end
+  -- the pixels the atlas texture was built from: our own SGB bake when we
+  -- made one, else whatever the engine's renderer is drawing with. A
+  -- readback can fail for one frame and work the next, so this is a
+  -- retryable miss rather than a verdict.
+  local src = baked or rendererPixels(map)
+  if not src then return nil end
+
+  local ok, entry = pcall(function()
+    local w, h = src:getDimensions()
+    -- A PRIVATE copy, always. The base may be the engine's own atlas, and
+    -- the 2D path draws the static tile from it and overdraws the animated
+    -- cell on top -- rewriting the slot underneath would animate the tile
+    -- twice over there and corrupt every still frame of it.
+    local data = love.image.newImageData(w, h)
+    data:paste(src, 0, 0, 0, 0, w, h)
+    local image = love.graphics.newImage(data)
+    image:setFilter("nearest", "nearest")
+    local e = { base = src, data = data, image = image, specs = specs,
+                perRow = tileset.tilesPerRow or 16, step = nil }
+    -- the frame files are raw grayscale; learn what the atlas did to the
+    -- tile each one stands in for, so they land on the same colours
+    local recolored = baked or (map.renderer and map.renderer.gbcAtlas)
+    if recolored and not tileset.trueColor then
+      local raw = Assets.imageData(tileset.image)
+      e.shades = {}
+      for _, spec in ipairs(specs) do
+        if spec.kind == "frames" then
+          e.shades[spec.tile] = learnShades(raw, src, spec.tile, e.perRow)
+        end
+      end
+    end
+    -- a frame-animated tile that resolved to the `flower` class stands as
+    -- a 1px billboard (Structures.buildFlowers), and its slot in THIS
+    -- copy carries only each frame's dark tones with the rest keyed to
+    -- alpha -- see patch(). Gated on the resolved shape so a profile that
+    -- pins the tile to something solid keeps a fully opaque slot, and on
+    -- the tileset art being readable: without pixels Structures cannot
+    -- have stood the billboard up (or synthesized the ground), and an
+    -- alpha-keyed slot under an ordinary flat quad is a hole in the world.
+    for _, spec in ipairs(specs) do
+      if spec.kind == "frames" then
+        local okCut, isFlower = pcall(function()
+          local okA, art = pcall(Assets.imageData, tileset.image)
+          if not (okA and art and art.getPixel) then return false end
+          local sh = V.require("TileShape").forMap(map)[spec.tile]
+          return sh ~= nil and sh.class == "flower"
+        end)
+        if okCut and isFlower then
+          e.cut = e.cut or {}
+          e.cut[spec.tile] = true
+        end
+      end
+    end
+    return e
+  end)
+  return (ok and entry) or false
+end
+
+-- The atlas for this frame: the static one when nothing on this tileset
+-- animates (or anything at all goes wrong), else a private copy with the
+-- animated slots rewritten to the current step. Repatched only when the
+-- step actually changes -- three times a second, ~130 pixels of work.
+function TerrainAtlas.animate(map, colors, base, baked)
+  -- RED++ bakes a per-MAP atlas, so its animated copy is per map too and
+  -- has to be evicted with the meshes (setLive below); the shared paths key
+  -- on the tileset and palette alone, which is bounded by how many of those
+  -- exist at all.
+  local perMap = map.renderer and map.renderer.gbcAtlas and map.id or nil
+  local key = map.tileset.image .. "#a#" .. paletteKey(colors or {})
+    .. (perMap or "")
+  local entry = animated[key]
+  if entry == nil then
+    entry = newEntry(map, base, baked)
+    if entry then
+      entry.mapId = perMap
+      animated[key] = entry
+    else
+      -- false from newEntry is a verdict (nothing animates on this tileset,
+      -- no pixel access at all); nil is a miss that may not repeat
+      animated[key] = (entry == false) and false or attemptFailed(key)
+    end
+  end
+  if not entry then return nil end
+
+  local frame = animFrame()
+  -- one number for the whole entry: every spec's own step, folded together,
+  -- so a repatch happens when ANY of them turns over
+  local step = 0
+  for i, spec in ipairs(entry.specs) do
+    local n = spec.kind == "hshift" and #spec.offsets or #spec.sequence
+    step = step + (math.floor(frame / (spec.period or 20)) % n) * (16 ^ i)
+  end
+  if step ~= entry.step then
+    entry.step = step
+    local ok = pcall(function()
+      for _, spec in ipairs(entry.specs) do
+        local n = spec.kind == "hshift" and #spec.offsets or #spec.sequence
+        patch(entry.data, entry, spec,
+              math.floor(frame / (spec.period or 20)) % n)
+      end
+      entry.image:replacePixels(entry.data)
+    end)
+    if not ok then
+      -- drop the entry rather than condemning the key: the next frame
+      -- rebuilds and tries again, and attemptFailed gives up eventually
+      animated[key] = attemptFailed(key)
+      return nil
+    end
+  end
+  -- Only a frame that got all the way here counts as healthy. Clearing the
+  -- budget on a successful BUILD instead would never let it run out: an
+  -- entry that builds fine and fails on upload would rebuild every frame,
+  -- forever, which is worse than either animating or giving up.
+  if attempts[key] then attempts[key] = nil end
+  return entry.image
+end
+
+function TerrainAtlas.forMap(map, colors)
+  local base, baked = staticAtlas(map, colors)
+  if not base then return nil end
+  return TerrainAtlas.animate(map, colors, base, baked) or base
+end
+
+-- The image a character model should texture from under an SGB palette.
+--
+-- In the 2D SGB modes, sprites are colorized by the screen-space
+-- shade-remap shader at blit time -- the sheet itself stays grayscale. The
+-- voxel canvas composites 1:1 with no shader pass, so a model textured
+-- straight from the sheet renders in raw DMG grays (a black-and-gray
+-- character standing in a colored room). Bake instead, exactly like the
+-- terrain above: one recolored sheet per (sheet, palette), remapped
+-- through the same cutoffs the shader uses, alpha preserved so OBJ color
+-- 0 stays transparent. Falls back to nil (caller keeps its texture) when
+-- pixels are unreachable.
+function TerrainAtlas.forSprite(path, colors)
+  if not (colors and love.image and love.image.newImageData) then
+    return nil
+  end
+  local key = "spr:" .. path .. "#" .. paletteKey(colors)
+  if cache[key] ~= nil then return cache[key] or nil end
+
+  local ok, img = pcall(function()
+    local src = Assets.imageData(path)
+    local w, h = src:getDimensions()
+    local out = love.image.newImageData(w, h)
+    for y = 0, h - 1 do
+      for x = 0, w - 1 do
+        local r, g, b, a = src:getPixel(x, y)
+        r, g, b, a = TileRenderer.recolorSample(r, g, b, a, colors)
+        out:setPixel(x, y, r, g, b, a)
+      end
+    end
+    local image = love.graphics.newImage(out)
+    image:setFilter("nearest", "nearest")
+    return image
+  end)
+  cache[key] = ok and img or false
+  return cache[key] or nil
+end
+
+-- Release the animated copies of maps outside `live` (a set of map ids),
+-- the same neighbourhood ChunkMesher bounds its meshes to and called from
+-- the same place. Only the per-map RED++ copies are held this way; the rest
+-- are keyed by tileset and palette, of which a session sees a handful.
+-- Without this a cross-region trek accumulates one atlas and one texture
+-- per map ever entered, and each pins the engine's own baked ImageData
+-- alive behind it.
+function TerrainAtlas.setLive(live)
+  for key, entry in pairs(animated) do
+    if entry and entry.mapId and not live[entry.mapId] then
+      if entry.image and entry.image.release then
+        pcall(entry.image.release, entry.image)
+      end
+      animated[key] = nil
+    end
+  end
+end
+
+function TerrainAtlas.invalidate()
+  cache = {}
+  cacheData = {}
+  attempts = {}
+  for _, entry in pairs(animated) do
+    if entry and entry.image and entry.image.release then
+      pcall(entry.image.release, entry.image)
+    end
+  end
+  animated = {}
+end
+
+Assets.register(TerrainAtlas.invalidate)
+
+return TerrainAtlas

--- a/mods/dramatic_shape/lib/TileShape.lua
+++ b/mods/dramatic_shape/lib/TileShape.lua
@@ -1,0 +1,551 @@
+-- Voxel world mode: resolve every tile of a tileset to an extrusion shape.
+--
+-- Reads the hand-authored groups in data/voxel_heights.lua and fills the
+-- gaps from data the ROM extractor already emits. Resolution happens at two
+-- granularities, and the order matters:
+--
+--   per tile   1. a group named in data/voxel_heights.lua  (hand-authored)
+--   per CELL   2. the cell is water                        -> "water"
+--              3. the cell is walkable                     -> "ground"
+--   per tile   4. tile-level fallback: the map's water set -> "water",
+--                 its walkable set -> "ground", else       -> "wall"
+--
+-- The cell steps (TileShape.at) are the load-bearing part. Collision in
+-- this engine -- like the GB original -- is defined per 16x16 CELL, judged
+-- by the cell's bottom-left 8x8 tile alone. The other three tiles of a
+-- cell carry no collision meaning, and treating their walkable-list
+-- membership as one (which is what a pure per-tile lookup does) misfiles
+-- every decorative tile: flowers become 16px pillars, the gap tiles of a
+-- fence row become wall, grass tufts extrude. A tile in a walkable cell is
+-- ground the player is standing on, whatever the walkable list says about
+-- it; hand-authoring (rule 1) is the only thing that overrides that.
+--
+-- Rule 4 covers positions whose cell IS blocked: there, walkable-listed
+-- tiles (the gaps between fence posts) stay ground and the rest rise.
+--
+-- Every class also carries an ART mode, which is what the mesher renders:
+--
+--   flat     ground/water/void: a single quad, no box.
+--   top      ledge/roof: a box with its art on the TOP face -- things
+--            whose 2D art depicts a surface seen from above.
+--   upright  wall/tree/fence/sign: a box whose SOUTH face reconstructs
+--            the 2D artwork standing up (the mesher's fold-up rule) --
+--            things whose 2D art depicts a surface seen face-on, which is
+--            most of Gen 1: interior walls, furniture, tree canopies,
+--            building facades.
+--
+-- Purely presentational: a shape decides how a tile DRAWS in voxel mode
+-- and nothing else. Collision still reads the same walkable list it
+-- always did.
+
+-- the mod namespace (see main.lua): V.data loads a shipped data file
+local V = ...
+
+local TileShape = {}
+
+-- class -> height fallbacks, used when data/voxel_heights.lua is missing
+-- or omits a class. Same numbers the shipped file carries; a cell is 16x16.
+local FALLBACK_HEIGHTS = {
+  ground = 0,
+  water = -2,
+  void = 0,
+  ledge = 6,
+  fence = 10,
+  sign = 12,
+  wall = 16,
+  tree = 16,
+  -- masonry drawn TWO courses tall: the Indigo Plateau's rim and the
+  -- badge-check gates down Route 23 are drawn 32px, the same height as a
+  -- statue on its plinth, and read as a step in the terrain rather than a
+  -- room's wall.  Same fold as `wall`, twice the height -- and its own
+  -- class because `wall` is 16px for every interior in the game.
+  cliff = 32,
+  roof = 28,
+  cylinder = 16,
+  -- big round scenery: a 2x2-CELL drawing carved as ONE 32px voxel hull
+  -- (Viridian Forest's trees). The class pins only the drawing's
+  -- top-left corner tile; the other cells stay `cylinder` and are
+  -- claimed by the group build (see Structures.buildCylinders)
+  canopy = 32,
+  -- a cylinder hull whose drawn top is a CUT FACE (tree stumps): the
+  -- body builds from the bark rows and the drawn ellipse projects onto
+  -- the hull's round top
+  stump = 16,
+  billboard = 16,
+  signpost = 16,
+  post = 16,
+  grass = 0,
+  flower = 0,
+  -- interior furniture: face-on drawings the detector would otherwise
+  -- raise to wall height (or merge into the wall).  A bed is drawn from
+  -- above and lies low; tables and desks are boxes at their real height;
+  -- stairs become stepped geometry rising toward the named side.
+  bed = 7,
+  stool = 8,
+  counter = 8,
+  table = 12,
+  desk = 24,
+  prop = 16,
+  cutout = 16,
+  console = 16,
+  relief = 3,
+  bookcase = 32,
+  stair_e = 16,
+  stair_w = 16,
+  stair_down_e = 16,
+  stair_down_w = 16,
+}
+
+-- class -> how the mesher draws it (see the header). The last three are
+-- profile archetypes Structures.lua builds special geometry for:
+--   cylinder   round-drawn cells (tree canopies) become voxel hulls cut
+--              from the art's darkest-pixel outline, round in depth
+--   billboard  signs, props: the art stands as a thin per-pixel voxel
+--              slab, transparency respected
+--   post       fence posts: the same thin per-pixel slab, but every CELL
+--              stands alone in its own depth band -- a north-south fence
+--              line is a march of separate posts, not one tall drawing
+--              (which is what a shared cluster would make of it)
+--   grass      tall grass: flat ground PLUS two thin standing rows of
+--              tufts per tile (the art's top and bottom halves), each at
+--              its drawn depth -- the player walks between them
+local ART = {
+  ground = "flat",
+  water = "flat",
+  void = "flat",
+  ledge = "top",
+  roof = "top",
+  wall = "upright",
+  cliff = "upright",
+  tree = "upright",
+  fence = "upright",
+  sign = "upright",
+  cylinder = "cylinder",
+  canopy = "canopy",
+  stump = "cylinder",
+  billboard = "billboard",
+  -- signposts share the billboard treatment but as their own pool at a
+  -- 2-voxel depth: a sign is a thin plate on a stick, and the standard
+  -- 10px standee body reads as a chunk of furniture outdoors
+  signpost = "billboard",
+  post = "post",
+  grass = "grass",
+  -- animated flowers: flat synthesized ground PLUS a standing cutout of
+  -- the drawing's darkest tones, one voxel deep (see Structures'
+  -- buildFlowers). Height 0 so a build with no pixel access degrades to
+  -- the flat tile it always drew, not a box
+  flower = "flower",
+  -- furniture: a bed's art depicts its top surface; tables and desks are
+  -- boxes whose fronts fold up (the mesher's authored-fold rule).
+  -- Stools, `prop` and `cutout` are standee pools alongside `billboard`
+  -- -- same per-pixel cutout, different thickness (see Structures'
+  -- PINNED_DEPTH), and separate pools cluster separately so touching
+  -- drawings never stack; a stool keeps its 8px height so a character
+  -- standing on its (walkable) cell sits at seat height.  Stairs are a
+  -- profile archetype Structures builds real steps for -- rising flights
+  -- for stairs leading up, sunken stairwells for stairs leading down
+  bed = "top",
+  stool = "billboard",
+  -- half-cell furniture: a service counter, a low couch.  One 8px band,
+  -- so exactly the drawing's bottom row stands up as the front and
+  -- every row above it rides the top face in drawn order -- which is
+  -- also the only way to place a figure drawn INTO the furniture (the
+  -- Center's seated man) without repeating him, since a taller box
+  -- folds two rows upright and then repeats its north row across the
+  -- top.  Reads as something you lean on rather than a wall stub
+  counter = "upright",
+  table = "upright",
+  desk = "upright",
+  prop = "billboard",
+  cutout = "billboard",
+  -- a machine standing on furniture: the billboard treatment with
+  -- body, plus the one-object contract `cutout` has -- the drawing is
+  -- ringed by the furniture it sits on, and those edges must not be
+  -- extruded along with it (see Structures' component filter)
+  console = "billboard",
+  relief = "relief",
+  -- free-standing shelves: the drawing is TALL, not deep -- Structures
+  -- collapses each drawn rank onto a one-cell-deep box at full height
+  bookcase = "bookcase",
+  stair_e = "stair",
+  stair_w = "stair",
+  stair_down_e = "stair",
+  stair_down_w = "stair",
+}
+
+local spec = nil          -- the loaded data file, or false when absent
+local cache = {}          -- tileset id -> resolved shape list
+local figCache = {}       -- tileset id -> parsed figure masks, or false
+local bgCache = {}        -- tileset id -> prop background shades, or false
+
+-- The shape profile ships with the mod (data/voxel_heights.lua) and is read
+-- through the mod's own file loader rather than package.path: a mod's
+-- directory is not on it, and may live inside a mounted .love archive that
+-- plain require cannot reach either.  Absent or broken degrades to the
+-- derived defaults, which is a rougher-looking world rather than no world.
+local function load()
+  if spec == nil then
+    local ok, s = pcall(V.data, "voxel_heights")
+    spec = (ok and type(s) == "table") and s or false
+  end
+  return spec or nil
+end
+
+function TileShape.heights()
+  local s = load()
+  local out = {}
+  for class, h in pairs(FALLBACK_HEIGHTS) do out[class] = h end
+  for class, h in pairs(s and s.heights or {}) do
+    if type(h) == "number" and FALLBACK_HEIGHTS[class] then out[class] = h end
+  end
+  return out
+end
+
+-- tile id -> class, from the hand-authored groups for one tileset. Unknown
+-- class names are dropped rather than trusted: a typo in the data file
+-- should degrade to the derived default, not invent a zero-height class.
+local function authoredGroups(tilesetId, heights)
+  local s = load()
+  local entry = s and s.tilesets and s.tilesets[tilesetId]
+  local out = {}
+  if not entry then return out end
+  for class, tiles in pairs(entry) do
+    if heights[class] and type(tiles) == "table" then
+      for _, t in ipairs(tiles) do out[t] = class end
+    end
+  end
+  return out
+end
+
+-- Conditional pins: tile id -> list of { above = {tile ids}, class }.
+--
+-- A pin is per TILE ID, and one graphic can mean two things. The route
+-- gates' $32/$33 is the case that forced this: the artist reuses it for
+-- the wall's dark base course AND for every service counter's front, and
+-- it is the bottom row of its cell either way. Pinned `wall` the counter
+-- stands a full 16px; pinned `counter` the wall bank corrugates 16/8 for
+-- sixteen rows. Neither is right, and no per-tile pin can be, because
+-- forMap resolves an id to ONE shape.
+--
+-- What separates the two uses is what is drawn ABOVE: the wall's upper
+-- course over a wall base, the counter's top over a counter front. So a
+-- profile entry may carry `when_above = { [tile] = { { above = {...},
+-- class = "..." } } }`, evaluated per POSITION in TileShape.at, where
+-- the map and coordinates are in hand. First match wins; no match keeps
+-- the tile's ordinary pin.
+-- `when_below` is the mirror, and it exists because ABOVE is not always the
+-- side that tells the two uses apart.  The Plateau's $0D is the case: it is
+-- the gate wall's top band AND the base course under a column of rock face,
+-- and scanned over both maps the tile above is $03 for 64 of the first and
+-- 140 of the second -- no rule on `above` can split them.  What is BELOW
+-- does, exactly: the wall's own face $0F sits under the top band and under
+-- nothing else (336 vs 352, clean).
+local function authoredConditions(tilesetId, heights)
+  local s = load()
+  local entry = s and s.tilesets and s.tilesets[tilesetId]
+  if type(entry) ~= "table" then return nil end
+  local out, any = {}, false
+
+  local function collect(spec, side)
+    if type(spec) ~= "table" then return end
+    for tile, rules in pairs(spec) do
+      if type(tile) == "number" and type(rules) == "table" then
+        local list = out[tile] or {}
+        for _, rule in ipairs(rules) do
+          if type(rule) == "table" and heights[rule.class]
+             and type(rule[side]) == "table" then
+            local set = {}
+            for _, t in ipairs(rule[side]) do set[t] = true end
+            list[#list + 1] = { side = side, set = set, class = rule.class }
+          end
+        end
+        if #list > 0 then
+          out[tile] = list
+          any = true
+        end
+      end
+    end
+  end
+
+  collect(entry.when_above, "above")
+  collect(entry.when_below, "below")
+  return any and out or nil
+end
+
+local function shapeFor(class, heights, authored)
+  return { class = class, h = heights[class] or 0,
+           art = ART[class] or "upright",
+           -- grass and flowers draw a flat ground base like any walkable
+           -- tile; the standing tufts and cutouts are additive geometry
+           -- from Structures
+           flat = ART[class] == "flat" or class == "grass"
+                  or class == "flower",
+           authored = authored or false }
+end
+
+-- Resolved TILE-LEVEL shapes for the tileset `map` uses: a list indexed by
+-- tile id holding { class, h, art, flat, authored }, plus `classes`, one
+-- canonical shape per class for the cell-level overrides in TileShape.at.
+-- Cached per tileset id -- this table depends only on the tileset record
+-- and the data file, both constant for a given id. The per-map part of
+-- resolution (cell walkability) lives in TileShape.at, NOT here.
+function TileShape.forMap(map)
+  local tileset = map.tileset
+  local id = tileset.id
+  if cache[id] then return cache[id] end
+
+  local heights = TileShape.heights()
+  local authored = authoredGroups(id, heights)
+  local count = math.floor((tileset.imageWidth or 128) / 8)
+                * math.floor((tileset.imageHeight or 48) / 8)
+
+  -- derived pin: a tile the tileset animates by FRAME REWRITE (the
+  -- overworld's flower) is already named by its animation spec, so like
+  -- tall grass it needs no profile entry anywhere. Hand-authoring still
+  -- wins -- a mod animating a wall tile this way keeps its wall by
+  -- listing it. Guarded because the spec seam is engine data a stub map
+  -- may not carry.
+  local flowerTiles = {}
+  do
+    local ok, declared = pcall(function()
+      if tileset.animatedTiles then return tileset.animatedTiles end
+      local TileRenderer = require("src.render.TileRenderer")
+      return TileRenderer.defaultAnimatedTiles(tileset)
+    end)
+    if ok then
+      for _, spec in ipairs(type(declared) == "table" and declared or {}) do
+        if spec.kind == "frames" and spec.tile then
+          flowerTiles[spec.tile] = true
+        end
+      end
+    end
+  end
+
+  local shapes = { classes = {}, cond = authoredConditions(id, heights) }
+  for class in pairs(FALLBACK_HEIGHTS) do
+    shapes.classes[class] = shapeFor(class, heights)
+  end
+  -- a conditional pin's own AUTHORED shape per class it can resolve to,
+  -- kept apart from the shared canonical ones above (see TileShape.at)
+  if shapes.cond then
+    shapes.condShape = {}
+    for _, rules in pairs(shapes.cond) do
+      for _, rule in ipairs(rules) do
+        shapes.condShape[rule.class] = shapes.condShape[rule.class]
+          or shapeFor(rule.class, heights, true)
+      end
+    end
+  end
+  for t = 0, count - 1 do
+    local class = authored[t]
+    if class then
+      shapes[t] = shapeFor(class, heights, true)
+    elseif t == tileset.grassTile then
+      -- derived pin: every tileset already names its tall-grass tile, so
+      -- the standing-tuft treatment needs no profile entry anywhere
+      shapes[t] = shapeFor("grass", heights, true)
+    elseif flowerTiles[t] then
+      shapes[t] = shapeFor("flower", heights, true)
+    elseif map.waterTiles and map.waterTiles[t] then
+      shapes[t] = shapes.classes.water
+    elseif map.walkable and map.walkable[t] then
+      shapes[t] = shapes.classes.ground
+    else
+      shapes[t] = shapes.classes.wall
+    end
+  end
+  shapes.count = count
+  cache[id] = shapes
+  return shapes
+end
+
+-- The shape of the tile at TILE coordinates (tx, ty) -- the full
+-- resolution including the cell-granularity steps (see the header).
+-- `shapes` is the table forMap returned for this map; `tile` is
+-- map:tileAt(tx, ty), passed in because every caller already has it.
+function TileShape.at(map, shapes, tile, tx, ty)
+  local s = shapes[tile]
+  -- conditional pins first: they are authored answers that need the
+  -- POSITION to resolve, so they outrank both the flat pin on the same
+  -- tile and the cell rules below (see authoredConditions)
+  local rules = shapes.cond and shapes.cond[tile]
+  if rules then
+    for _, rule in ipairs(rules) do
+      -- NOTE map:tileAt border-EXTENDS: one row off an edge answers the
+      -- map's borderBlock, never nil.  A rule listing whatever that block
+      -- draws will fire along that whole edge (it did, on the Marts).
+      local n = map:tileAt(tx, rule.side == "above" and ty - 1 or ty + 1)
+      if n and rule.set[n] then
+        -- shapes.condShape, NOT shapes.classes: the canonical class
+        -- shapes are SHARED, and `wall` in particular is the very object
+        -- rule 4 hands every unauthored solid tile. Marking that one
+        -- authored (which the first cut did) made every one of them skip
+        -- the cell rules below, so walkable floors stopped flattening and
+        -- whole rooms rose into a checkerboard of blocks.
+        return shapes.condShape[rule.class]
+      end
+    end
+  end
+  if not s or s.authored then return s end
+  local cx = math.floor(tx / 2)
+  local cy = math.floor(ty / 2)
+  if map:isWaterCell(cx, cy) then return shapes.classes.water end
+  if map:isWalkableCell(cx, cy) then return shapes.classes.ground end
+  return s
+end
+
+-- Hand-authored FIGURES for one tileset: a drawing painted INTO furniture,
+-- cut out by an explicit pixel mask and stood up on top of it.
+--
+-- Every other route in this file resolves a whole 8x8 TILE, which is
+-- exactly why none of them can reach a figure that shares its tiles with
+-- the thing it sits on -- and the detector's segmentation cannot either
+-- when the drawing has no background margin to flood from and wears the
+-- same shades as its furniture.  So the profile authors the silhouette
+-- pixel by pixel (see data/voxel_heights.lua):
+--
+--   figures = { { w      = <tiles across>,
+--                 tiles  = { ...w*h tile ids, row-major... },
+--                 under  = { ...w*h ids: what each tile wears once the
+--                            figure is lifted off it... },
+--                 pixels = { ...h*8 strings of w*8 chars, "." = not the
+--                            figure... } } }
+--
+-- No class: a figure is always a flat sprite card, drawn the way
+-- SpriteBillboards draws a character (see Structures.buildFigures).
+--
+-- Returned normalized: `mask` as a set keyed by ly * (w * 8) + lx, so
+-- Structures can read it as a bitmap without re-parsing per position.
+-- A malformed entry is dropped rather than half-applied -- a typo in a
+-- mask should leave the couch alone, not carve a hole in it.
+function TileShape.figures(tilesetId)
+  local hit = figCache[tilesetId]
+  if hit ~= nil then return hit or nil end
+
+  local s = load()
+  local entry = s and s.tilesets and s.tilesets[tilesetId]
+  local list = entry and entry.figures
+  local out = {}
+  if type(list) == "table" then
+    for _, f in ipairs(list) do
+      local ok = type(f) == "table" and type(f.w) == "number"
+                 and type(f.tiles) == "table" and type(f.under) == "table"
+                 and type(f.pixels) == "table"
+      local w = ok and math.floor(f.w) or 0
+      local h = (w >= 1) and (#f.tiles / w) or 0
+      ok = ok and w >= 1 and h >= 1 and h == math.floor(h)
+           and #f.under == #f.tiles and #f.pixels == h * 8
+      if ok then
+        for i = 1, h * 8 do
+          local row = f.pixels[i]
+          if type(row) ~= "string" or #row ~= w * 8 then
+            ok = false
+            break
+          end
+        end
+      end
+      if ok then
+        local mask, n = {}, 0
+        for ly = 0, h * 8 - 1 do
+          local row = f.pixels[ly + 1]
+          for lx = 0, w * 8 - 1 do
+            if row:sub(lx + 1, lx + 1) ~= "." then
+              mask[ly * (w * 8) + lx] = true
+              n = n + 1
+            end
+          end
+        end
+        if n > 0 then
+          out[#out + 1] = { w = w, h = h, n = n, mask = mask,
+                            tiles = f.tiles, under = f.under }
+        end
+      end
+    end
+  end
+
+  figCache[tilesetId] = (#out > 0) and out or false
+  return figCache[tilesetId] or nil
+end
+
+-- Which GB shades count as BACKGROUND for a pinned per-pixel prop, per tile
+-- (a tileset entry's prop_bg). Returns tile id -> set of shade names, or nil.
+--
+-- Structures normally votes on this by reading the shades that touch the
+-- drawing's own bounding box, which is right whenever the drawing has a
+-- margin of floor around it and wrong when it does not: a prop whose body
+-- reaches its own edge votes itself out. Naming the shades is the override,
+-- and it is keyed by TILE because the answer is per drawing rather than per
+-- tileset -- two props in one atlas can want opposite calls on the same
+-- shade (see the POKECENTER entry).
+--
+--   prop_bg = { { tiles = { ...ids... }, shades = { "light", "white" } } }
+--
+-- Only the four GB shade names exist; anything else is dropped, so a typo
+-- degrades to the ordinary vote rather than emptying the background.
+local SHADES = { black = true, dark = true, light = true, white = true }
+
+function TileShape.propBg(tilesetId)
+  local hit = bgCache[tilesetId]
+  if hit ~= nil then return hit or nil end
+
+  local s = load()
+  local entry = s and s.tilesets and s.tilesets[tilesetId]
+  local list = entry and entry.prop_bg
+  local out, any = {}, false
+  if type(list) == "table" then
+    for _, rule in ipairs(list) do
+      if type(rule) == "table" and type(rule.tiles) == "table"
+         and type(rule.shades) == "table" then
+        local set, n = {}, 0
+        for _, name in ipairs(rule.shades) do
+          if SHADES[name] then
+            set[name] = true
+            n = n + 1
+          end
+        end
+        if n > 0 then
+          for _, t in ipairs(rule.tiles) do
+            if type(t) == "number" then
+              out[t] = set
+              any = true
+            end
+          end
+        end
+      end
+    end
+  end
+
+  bgCache[tilesetId] = any and out or false
+  return bgCache[tilesetId] or nil
+end
+
+-- What a bookcase rank does with the rows it VACATES -- the ones behind the
+-- one-cell-deep box it collapses onto (a tileset entry's
+-- bookcase_backfill).  Returns the mode name, or nil for the default.
+--
+--   "above"   hand them the cell immediately above the run: its shape and
+--             its art.  A wall set INTO a terrace wants this -- the ground
+--             behind it is more terrace, not a trench.
+--   nil       skip them and paint the map's commonest ground underneath,
+--             which is right for a free-standing shelf against a wall.
+--
+-- Per tileset because it is a statement about what the drawing depicts, and
+-- the answer differs: the Mart's racks and Red's shelves stand in a room,
+-- the Plateau's gate walls are cut into a hillside.
+function TileShape.bookcaseBackfill(tilesetId)
+  local s = load()
+  local entry = s and s.tilesets and s.tilesets[tilesetId]
+  local mode = entry and entry.bookcase_backfill
+  return mode == "above" and mode or nil
+end
+
+-- Drop the cache: a mod that shadows data/voxel_heights.lua or a tileset
+-- record needs the next lookup to re-resolve (hot reload, mod toggle).
+function TileShape.invalidate()
+  spec = nil
+  cache = {}
+  figCache = {}
+  bgCache = {}
+end
+
+return TileShape

--- a/mods/dramatic_shape/lib/TiltShift.lua
+++ b/mods/dramatic_shape/lib/TiltShift.lua
@@ -1,0 +1,177 @@
+-- Voxel world mode: tilt-shift post-process (the miniature-diorama look).
+--
+-- A depth-of-field fake that reads perfectly on a tilted voxel scene: a
+-- horizontal band through the view centre (where the camera focuses -- the
+-- player) stays sharp, and the frame blurs progressively toward the top
+-- and bottom edges, with a slight saturation lift to sell the model-photo
+-- feel. It runs on the finished voxel canvas as two separable gaussian
+-- passes, so it costs two fullscreen draws and touches nothing in the 3D
+-- pass itself.
+--
+-- This is a render pipeline in its own right -- a worldPresent pass, which
+-- is the stage that post-processes the finished world BEFORE the UI
+-- composites over it. That placement is the whole point: a miniature-photo
+-- blur belongs on the diorama, not on the dialog box in front of it.
+--
+-- The engine owns the level: the T-SHIFT options row, its hotkey, the
+-- OFF -> 1 -> 2 -> 3 -> OFF ladder and persistence in
+-- save.options.pipelines all come from the render_pipelines record in
+-- main.lua, and the current level arrives through update(). Each step
+-- narrows the sharp band, deepens the blur and pushes the saturation a
+-- little further.
+--
+-- Because worldPresent only runs when some pipeline rendered the world,
+-- this draws over the voxel scene and nothing else. With it off (or on any
+-- failure -- headless, no shader support) apply() hands the canvas back
+-- untouched, so every other path is byte-for-byte what it always was.
+
+local TiltShift = {}
+
+TiltShift.level = 0
+TiltShift.LABELS = { "OFF", "1", "2", "3" }
+
+-- The strength ladder. `spacing` is the gap between the gaussian's taps
+-- at full blur, as a fraction of the canvas height (so the miniature
+-- reads the same in a window and fullscreen; the blur's reach is 4x the
+-- spacing per pass, and the two passes compound). `band` is the
+-- half-height of the fully sharp zone and `range` the ramp to full blur,
+-- both in canvas-uv units. The focus line sits at the vertical centre
+-- because that is where the voxel camera parks the player.
+TiltShift.FOCUS_Y = 0.5
+TiltShift.PRESETS = {
+  [1] = { spacing = 0.0016, band = 0.14, range = 0.42, saturation = 1.10 },
+  [2] = { spacing = 0.0028, band = 0.10, range = 0.36, saturation = 1.18 },
+  [3] = { spacing = 0.0042, band = 0.07, range = 0.30, saturation = 1.28 },
+}
+
+local SHADER = [[
+  uniform vec2 dir;        // one texel step along the axis being blurred
+  uniform float focusY;
+  uniform float band;
+  uniform float range;
+  uniform float spacing;   // gap between taps at full blur, in texels
+  uniform float boost;     // 0 = plain blur pass, 1 = final pass (color pop)
+  uniform float saturation;
+  vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+    float d = abs(tc.y - focusY) - band;
+    float s = clamp(d / range, 0.0, 1.0);
+    s = s * s;             // ease in, so the band edge has no visible seam
+    // 9 taps a small step apart: dense enough that even the strongest
+    // preset blurs smoothly instead of ghosting into streaks
+    vec2 o = dir * (s * spacing);
+    vec4 sum = Texel(tex, tc) * 0.2270270270;
+    sum += (Texel(tex, tc + o) + Texel(tex, tc - o)) * 0.1945945946;
+    sum += (Texel(tex, tc + 2.0 * o) + Texel(tex, tc - 2.0 * o)) * 0.1216216216;
+    sum += (Texel(tex, tc + 3.0 * o) + Texel(tex, tc - 3.0 * o)) * 0.0540540541;
+    sum += (Texel(tex, tc + 4.0 * o) + Texel(tex, tc - 4.0 * o)) * 0.0162162162;
+    if (boost > 0.5) {
+      float luma = dot(sum.rgb, vec3(0.299, 0.587, 0.114));
+      sum.rgb = mix(vec3(luma), sum.rgb, saturation);
+    }
+    return sum * color;
+  }
+]]
+
+local shader = nil            -- nil = untried, false = unavailable
+local ping, pong, cw, ch = nil, nil, 0, 0
+
+local function getShader()
+  if shader == nil then
+    local ok, sh = pcall(function() return love.graphics.newShader(SHADER) end)
+    shader = (ok and sh) or false
+  end
+  return shader or nil
+end
+
+local function getCanvases(w, h)
+  if not ping or cw ~= w or ch ~= h then
+    local ok, a = pcall(love.graphics.newCanvas, w, h)
+    if not ok then return nil end
+    local okB, b = pcall(love.graphics.newCanvas, w, h)
+    if not okB then return nil end
+    -- the gaussian's fractional tap offsets need linear filtering
+    a:setFilter("linear", "linear")
+    b:setFilter("linear", "linear")
+    ping, pong, cw, ch = a, b, w, h
+  end
+  return ping, pong
+end
+
+function TiltShift.setLevel(level)
+  level = math.floor(tonumber(level) or 0)
+  if level < 0 then level = 0 end
+  if level > 3 then level = 3 end
+  TiltShift.level = level
+end
+
+-- The pipeline's per-frame tick: the engine hands over the level the
+-- player has the T-SHIFT row set to.  No tween -- unlike the camera angle,
+-- a blur strength has nothing to ease through.
+function TiltShift.update(_, level)
+  TiltShift.setLevel(level)
+end
+
+function TiltShift.levelLabel(level)
+  return TiltShift.LABELS[(level or TiltShift.level) + 1] or "OFF"
+end
+
+function TiltShift.active()
+  return TiltShift.level > 0
+end
+
+function TiltShift.reset()
+  TiltShift.level = 0
+end
+
+-- Run the effect over `canvas` and return the processed canvas. Returns
+-- the input unchanged when the effect is off or cannot run (headless, no
+-- shader support), so the caller composites exactly what it was handed.
+function TiltShift.apply(canvas)
+  local preset = TiltShift.PRESETS[TiltShift.level]
+  if not (preset and canvas) then return canvas end
+  local sh = getShader()
+  if not sh then return canvas end
+  local w, h = canvas:getDimensions()
+  local a, b = getCanvases(w, h)
+  if not a then return canvas end
+
+  local spacing = math.max(0.75, math.min(3, h * preset.spacing))
+  local prevBlend, prevAlpha = love.graphics.getBlendMode()
+
+  -- the voxel canvas filters nearest for its 1:1 blit; the blur taps need
+  -- linear, restored below so the composite path sees what it expects
+  canvas:setFilter("linear", "linear")
+  love.graphics.setShader(sh)
+  love.graphics.setColor(1, 1, 1, 1)
+  -- replace, not alpha-blend: these are image-processing copies
+  love.graphics.setBlendMode("replace", "premultiplied")
+  pcall(sh.send, sh, "focusY", TiltShift.FOCUS_Y)
+  pcall(sh.send, sh, "band", preset.band)
+  pcall(sh.send, sh, "range", preset.range)
+  pcall(sh.send, sh, "spacing", spacing)
+  pcall(sh.send, sh, "saturation", preset.saturation)
+
+  local ok = pcall(function()
+    love.graphics.setCanvas(a)
+    pcall(sh.send, sh, "dir", { 1 / w, 0 })
+    pcall(sh.send, sh, "boost", 0)
+    love.graphics.draw(canvas)
+    love.graphics.setCanvas(b)
+    pcall(sh.send, sh, "dir", { 0, 1 / h })
+    pcall(sh.send, sh, "boost", 1)
+    love.graphics.draw(a)
+  end)
+
+  love.graphics.setCanvas()
+  love.graphics.setShader()
+  love.graphics.setBlendMode(prevBlend or "alpha", prevAlpha)
+  canvas:setFilter("nearest", "nearest")
+  return ok and b or canvas
+end
+
+-- Drop the GPU objects (window resize, hot reload).
+function TiltShift.invalidate()
+  ping, pong, cw, ch = nil, nil, 0, 0
+end
+
+return TiltShift

--- a/mods/dramatic_shape/lib/Voxel3D.lua
+++ b/mods/dramatic_shape/lib/Voxel3D.lua
@@ -1,0 +1,950 @@
+-- Voxel world mode: the 3D pass -- shader, depth buffer and camera.
+--
+-- World space is world PIXELS, so every coordinate the 2D paths already
+-- compute drops straight in with no unit conversion:
+--
+--   +X  map east   (world-pixel x)
+--   +Y  up         (0 is the ground plane)
+--   +Z  map south  (world-pixel y)
+--
+-- A character at rest faces +Z, i.e. toward a camera parked to the south,
+-- which is what "facing down" means in the 2D game -- and a character card
+-- is drawn in exactly that pose, leaning back rather than yawing.
+--
+-- The camera orbits the view centre at Voxel.angle: 0 is straight down
+-- (what the flat 2D view already is) and 50 degrees leans toward the
+-- horizon. Distance and field of view are tied to Voxel.FOCAL, which is the
+-- same constant Tilt projects with, so a given angle frames the world
+-- identically in both modes -- switching between them changes the geometry,
+-- not the framing.
+--
+-- Every GPU object is pcall-guarded and `available()` reports the result:
+-- headless test runs and any driver without depth-canvas support fall back
+-- to the existing tilt/flat paths rather than erroring.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local Mat4 = V.require("Mat4")
+local Voxel = V.require("VoxelState")
+local ShadowMap = V.require("ShadowMap")
+local VoxelGrid = V.require("VoxelGrid")
+local WorldCurve = V.require("WorldCurve")
+local Sky = V.require("Sky")
+local DayNight = V.require("DayNight")
+local GlassMask = V.require("GlassMask")
+
+local Voxel3D = {}
+
+-- Vertex format shared by terrain chunks and character models: a position,
+-- the map-canvas / sprite-sheet pixel it samples, and a per-vertex darken
+-- factor that gives a face its angle to the sun without a normal or a
+-- light uniform. Cast shadows are a separate thing entirely -- see
+-- ShadowMap, which the pixel shader below samples on top of this.
+Voxel3D.FORMAT = {
+  { "VertexPosition", "float", 3 },
+  { "VertexTexCoord", "float", 2 },
+  { "VertexShade", "float", 1 },
+}
+
+-- Face shading by direction id: top faces stay
+-- full brightness, sides step down so an extruded block reads as solid
+-- instead of a flat sticker, and the faces turned away from the sun are
+-- darkest. The sun hangs in the SOUTHEAST (see ShadowMap), so south and
+-- east are the lit flanks and north and west the shaded ones -- east and
+-- west used to share one value back when the sun sat due northwest and the
+-- two were symmetric about it.
+--
+-- This is still worth baking even now that the shadow pass throws real
+-- shadows: a face turned away from the sun is dark because of its ANGLE,
+-- which no shadow map measures, and the two compound the way they should
+-- -- an away-facing wall that is also occluded goes darker still.
+Voxel3D.FACE_SHADE = {
+  [1] = 0.84,   -- +X east (toward the sun)
+  [2] = 0.72,   -- -X west (away)
+  [3] = 1.00,   -- +Y up
+  [4] = 0.55,   -- -Y down
+  [5] = 0.90,   -- +Z south (toward the camera, and toward the sun)
+  [6] = 0.68,   -- -Z north (away)
+}
+
+local SHADER = [[
+  varying float vShade;
+  varying vec3 vSun;          // this fragment's place in the sun's view
+#ifdef VOXEL_GRID
+  // model space, one unit per voxel -- see VoxelGrid. Precision matters
+  // here in a way it does not for a colour: the seam is the FRACTIONAL
+  // part of a coordinate that runs to a few thousand across a big route,
+  // so a mediump varying would quantise the fraction away entirely.
+  varying LOVE_HIGHP_OR_MEDIUMP vec3 vGrid;
+#endif
+#ifdef VERTEX
+  uniform mat4 vp;
+  uniform mat4 model;
+  uniform mat4 sunModel;      // where the SUN sees this vertex (see below)
+  uniform mat4 sunVP;         // world -> the shadow map's unit cube
+  uniform vec3 eye;
+  uniform float pull;
+  uniform vec3 curve;         // xy = the focus in world XZ, z = k; 0 = off
+  attribute float VertexShade;
+  vec4 position(mat4 transform_projection, vec4 vertex_position) {
+    vShade = VertexShade;
+#ifdef VOXEL_GRID
+    // MODEL space, deliberately: every mesh here is built a unit per
+    // voxel in its own frame, so the seams ride the model however it is
+    // posed rather than the world's grid sliding across a leaning sprite
+    vGrid = vertex_position.xyz;
+#endif
+    vec4 w = model * vertex_position;
+    // The shadow lookup runs off `sunModel`, not `model`. For terrain the
+    // two are the same matrix, but a character is drawn as a slab LEANING
+    // back by the camera's pitch -- a trick played on the viewer, which
+    // the sun never saw: it lit the upright card. Looking up with the
+    // leaned position asks whether the sun reached a place the figure is
+    // not, and since the lean tips the body north and shadows now fall
+    // north, every sprite's own card fell across its front. Looking up
+    // with the card's position asks the question the sun actually
+    // answered. (The pull below is excluded for the same reason: it is a
+    // depth trick aimed at the camera's own buffer.)
+    vSun = (sunVP * (sunModel * vertex_position)).xyz;
+    // The curved world (see WorldCurve): drop every vertex by the square
+    // of how far its column stands from the camera's focus. Applied AFTER
+    // the shadow lookup above and clear of the wireframe's model space, so
+    // both are worked out on the flat world and the bend carries them
+    // along -- which is why neither has to know this exists. Along Y only,
+    // so a column moves as one piece: the world tips away and the
+    // buildings standing on it stay upright.
+    if (curve.z > 0.0) {
+      vec2 cd = w.xz - curve.xy;
+      w.y -= dot(cd, cd) * curve.z;
+    }
+    // camera-ward pull: move the vertex along ITS OWN ray to the eye.
+    // This is a pure depth bias -- the projection of a point moved along
+    // its eye ray is bit-identical, so there is no screen drift at all.
+    // (An earlier CPU version translated along the central view axis,
+    // which preserved only the screen centre and made off-centre sprites
+    // and grass swim against the ground while the camera scrolled.)
+    if (pull > 0.0) {
+      w.xyz += normalize(eye - w.xyz) * pull;
+    }
+    return vp * w;
+  }
+#endif
+#ifdef PIXEL
+  uniform Image sunMap;
+  uniform float sunDark;      // how far into black a shadow goes; 0 = off
+  uniform float sunBias;
+  uniform vec2 sunTexel;
+
+  // the two-channel pack ShadowMap writes: high byte, then low
+  float sunDepth(vec2 uv) {
+    vec4 c = Texel(sunMap, uv);
+    return c.r + c.g * (1.0 / 255.0);
+  }
+
+  // 1.0 in full sun, 1.0 - sunDark in full shadow. Four taps half a texel
+  // out on the diagonals: a 2x2 box filter, which is what turns the
+  // shadow map's texel staircase into a one-pixel soft edge.
+  float sunlight(vec3 p) {
+    if (sunDark <= 0.0) return 1.0;
+    // outside the sun's frustum nothing was recorded, so nothing occludes
+    if (p.x < 0.0 || p.x > 1.0 || p.y < 0.0 || p.y > 1.0 || p.z > 1.0) {
+      return 1.0;
+    }
+    // Ease the shadows off at the frustum's rim. The map covers the ground
+    // the camera can see out to a cap, and past the low rungs -- 75 degrees
+    // especially -- the horizon is further than any box worth paying for.
+    // Without this the covered region simply ENDS, drawing a hard line
+    // across the middle distance where every shadow stops at once; with it
+    // the far field just loses them, which reads as distance.
+    vec2 e = min(p.xy, 1.0 - p.xy);
+    float edge = smoothstep(0.0, 0.06, min(e.x, e.y));
+    if (edge <= 0.0) return 1.0;
+    float z = p.z - sunBias;
+    float lit = step(z, sunDepth(p.xy + sunTexel * vec2(-0.5, -0.5)))
+              + step(z, sunDepth(p.xy + sunTexel * vec2( 0.5, -0.5)))
+              + step(z, sunDepth(p.xy + sunTexel * vec2(-0.5,  0.5)))
+              + step(z, sunDepth(p.xy + sunTexel * vec2( 0.5,  0.5)));
+    return 1.0 - sunDark * edge * (1.0 - lit * 0.25);
+  }
+
+#ifdef VOXEL_GRID
+  uniform float gridDark;     // how far toward black a seam pulls; 0 = off
+  uniform float gridWidth;    // seam width, in display pixels
+
+  // How much of this fragment a voxel seam covers, 0 to 1.
+  float voxelSeam(vec3 p) {
+    // how much of `p` this fragment spans on screen, per axis: the
+    // conversion from model units to display pixels, measured rather than
+    // derived, so it holds under any camera pitch or zoom
+    vec3 w = fwidth(p);
+    vec3 d = abs(fract(p + 0.5) - 0.5);      // distance to the nearest plane
+    // The axis a face does not vary along is that face's own normal, and
+    // its distance is a constant zero -- take it at face value and every
+    // face floods solid. Push those axes out of reach instead of dividing
+    // by their zero.
+    vec3 live = step(1e-4, w);
+    vec3 px = d / max(w, vec3(1e-6)) + (1.0 - live) * 1e6;
+    float near = min(min(px.x, px.y), px.z);
+    // Fade out where a voxel is too small to hold a line. Survey zoom
+    // draws a world pixel at about a display pixel, and a wall seen nearly
+    // edge-on squashes one to nothing at any zoom -- either way the seams
+    // land closer together than they are wide, and drawn anyway they stop
+    // being a wireframe and become a flat 45% dimming of the whole scene.
+    // The tightest axis decides, which is the honest test of whether the
+    // grid can be resolved at all.
+    float span = 1.0 / max(max(w.x, max(w.y, w.z)), 1e-6);
+    float fade = clamp((span - 2.0) * 0.5, 0.0, 1.0);
+    // the textbook antialiased line: solid within the half-width, fading
+    // over the one pixel outside it
+    return fade * clamp(gridWidth * 0.5 + 0.5 - near, 0.0, 1.0);
+  }
+#endif
+
+  uniform vec3 ghostColor;    // the flat silhouette colour
+  uniform float ghost;        // 0 = shade normally, 1 = flatten to it
+  uniform vec3 dayTint;       // the hour's light on the world; 1,1,1 = noon
+  uniform Image glassMask;    // opaque where the atlas texel is window glass
+  uniform vec2 glassSize;     // the mask's dimensions: tc -> atlas texels
+  uniform float glassNight;   // 0 = daylight .. 1 = the lamps are on
+  uniform float glassPhase;   // the glint's phase: advances with TRAVEL
+  uniform float glassGlint;   // and its strength: 0 while standing still
+  uniform float glassOn;      // 0 for sprite-sheet draws (see Voxel3D.glass)
+
+  vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+    vec4 p = Texel(tex, tc);
+    // sprite sheets key GB OBJ color 0 to alpha 0; discarding rather than
+    // blending keeps those texels out of the depth buffer, so a model never
+    // carves a transparent hole out of whatever stands behind it
+    if (p.a < 0.5) discard;
+    // the hour's tint multiplies like the sun terms do: it is LIGHT, the
+    // same warm or moonlit cast on every surface, not a palette swap
+    vec3 rgb = p.rgb * vShade * sunlight(vSun) * dayTint;
+#ifdef VOXEL_GRID
+    // darken what is there rather than painting a colour, so a seam across
+    // dark grass and one across a white roof each stay in their own palette
+    rgb *= 1.0 - gridDark * voxelSeam(vGrid);
+#endif
+    // WINDOW GLASS, marked per atlas texel by the mask (see GlassMask).
+    // By day a thin diagonal glint crosses the panes WHILE THE VIEW MOVES
+    // -- the phase is fed by the camera's own travel and the strength dies
+    // within a beat of standing still, because a reflection is something
+    // the viewpoint does: still camera, still glass. It lifts the texel
+    // toward sky-white and leaves the art visible through it. After dark
+    // the pane is LIT: the texel's own shine pattern carried into a warm
+    // lamp colour, replacing the shaded answer above -- so a lit window
+    // ignores the sun, every shadow and the hour's tint, exactly as a
+    // window with a lamp behind it does.
+    // glassOn gates the whole thing per DRAW: the mask is shaped like the
+    // tileset atlas, and only meshes textured FROM that atlas may consult
+    // it -- a character samples its own sprite sheet, whose coordinates
+    // land on the mask's pane rectangles by accident and would stripe the
+    // cast with lamplight at night.
+    float glass = Texel(glassMask, tc).a * glassOn;
+    if (glass > 0.0) {
+      // the sweep lives in the PANE's own space (atlas texels), not the
+      // screen's: a pattern anchored to the screen has the world sliding
+      // through it at zoom speed whenever the camera pans, which strobed --
+      // worst where the pan and the phase ran opposite ways. Anchored to
+      // the glass, panning moves nothing; only the phase does, a fraction
+      // of a texel per step, the same in every walking direction.
+      float sweep = sin(tc.x * glassSize.x * 0.8 - glassPhase);
+      float glint = pow(max(sweep, 0.0), 20.0) * 0.55 * glassGlint;
+      vec3 pane = mix(rgb, vec3(0.93, 0.97, 1.0), glint * glass);
+      float shine = dot(p.rgb, vec3(0.299, 0.587, 0.114));
+      vec3 lamp = vec3(1.0, 0.84, 0.5) * (0.5 + 0.55 * shine);
+      rgb = mix(pane, lamp, glassNight * glass);
+    }
+    // The hidden player is a SHAPE, not a dimmed picture of itself. Tinting
+    // through `color` could only multiply the sprite's own pixels, which
+    // darkens each one by its own amount and keeps the character's internal
+    // detail; replacing the colour outright is what makes it read as one
+    // solid silhouette. Last in the chain, so neither the sun nor a voxel
+    // seam can mottle it.
+    rgb = mix(rgb, ghostColor, ghost);
+    return vec4(rgb, 1.0) * color;
+  }
+#endif
+]]
+
+-- Two compilations of SHADER: the plain scene, and the same thing with the
+-- voxel wireframe compiled in. The wireframe needs shader derivatives
+-- (fwidth), the one piece of this a driver can refuse, so it is a separate
+-- build rather than a branch -- a refusal costs the grid and nothing else.
+-- Each entry is nil = untried, false = unavailable.
+local shaders = { [false] = nil, [true] = nil }
+local activeShader = nil      -- the variant this pass bound
+
+-- Scene canvases, one per NAMED SLOT. There are exactly two callers and
+-- they want different sizes -- the free-roam pass renders at the window's
+-- pixel dimensions, the overworld battle at the GB's 160x144 -- and a
+-- single cached canvas made every battle entry and exit reallocate one.
+-- A slot reallocates only when its OWN size changes, which is a window
+-- resize, so the pair is stable for a session.
+local slots = {}
+local canvas, canvasW, canvasH = nil, 0, 0   -- the slot this pass bound
+local active = false
+
+local IDENTITY = Mat4.identity()
+
+-- Whether the driver admits to supporting derivatives. Only a hint --
+-- the compile below is the real test -- but it saves building a shader
+-- that was never going to work, and it is how LOVE reports the ES2
+-- extension the grid rides on.
+local function derivativesOK()
+  if not (love.graphics and love.graphics.getSupported) then return false end
+  local ok, caps = pcall(love.graphics.getSupported)
+  return ok and caps and caps.shaderderivatives == true
+end
+
+-- The scene shader. `grid` asks for the wireframe variant, and nil comes
+-- back when that one will not build -- callers then fall back to the plain
+-- one rather than losing the whole 3D pass.
+function Voxel3D.shader(grid)
+  grid = grid and true or false
+  if shaders[grid] == nil then
+    if grid and not derivativesOK() then
+      shaders[grid] = false
+    else
+      local src = grid and ("#define VOXEL_GRID 1\n" .. SHADER) or SHADER
+      local ok, sh = pcall(love.graphics.newShader, src)
+      shaders[grid] = ok and sh or false
+    end
+  end
+  return shaders[grid] or nil
+end
+
+-- Whether the 3D path can run at all. False on a headless test run (no
+-- love.graphics), without shader support, or where a depth canvas cannot be
+-- created -- every caller treats that as "stay on the 2D path".
+function Voxel3D.available()
+  if not (love.graphics and love.graphics.newCanvas
+          and love.graphics.setDepthMode) then
+    return false
+  end
+  return Voxel3D.shader() ~= nil
+end
+
+-- Build a mesh in the shared format. `verts` is the LOVE vertex list and
+-- `map` the triangle index list. Returns nil when meshes are unavailable,
+-- which the callers treat the same way they treat a missing model.
+function Voxel3D.newMesh(verts, map)
+  if #verts == 0 then return nil end
+  local ok, mesh = pcall(love.graphics.newMesh, Voxel3D.FORMAT, verts,
+                         "triangles", "static")
+  if not ok then return nil end
+  if map and #map > 0 then pcall(mesh.setVertexMap, mesh, map) end
+  return mesh
+end
+
+-- The quad corner offsets and UV corners for one face direction, in the
+-- order the vertex map below stitches into two triangles. Corners are unit
+-- offsets from the voxel's (x, y, z) minimum corner.
+Voxel3D.FACE_CORNERS = {
+  [1] = { { 1, 0, 0 }, { 1, 0, 1 }, { 1, 1, 1 }, { 1, 1, 0 } },  -- +X
+  [2] = { { 0, 0, 1 }, { 0, 0, 0 }, { 0, 1, 0 }, { 0, 1, 1 } },  -- -X
+  [3] = { { 0, 1, 0 }, { 1, 1, 0 }, { 1, 1, 1 }, { 0, 1, 1 } },  -- +Y
+  [4] = { { 0, 0, 1 }, { 1, 0, 1 }, { 1, 0, 0 }, { 0, 0, 0 } },  -- -Y
+  [5] = { { 0, 0, 1 }, { 1, 0, 1 }, { 1, 1, 1 }, { 0, 1, 1 } },  -- +Z
+  [6] = { { 1, 0, 0 }, { 0, 0, 0 }, { 0, 1, 0 }, { 1, 1, 0 } },  -- -Z
+}
+
+-- Append the six indices of quad `n` (0-based) to a triangle index list.
+function Voxel3D.pushQuad(map, n)
+  local b = n * 4
+  map[#map + 1] = b + 1
+  map[#map + 1] = b + 2
+  map[#map + 1] = b + 3
+  map[#map + 1] = b + 1
+  map[#map + 1] = b + 3
+  map[#map + 1] = b + 4
+end
+
+-- ---------------------------------------------------------------- camera --
+
+-- An explicit camera, replacing the orbit below for as long as it is set:
+-- { eye = {x,y,z}, focus = {x,y,z}, fov = radians, curve = k or nil }.
+--
+-- The orbit is the free-roam camera and it is described entirely by ONE
+-- number, the pitch, because that is all a camera following the player over
+-- their own map ever needs. A staged shot -- the overworld battle's
+-- over-the-shoulder rig (see BattleCam) -- is a placed camera: it has a yaw,
+-- it does not sit above its focus, and its framing comes from the arena
+-- rather than from the view size. Rather than widen the orbit into
+-- something that could express both and be the wrong shape for each, a
+-- caller with a camera of its own simply hands it over.
+--
+-- Everything downstream is unchanged by this: the shader uniforms, project()
+-- and the overlay all read Voxel3D.vp / Voxel3D.eye, which are set the same
+-- way either way.
+Voxel3D.camera = nil
+
+-- View and projection for a `vw` x `vh` world-pixel view centred on
+-- (cx, cy) in world pixels. Returns the combined matrix.
+function Voxel3D.viewProjection(cx, cy, vw, vh)
+  local cam = Voxel3D.camera
+  if cam then
+    local eye, focus = cam.eye, cam.focus
+    Voxel3D.eye = eye
+    -- kept beside the eye for horizonY: where the sky's pale end goes is a
+    -- question about which way this camera looks, and only these two answer it
+    Voxel3D.focus = focus
+    local dx = eye[1] - focus[1]
+    local dy = eye[2] - focus[2]
+    local dz = eye[3] - focus[3]
+    local dist = math.max(1, math.sqrt(dx * dx + dy * dy + dz * dz))
+    local proj = Mat4.perspective(cam.fov, vw / vh,
+                                  math.max(1, dist * 0.05), dist * 4 + 4096)
+    -- the same clip-space Y flip the orbit needs, for the same reason: we
+    -- bypass LOVE's transform_projection and canvas coordinates run Y down
+    proj = Mat4.mul(Mat4.scale(1, -1, 1), proj)
+    -- world up, so the horizon stays level -- a placed camera that rolled
+    -- with its own pitch would tip the whole arena
+    return Mat4.mul(proj, Mat4.lookAt(eye, focus, { 0, 1, 0 }))
+  end
+
+  local a = Voxel.angle
+  local focal = Voxel.FOCAL
+  local dist = focal * vh
+  -- the FOV that makes a straight-down camera at `dist` frame exactly `vh`
+  -- world pixels, which is the framing the flat view already has
+  local fov = 2 * math.atan(1 / (2 * focal))
+
+  local focus = { cx, 0, cy }
+  local eye = { cx, dist * math.cos(a), cy + dist * math.sin(a) }
+  -- exposed for camera-facing billboards (VoxelScene yaws sprites at it)
+  Voxel3D.eye = eye
+  Voxel3D.focus = focus
+  -- perpendicular to the view direction in the YZ plane: north is screen-up
+  -- when looking straight down, +Y is screen-up when looking level. Never
+  -- parallel to the view direction, so there is no degenerate a = 0 case.
+  local up = { 0, math.sin(a), -math.cos(a) }
+
+  local proj = Mat4.perspective(fov, vw / vh,
+                                math.max(1, dist * 0.05), dist * 4 + 4096)
+  -- Flip clip-space Y. Mat4.perspective emits textbook GL clip space with
+  -- +Y up, but we bypass LOVE's own transform_projection, and LOVE's canvas
+  -- coordinates run Y DOWN -- so without this the entire scene composites
+  -- vertically mirrored: north at the bottom and buildings extruding
+  -- downward. Winding flips with it, which is free here because the pass
+  -- draws with culling off.
+  proj = Mat4.mul(Mat4.scale(1, -1, 1), proj)
+  return Mat4.mul(proj, Mat4.lookAt(eye, focus, up))
+end
+
+-- ------- the horizon
+--
+-- Where the ground plane's vanishing line lands, in canvas pixels down from the
+-- top edge, or nil when this camera has no horizon to find.
+--
+-- Not a fraction picked by eye. A direction ALONG the ground is a point at
+-- infinity, and putting one through the same matrix the geometry is drawn with
+-- gives the line every ground plane in the scene converges on -- so the sky's
+-- pale end meets the horizon at any pitch, fov, window shape or zoom, and rides
+-- the camera tween instead of having to be retuned against it.
+--
+-- The world CURVE is not in it, and cannot be: it bends distant ground down in
+-- the vertex shader, so the ground's apparent edge sits BELOW this line by
+-- however much the bend took. What shows in between is the haze the sky's fill
+-- already is, which is what a curved-away horizon should look like.
+--
+-- nil in two cases, both meaning "no horizon in this frame": a camera looking
+-- straight down, whose forward direction has no horizontal part to send to
+-- infinity, and one whose vanishing line is behind it.
+function Voxel3D.horizonY(h)
+  local m, eye, focus = Voxel3D.vp, Voxel3D.eye, Voxel3D.focus
+  if not (m and eye and focus and h and h > 0) then return nil end
+  local dx = focus[1] - eye[1]
+  local dz = focus[3] - eye[3]
+  local len = math.sqrt(dx * dx + dz * dz)
+  if len < 1e-6 then return nil end
+  dx, dz = dx / len, dz / len
+  -- a DIRECTION, so its w is zero and the matrix's translation column drops
+  -- out; the clip-space Y flip is already baked into m, so this comes out in
+  -- canvas coordinates rather than needing one
+  local y = m[5] * dx + m[7] * dz
+  local w = m[13] * dx + m[15] * dz
+  if w <= 1e-6 then return nil end
+  return (y / w * 0.5 + 0.5) * h
+end
+
+-- ------- the hour's light
+--
+-- What the scene shader multiplies every surface by (see dayTint in the
+-- shader). Set per pass by whoever knows what map is being drawn --
+-- VoxelScene for free-roam, BattleScene for the arena -- because "is this
+-- outdoors" is the map's question, not this pass's. Neutral until somebody
+-- answers it, so a caller that never does draws exactly what it always drew.
+Voxel3D.tint = { 1, 1, 1 }
+
+-- The window-glass pass, set the same way and for the same reason: the
+-- MASK belongs to the map's tileset (GlassMask.texture) and how lit the
+-- panes are belongs to the hour and to being outdoors at all
+-- (DayNight.windowLight). nil / 0 -- the defaults -- draw no glass effect.
+Voxel3D.glassMask = nil
+Voxel3D.glassNight = 0
+
+-- the glint, fed by the camera's TRAVEL rather than by a clock (see
+-- VoxelScene.glintStep): the phase is radians already wrapped to 2pi, and
+-- the strength is 0 whenever the view has been still for a beat
+Voxel3D.glassPhase = 0
+Voxel3D.glassGlint = 0
+
+-- The sun or moon disc's place on this camera's canvas, or nil when the
+-- body is set, on the southern half of the sky, or behind the camera.
+--
+-- The direction comes from DayNight (true bearing, squashed elevation) and
+-- goes through the SAME matrix the geometry is drawn with, as a point at
+-- infinity -- exactly how horizonY finds the vanishing line. So the disc's
+-- azimuth is honest: it stands over the point on the horizon its shadows
+-- point away from, at every pitch, fov, window shape and zoom.
+--
+-- Must run after beginScene has set Voxel3D.vp for this frame's camera.
+function Voxel3D.skyBody(w, h)
+  local m = Voxel3D.vp
+  local b = m and DayNight.body()
+  if not b then return nil end
+  local x = m[1] * b.dx + m[2] * b.dy + m[3] * b.dz
+  local y = m[5] * b.dx + m[6] * b.dy + m[7] * b.dz
+  local ww = m[13] * b.dx + m[14] * b.dy + m[15] * b.dz
+  if ww <= 1e-6 then return nil end
+  local amt, color = DayNight.glow()
+  return {
+    x = (x / ww * 0.5 + 0.5) * w,
+    y = (y / ww * 0.5 + 0.5) * h,
+    moon = b.moon,
+    glowAmt = amt,
+    glowColor = color,
+  }
+end
+
+-- ----------------------------------------------------------------- scene --
+
+-- Begin the 3D pass into a `w` x `h` pixel canvas centred on world
+-- (cx, cy), covering `vw` x `vh` world pixels. Returns false when the pass
+-- could not start, in which case the caller must not call endScene.
+-- `sky` is an optional {r, g, b, a} in 0..1 to clear the void to, for the
+-- pitch where the horizon is in frame (VoxelScene.skyFor). nil leaves the
+-- void transparent, which is what every rung below it wants.
+-- `slot` names which cached canvas to render into (see `slots` above);
+-- omitted is the free-roam world pass.
+function Voxel3D.beginScene(w, h, cx, cy, vw, vh, sky, slot)
+  -- the wireframe variant when the player has it on AND it built; either
+  -- answer falls through to the plain scene rather than to no scene
+  local grid = VoxelGrid.enabled()
+  local sh = grid and Voxel3D.shader(true) or nil
+  if not sh then
+    grid, sh = false, Voxel3D.shader()
+  end
+  if not sh then return false end
+  local name = slot or "world"
+  local held = slots[name]
+  if not (held and held.w == w and held.h == h) then
+    local ok, c = pcall(love.graphics.newCanvas, w, h)
+    if not ok then return false end
+    c:setFilter("nearest", "nearest")
+    if held and held.canvas and held.canvas.release then
+      pcall(held.canvas.release, held.canvas)
+    end
+    held = { canvas = c, w = w, h = h }
+    slots[name] = held
+  end
+  canvas, canvasW, canvasH = held.canvas, w, h
+  -- a depth buffer is what makes occlusion real: walk behind a building and
+  -- the building wins, with no y-sorting anywhere
+  local ok = pcall(love.graphics.setCanvas,
+                   { canvas, depth = true })
+  if not ok then
+    pcall(love.graphics.setCanvas)
+    return false
+  end
+  -- Ahead of the clear, because the sky's bands are placed off the ground
+  -- plane's vanishing line and that is a property of this matrix.
+  Voxel3D.vp = Voxel3D.viewProjection(cx, cy, vw, vh)
+  if sky then
+    love.graphics.clear(sky[1], sky[2], sky[3], sky[4] or 1, true, true)
+    -- The sky goes down here, in the one window in this function where a
+    -- rectangle is just a rectangle: the depth mode and the scene shader are
+    -- both set below. Sky.paint puts them aside anyway -- beginScene is not the
+    -- only thing that has ever left a shader bound.
+    --
+    -- w / vw is this frame's pixels per WORLD pixel, which is the size a diorama
+    -- pixel is on screen: the sky's dither grid is cut to that, so its squares
+    -- are the same size as the world's own and follow every resize and zoom.
+    -- The banded sky also hangs the hour's sun or moon (skyBody projects it
+    -- through this very camera); a flat sky has no bands and hangs nothing.
+    Sky.paint(w, h, sky, Voxel3D.horizonY(h), w / math.max(1, vw or w),
+              sky.bands and Voxel3D.skyBody(w, h) or nil)
+  else
+    love.graphics.clear(0, 0, 0, 0, true, true)
+  end
+  love.graphics.setDepthMode("lequal", true)
+  -- models mirror on X for right-facing and alternate walk steps, which
+  -- flips winding; hidden faces are already culled at build time, so there
+  -- is nothing to gain from backface culling and a real bug to avoid
+  love.graphics.setMeshCullMode("none")
+  love.graphics.setShader(sh)
+  love.graphics.setColor(1, 1, 1, 1)
+  pcall(sh.send, sh, "vp", "row", Voxel3D.vp)
+  pcall(sh.send, sh, "eye", Voxel3D.eye)
+  -- the sun's frame, filled by ShadowMap just before this pass opened.
+  -- Sent unconditionally: the sampler is declared either way, and leaving
+  -- one unbound is a driver-dependent crash rather than a fallback.
+  local map = ShadowMap.active()
+  pcall(sh.send, sh, "sunVP", "row", map and ShadowMap.uvVP or IDENTITY)
+  local tex = ShadowMap.texture()
+  if tex then pcall(sh.send, sh, "sunMap", tex) end
+  pcall(sh.send, sh, "sunDark", map and Voxel3D.SHADOW_ALPHA or 0)
+  pcall(sh.send, sh, "sunBias", ShadowMap.bias)
+  local texel = 1 / ShadowMap.res
+  pcall(sh.send, sh, "sunTexel", { texel, texel })
+  if grid then
+    pcall(sh.send, sh, "gridDark", VoxelGrid.DARK)
+    pcall(sh.send, sh, "gridWidth", VoxelGrid.WIDTH)
+  end
+  -- ordinary shading until the silhouette pass asks for otherwise. Sent
+  -- every frame rather than once, because a scene that opened mid-ghost --
+  -- a driver hiccup between beginGhost and endGhost -- would otherwise
+  -- start out flattening everything it drew.
+  pcall(sh.send, sh, "ghost", 0)
+  pcall(sh.send, sh, "ghostColor", Voxel3D.GHOST_COLOR)
+  -- the hour's light, as the caller last set it (see Voxel3D.tint)
+  pcall(sh.send, sh, "dayTint", Voxel3D.tint or { 1, 1, 1 })
+  -- the window glass: the tileset's mask (or the blank -- the sampler is
+  -- declared either way, and unbound is a driver-dependent crash), how lit
+  -- the panes are, and the movement-fed glint as the caller last set it
+  local mask = Voxel3D.glassMask or GlassMask.blank()
+  if mask then
+    pcall(sh.send, sh, "glassMask", mask)
+    local ok, mw, mh = pcall(mask.getDimensions, mask)
+    pcall(sh.send, sh, "glassSize", { ok and mw or 1, ok and mh or 1 })
+  end
+  pcall(sh.send, sh, "glassNight", Voxel3D.glassNight or 0)
+  pcall(sh.send, sh, "glassPhase", Voxel3D.glassPhase or 0)
+  pcall(sh.send, sh, "glassGlint", Voxel3D.glassGlint or 0)
+  -- on until a sprite pass says otherwise, reset per frame like `ghost`
+  pcall(sh.send, sh, "glassOn", 1)
+  -- the curved world bends about the camera's focus, so the horizon keeps
+  -- a fixed distance ahead of the player rather than sitting on the map.
+  -- A placed camera may decline it outright (Voxel3D.camera.curve = 0).
+  local placed = Voxel3D.camera
+  Voxel3D.curveK = (placed and placed.curve) or WorldCurve.k(vh)
+  Voxel3D.curveX, Voxel3D.curveZ = cx, cy
+  pcall(sh.send, sh, "curve", { cx, cy, Voxel3D.curveK })
+  -- clip w at the focus point, the reference depth project() reports scale
+  -- against (so scale == 1 for anything standing at the view centre)
+  local m = Voxel3D.vp
+  Voxel3D.focusW = m[13] * cx + m[14] * 0 + m[15] * cy + m[16]
+  activeShader = sh
+  active = true
+  return true
+end
+
+-- Depth handling for the character pass. Gen 1 draws sprites over the
+-- background unconditionally, so characters render with the depth test
+-- forced to pass (still writing depth: the grass mesh drawn after them
+-- tests against it to overdraw feet). "test" restores normal occlusion.
+function Voxel3D.depth(mode)
+  if not active then return end
+  pcall(love.graphics.setDepthMode, mode == "always" and "always" or "lequal",
+        true)
+end
+
+-- ------------------------------------------------ the player's own ghost --
+
+-- The silhouette's colour, and how solid it is.
+--
+-- ONE flat grey rather than a dimmed copy of the sprite, so the shape reads
+-- at a glance instead of competing with whatever is showing through it --
+-- and translucent rather than opaque, so it stays a hint of where the
+-- player is rather than a hole punched in the building. The wall it is
+-- seen through still shows, which is what keeps it reading as "behind
+-- that" instead of "in front of it".
+Voxel3D.GHOST_COLOR = { 0.26, 0.26, 0.28 }
+Voxel3D.GHOST_ALPHA = 0.5
+
+-- Draw a character AGAIN wherever the ordinary draw LOST the depth test.
+--
+-- Honest occlusion is the point of this mode -- walk behind the Mart and the
+-- Mart is genuinely in front of you -- but a player who cannot see their own
+-- character has lost track of where they are standing, which the flat game
+-- never allowed. So the figure is drawn a second time with the test
+-- INVERTED: "greater" passes exactly where "lequal" failed, and LOVE hands
+-- the compare straight to glDepthFunc, so the two are true complements.
+-- Every texel of the sprite is therefore drawn once and once only -- solid
+-- where it is visible, translucent where it is not -- with no seam where
+-- they meet and no double-blending anywhere.
+--
+-- Nothing is drawn at all when nothing is in the way, and no code here ever
+-- asks whether the player is occluded: the depth buffer already knows, and
+-- the test is the question.
+--
+-- Depth WRITES are off. This pass is behind the scenery by definition, and
+-- writing would file the hidden figure's depth in front of the building
+-- hiding it -- the grass pass at the end of the frame reads that buffer.
+--
+-- The caller redraws through the ordinary character path, so the ghost keeps
+-- the same mesh, matrix and camera-ward PULL as the real draw. The pull
+-- matching is what keeps the leaning-over-a-near-wall case out of here: pull
+-- already won that fight for the solid draw, so this pass finds nothing left
+-- to paint and a character merely standing close to a wall does not shimmer
+-- a ghost over it.
+function Voxel3D.beginGhost()
+  if not active then return end
+  pcall(love.graphics.setDepthMode, "greater", false)
+  love.graphics.setColor(1, 1, 1, Voxel3D.GHOST_ALPHA)
+  if activeShader then
+    pcall(activeShader.send, activeShader, "ghostColor", Voxel3D.GHOST_COLOR)
+    pcall(activeShader.send, activeShader, "ghost", 1)
+  end
+end
+
+-- Flatten whatever is drawn next to one solid colour, or nil to stop.
+--
+-- The same `ghost` path the silhouette uses, WITHOUT beginGhost's inverted
+-- depth test and half alpha -- this is for something drawn normally that
+-- simply wants to come out one colour, which is what a hit flash on a sprite
+-- is. beginScene resets the uniform every frame, so a pass that forgets to
+-- clear it cannot leak into the next one.
+-- `amount` is how far toward that colour, 0..1; omitted is all the way.
+-- Anything short of 1 leaves the sprite's own shading showing through, which
+-- is the difference between a hit flash and a white cut-out.
+function Voxel3D.flatten(color, amount)
+  if not (active and activeShader) then return end
+  local sh = activeShader
+  if color then
+    pcall(sh.send, sh, "ghostColor", color)
+    pcall(sh.send, sh, "ghost", math.max(0, math.min(1, amount or 1)))
+  else
+    pcall(sh.send, sh, "ghost", 0)
+  end
+end
+
+-- Whether what is drawn next carries the voxel wireframe. false for the
+-- length of a draw, true to put it back.
+--
+-- The wireframe reads a mesh's OWN model space and darkens its integer
+-- planes (see VoxelGrid), which is only a wireframe because every mesh in
+-- this mode is built ONE UNIT PER VOXEL: terrain in world pixels, a
+-- character card in the sprite's own pixels. A mesh whose model space does
+-- not mean that gets no wireframe out of the same shader -- it gets
+-- whichever of its integer planes happen to fall inside it, which is a
+-- stray line rather than a seam.
+--
+-- So this is not a style switch. It is how a mesh that is not on the voxel
+-- grid says so, and the alternative -- rescaling such a mesh until its
+-- units happen to be voxels -- would change what it IS to satisfy a
+-- shading pass.
+--
+-- Sent rather than branched because the plain scene shader has no such
+-- uniform, and the send simply does not take there -- which is right: with
+-- no wireframe compiled in there is nothing to suppress.
+function Voxel3D.seams(on)
+  if not (active and activeShader) then return end
+  pcall(activeShader.send, activeShader, "gridDark",
+        on and VoxelGrid.DARK or 0)
+end
+
+-- Whether what is drawn next may consult the glass mask. false for the
+-- length of a sprite-sheet pass, true to put it back.
+--
+-- Same shape as seams(), for the same reason: the mask means "this ATLAS
+-- texel is window glass", so it is only an answer for meshes textured from
+-- the tileset atlas. A sprite sheet's coordinates land wherever they land
+-- on it, and at night that painted lamplight stripes down whoever was
+-- standing in the wrong part of their own sheet.
+function Voxel3D.glass(on)
+  if not (active and activeShader) then return end
+  pcall(activeShader.send, activeShader, "glassOn", on and 1 or 0)
+end
+
+function Voxel3D.endGhost()
+  if not active then return end
+  pcall(love.graphics.setDepthMode, "lequal", true)
+  love.graphics.setColor(1, 1, 1, 1)
+  -- back to ordinary shading before anything else draws; leaving it set
+  -- would flatten the grass pass that follows into one grey sheet
+  if activeShader then
+    pcall(activeShader.send, activeShader, "ghost", 0)
+  end
+end
+
+-- -------------------------------------------------------------- shadows --
+
+-- The sun. One direction, shared by everything that needs to know where
+-- the light comes from: the shadow map, the flat fallback below, and the
+-- baked contact shading in ChunkMesher. Both shears are negative, which
+-- hangs it in the SOUTHEAST and throws every shadow northwest -- up and to
+-- the left on screen.
+Voxel3D.SHADOW_KX = ShadowMap.KX   -- west drift per pixel of height
+Voxel3D.SHADOW_KZ = ShadowMap.KZ   -- north drift per pixel of height
+Voxel3D.SHADOW_EPS = 0.25     -- float above the ground to dodge z-fighting
+Voxel3D.SHADOW_ALPHA = 0.40   -- how far into black a shadowed surface goes
+
+-- Whether real shadows are running this frame. False headless and on any
+-- driver the sun pass could not start on, which is when VoxelScene falls
+-- back to the flat decals below.
+function Voxel3D.shadowsActive()
+  return ShadowMap.active()
+end
+
+-- The upright card a character presents to the sun: its 16x16 sprite quad
+-- (corners (0,0,0)..(16,16,0), feet at y = 0) standing on the middle of
+-- the cell whose top-left is world (px, py), feet at height `y`.
+--
+-- This is the caster the shadow pass draws -- deliberately NOT the leaning
+-- slab the camera sees. The slab tips back by the camera's pitch to read
+-- face-on, which is a trick played on the viewer; letting the sun see it
+-- too would shrink every shadow to nothing as the camera flattened toward
+-- top-down. The sun sees the figure standing up, at every tilt.
+--
+-- The z-flatten matters when this is used the other way round, as the
+-- lookup transform a lit slab reads its own shadowing with (Voxel3D.draw's
+-- `sunModel`): it collapses the slab's side relief onto the card plane, so
+-- every vertex asks about the exact surface the sun recorded rather than
+-- one a few pixels behind it, and a figure cannot fringe itself. On the
+-- caster itself it is a no-op -- that quad is already flat.
+function Voxel3D.casterMatrix(px, py, y, mirror)
+  local m = Mat4.translate(px + 8, y, py + 8)
+  if mirror then m = Mat4.mul(m, Mat4.scale(-1, 1, 1)) end
+  return Mat4.mul(Mat4.mul(m, Mat4.translate(-8, 0, 0)),
+                  Mat4.scale(1, 1, 0))
+end
+
+-- FALLBACK ONLY (no shadow map: headless, or a driver that cannot make the
+-- canvas). Character drop shadows as decals -- the sprite frame squashed
+-- flat onto its ground plane and drawn translucent black. It can only ever
+-- paint the floor, which is the whole reason ShadowMap exists.
+--
+-- Flattening is measured from the ground plane, so a hop slides the whole
+-- shadow along the sun line while it stays glued to the ground -- the
+-- classic jump-shadow tell.
+function Voxel3D.shadowMatrix(px, py, gh, lift, mirror)
+  local card = Voxel3D.casterMatrix(px, py, gh + (lift or 0), mirror)
+  -- flatten about the ground plane: y' = 0, x/z shear by height above it
+  local squash = { 1, Voxel3D.SHADOW_KX, 0, 0,
+                   0, 0,                 0, 0,
+                   0, Voxel3D.SHADOW_KZ, 1, 0,
+                   0, 0,                 0, 1 }
+  local m = Mat4.mul(squash, Mat4.mul(Mat4.translate(0, -gh, 0), card))
+  return Mat4.mul(Mat4.translate(0, gh + Voxel3D.SHADOW_EPS, 0), m)
+end
+
+-- The decal pass draws between terrain and characters: depth-tested so a
+-- building still hides a shadow behind it, but NOT depth-writing -- the
+-- grass tufts drawn at the end of the frame must keep beating the ground
+-- plane, and one quad per entity has no self-overlap to guard against.
+function Voxel3D.beginShadows()
+  if not active then return end
+  pcall(love.graphics.setDepthMode, "lequal", false)
+  love.graphics.setColor(0, 0, 0, Voxel3D.SHADOW_ALPHA)
+end
+
+function Voxel3D.endShadows()
+  if not active then return end
+  pcall(love.graphics.setDepthMode, "lequal", true)
+  love.graphics.setColor(1, 1, 1, 1)
+end
+
+-- Draw one mesh with `model` (a Mat4) applied. Texture may be nil to keep
+-- whatever the mesh already carries. `pull` moves every vertex toward the
+-- eye along its own ray (see the shader) -- the artifact-free depth bias
+-- the character and grass passes ride in front of the terrain.
+--
+-- `sunModel` is where the SHADOW PASS put this same geometry, and defaults
+-- to `model` because for everything but a character the two are one matrix.
+-- A character is drawn leaning and cast upright, so it must hand over the
+-- upright transform or it reads its own shadow as falling on itself.
+function Voxel3D.draw(mesh, texture, model, pull, sunModel)
+  if not (active and mesh) then return end
+  -- the variant beginScene actually bound, not whichever one is default:
+  -- sending a uniform to the other shader would go nowhere
+  local sh = activeShader
+  if not sh then return end
+  if texture then mesh:setTexture(texture) end
+  -- LOVE defaults matrix uniforms to column-major; Mat4 is row-major
+  pcall(sh.send, sh, "model", "row", model or IDENTITY)
+  pcall(sh.send, sh, "sunModel", "row", sunModel or model or IDENTITY)
+  pcall(sh.send, sh, "pull", pull or 0)
+  love.graphics.draw(mesh)
+end
+
+-- Project a world point to canvas pixels: returns (x, y, scale), or nil
+-- when the point is behind the camera. `scale` is how much bigger a thing
+-- at that depth appears than one at the focus point, so a caller can size
+-- with it -- or ignore it and draw unscaled, which is what tilt mode's
+-- billboards do.
+--
+-- This is what lets the overworld's FX closures (the "!" bubble, the heal
+-- machine, the Fly bird, the fishing rod) draw in voxel mode completely
+-- unchanged: they stay ordinary 2D draws, anchored to wherever their ground
+-- point lands under the same camera the 3D pass used.
+function Voxel3D.project(wx, wy, wz)
+  local m = Voxel3D.vp
+  if not m then return nil end
+  -- the same drop the vertex shader applies, or every FX anchored to a
+  -- ground point floats off its own feet the moment that ground bends
+  wy = wy - WorldCurve.drop(Voxel3D.curveK or 0, Voxel3D.curveX or 0,
+                            Voxel3D.curveZ or 0, wx, wz)
+  local cx = m[1] * wx + m[2] * wy + m[3] * wz + m[4]
+  local cy = m[5] * wx + m[6] * wy + m[7] * wz + m[8]
+  local cw = m[13] * wx + m[14] * wy + m[15] * wz + m[16]
+  if cw <= 1e-6 then return nil end
+  -- viewProjection already flipped clip-space Y into LOVE's Y-down canvas
+  -- convention, so both axes map the same way here -- no second flip
+  local x = (cx / cw * 0.5 + 0.5) * canvasW
+  local y = (cy / cw * 0.5 + 0.5) * canvasH
+  return x, y, (Voxel3D.focusW or cw) / cw
+end
+
+-- Re-bind the scene canvas for ordinary 2D drawing (no depth test), so
+-- screen-space overlays can be composited into the same image the 3D pass
+-- just filled. Pairs with endScene, which unbinds it.
+function Voxel3D.beginOverlay()
+  if not canvas then return false end
+  love.graphics.setShader()
+  love.graphics.setDepthMode()
+  local ok = pcall(love.graphics.setCanvas, canvas)
+  if not ok then return false end
+  love.graphics.setColor(1, 1, 1, 1)
+  return true
+end
+
+-- Close the overlay begun by beginOverlay.
+function Voxel3D.endOverlay()
+  love.graphics.setCanvas()
+  active, activeShader = false, nil
+end
+
+-- End the pass and hand back the rendered canvas.
+function Voxel3D.endScene()
+  if not active then return nil end
+  love.graphics.setShader()
+  love.graphics.setDepthMode()
+  love.graphics.setMeshCullMode("none")
+  love.graphics.setCanvas()
+  active, activeShader = false, nil
+  return canvas
+end
+
+function Voxel3D.canvas()
+  return canvas
+end
+
+-- Drop the GPU objects (window resize, hot reload).
+function Voxel3D.invalidate()
+  for name, held in pairs(slots) do
+    if held.canvas and held.canvas.release then
+      pcall(held.canvas.release, held.canvas)
+    end
+    slots[name] = nil
+  end
+  canvas, canvasW, canvasH = nil, 0, 0
+  ShadowMap.invalidate()
+  -- the sky is part of this pass and holds a shader of its own
+  Sky.invalidate()
+  -- and the glass masks are textures of this context too
+  GlassMask.invalidate()
+end
+
+return Voxel3D

--- a/mods/dramatic_shape/lib/VoxelGrid.lua
+++ b/mods/dramatic_shape/lib/VoxelGrid.lua
@@ -1,0 +1,83 @@
+-- Voxel world mode: the voxel wireframe, 3D Dot Game Heroes style.
+--
+-- Every mesh in this mode is built on a one-unit-per-voxel grid in its OWN
+-- model space -- terrain in world pixels, a character card in the sprite's
+-- own pixels. So the seams are simply the
+-- integer planes of that space, and drawing them is a pixel-shader job:
+-- measure how far the fragment is from the nearest integer plane, in
+-- DISPLAY pixels, and darken the ones within half a pixel of it. Sitting in
+-- model space is what keeps the wireframe glued to a thing however it is
+-- posed -- a character's card leans back by the camera's pitch and its
+-- seams lean with it, instead of the world's grid sliding across the
+-- sprite.
+--
+-- Deriving "in display pixels" needs shader derivatives (fwidth), which is
+-- the one part of this that a driver can refuse. So the grid is a SECOND
+-- COMPILATION of the scene shader rather than a branch inside the first
+-- one: if it will not build, the mod loses the wireframe and nothing else
+-- (see Voxel3D.shader).
+--
+-- This file owns the toggle rather than the drawing: the level, where it
+-- persists, and the row the player finds it on.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local ModSetting = V.require("ModSetting")
+
+local VoxelGrid = {}
+
+-- the key under options.modOptions.DRAMATIC_SHAPE, shared by the row in
+-- OPTIONS and the mod manager's own settings page for this mod
+VoxelGrid.KEY = "grid"
+VoxelGrid.LABEL = "V-GRID"
+
+-- How far toward black a seam pulls the surface it cuts across. The
+-- wireframe reads as a shading of the model rather than an overlay drawn
+-- on top of it, so it darkens what is already there instead of painting a
+-- colour -- a seam across dark grass and one across a white roof both stay
+-- in the palette they belong to.
+VoxelGrid.DARK = 0.45
+
+-- Line width, in display pixels. The scene canvas renders at window
+-- resolution and composites 1:1, so a canvas pixel IS a display pixel and
+-- 1.0 here is the one-pixel wireframe.
+VoxelGrid.WIDTH = 1.0
+
+-- where it persists and the rows that cycle it (see ModSetting)
+VoxelGrid.setting = ModSetting.new(VoxelGrid.KEY, VoxelGrid.LABEL,
+                                   { false, true }, { "OFF", "ON" })
+
+-- A pass that needs the wireframe whatever the player left the row on sets
+-- this for the length of its own draw and puts it back after. nil means
+-- "follow the setting", which is every frame outside such a pass.
+--
+-- The overworld battle is the one user: a fight is a STAGED shot, not the
+-- world being walked around in, and the seams are what make it read as
+-- constructed rather than as a photograph of somewhere. The row still owns
+-- what free-roam looks like, and is not written to -- switching the mode off
+-- mid-battle would silently rewrite the player's own setting.
+VoxelGrid.override = nil
+
+function VoxelGrid.enabled()
+  if VoxelGrid.override ~= nil then return VoxelGrid.override end
+  return VoxelGrid.setting:get() and true or false
+end
+
+function VoxelGrid.set(enabled, game)
+  return VoxelGrid.setting:setIndex(enabled and 2 or 1, game)
+end
+
+function VoxelGrid.toggle(game)
+  return VoxelGrid.setting:cycle(game)
+end
+
+function VoxelGrid.sync(value)
+  VoxelGrid.setting:sync(value and true or false)
+end
+
+function VoxelGrid.row()
+  return VoxelGrid.setting:row()
+end
+
+return VoxelGrid

--- a/mods/dramatic_shape/lib/VoxelScene.lua
+++ b/mods/dramatic_shape/lib/VoxelScene.lua
@@ -1,0 +1,756 @@
+﻿-- Voxel world mode: assemble and draw one frame of the 3D scene.
+--
+-- World space is world pixels and shares its origin with the 2D paths, so
+-- the terrain mesh needs no transform at all and a connected map just
+-- translates by the same (ox, oy) the flat renderer already offsets it by.
+--
+-- Order is: the sun's shadow pass, then terrain, then characters, then a 2D
+-- overlay for the field FX. There is no y-sort anywhere -- the depth buffer
+-- resolves occlusion, which is the whole point of the mode. Walk behind a
+-- building and the building is simply in front.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local Mat4 = V.require("Mat4")
+local Voxel3D = V.require("Voxel3D")
+local ShadowMap = V.require("ShadowMap")
+local ChunkMesher = V.require("ChunkMesher")
+local SpriteBillboards = V.require("SpriteBillboards")
+local TileShape = V.require("TileShape")
+local TerrainAtlas = V.require("TerrainAtlas")
+local Voxel = V.require("VoxelState")
+local Sky = V.require("Sky")
+local DayNight = V.require("DayNight")
+local PaletteFX = require("src.render.PaletteFX")
+local Map = require("src.world.Map")
+
+local VoxelScene = {}
+
+-- What the active display mode actually paints with.
+--
+-- paletteFor hands back a map's RAW SGB zone palette, and that is not what
+-- any of the non-colour modes draw. The flat path runs it through
+-- PaletteFX.effectiveColors on the way to the shade-remap shader, and that
+-- call IS where GRAY, INVERTED and CLASSIC happen -- OG / OG INV replace
+-- the palette with the DMG greys (inverted for the latter), CLASSIC
+-- replaces it with the green DMG set, and GBC INV permutes the zone's own
+-- shades. GBC and RED++ pass through untouched.
+--
+-- This pass has no shader to apply that in: colour is baked into the atlas
+-- and into the sprite sheets ahead of the draw, so it has to run the same
+-- transform itself. Without it every mode that is not already a colour mode
+-- comes through wearing the SGB palette -- grey and inverted both rendering
+-- as plain SGB blue.
+local function modeColors(paletteFor, map)
+  local c = paletteFor and paletteFor(map) or nil
+  return PaletteFX.effectiveColors(c)
+end
+
+VoxelScene._modeColors = modeColors   -- named for the suite
+
+-- ------------------------------------------------------------------ sky --
+--
+-- The void behind the diorama is SKY, at every rung -- so the world reads as
+-- standing under something rather than floating on a black plate.
+--
+-- What is up there differs by rung, and the sky follows it rather than being
+-- retuned for each. At 75 degrees the camera is pitched far enough over that
+-- the horizon is genuinely in frame, and the bands run down to meet it. At the
+-- steeper rungs the horizon is above the top edge and the void that shows is
+-- where the ground runs OUT -- past the map edge, past the curve -- so the
+-- bands take a fixed slice of the frame instead (lib/Sky.lua, Sky.SPAN) and the
+-- haze below them fills the rest.
+--
+-- INDOORS THERE IS NO SKY. A house, a cave or a gym is a room with a
+-- ceiling, and the void past its walls is the outside of a box, not open
+-- air. Map.isOutdoor is the same test the engine uses for door SFX and the
+-- town map, and the same one Structures already asks to decide whether a
+-- map rings with trees.
+--
+-- The colour is a four-shade ramp shaped like a world palette so the
+-- display mode can transform it exactly like one: GRAY gets a grey sky,
+-- CLASSIC a green one, GBC INV a dark one, and the colour modes the blue.
+-- A hardcoded blue would sit wrong in every non-colour mode -- the same
+-- mismatch the terrain bake had.
+--
+-- This ramp is the FLAT sky -- what a caller clears the void to. The free-roam
+-- camera's banded sky has a palette of its own (lib/Sky.lua), transformed the
+-- same way by the same seam; they are separate because the flat one also has to
+-- serve an indoor void and a battle's arena, which want a colour rather than a
+-- sky.
+local SKY_SHADES = { { 222, 242, 255 }, { 135, 196, 240 },
+                     { 64, 120, 192 }, { 16, 40, 80 } }
+local SKY_SHADE = 2       -- the ramp's "sky" proper; 1 is its highlight
+
+-- the ramp as the display mode has it, which is the only form anything here
+-- should be reading it in
+local function skyRamp()
+  return PaletteFX.effectiveColors(SKY_SHADES) or SKY_SHADES
+end
+
+-- Full strength at every rung: the sky is painted wherever the diorama is.
+--
+-- The ramp that is left is for ARRIVAL alone. Switching the mode on eases the
+-- camera up from flat, and the sky comes up with it over the first few degrees
+-- rather than appearing whole on the keypress -- which is also what keeps a
+-- top-down camera, where there is no void worth speaking of, from painting one.
+local SKY_FADE_DEG = 8
+
+local function skyStrength(angleRad)
+  local deg = math.deg(angleRad or 0)
+  if deg <= 0 then return 0 end
+  local t = deg / SKY_FADE_DEG
+  return t < 1 and t or 1
+end
+
+-- One shade off the sky ramp, transformed by the display mode, as an
+-- {r, g, b, a} in 0..1. `shade` picks the rung (SKY_SHADE is the sky
+-- proper; 4 is its darkest, which is what an indoor void wants).
+function VoxelScene.skyShade(shade, alpha)
+  local shades = skyRamp()
+  local c = shades[shade] or SKY_SHADES[shade] or SKY_SHADES[SKY_SHADE]
+  return { c[1] / 255, c[2] / 255, c[3] / 255, alpha or 1 }
+end
+
+-- The sky `map` stands under at strength `t`, or nil where there is no sky
+-- to paint: indoors, or with the horizon out of frame.
+--
+-- One flat colour, which is what a caller that only needs something to clear the
+-- void to wants -- the overworld battle's arena shot is one of those. The
+-- gradient is added on top of this by skyFor, for the free-roam camera alone.
+function VoxelScene.skyColor(map, t)
+  if not (map and map.def and Map.isOutdoor(map.def)) then return nil end
+  if not t or t <= 0 then return nil end
+  local sky = VoxelScene.skyShade(SKY_SHADE, t)
+  -- outdoors the flat fill follows the CLOCK: it becomes the hour's haze --
+  -- gold at dusk, navy at night -- so a battle staged on the map at
+  -- midnight is under a midnight void, not a noon one. Free-roam is
+  -- unchanged by this: Sky.dress overwrites the fill with the same value.
+  local haze = Sky.haze()
+  if haze then sky[1], sky[2], sky[3] = haze[1], haze[2], haze[3] end
+  return sky
+end
+
+-- The free-roam sky: the flat one above, dressed with the banded gradient
+-- (lib/Sky.lua).
+--
+-- Only here, and deliberately. This is the sky the walking camera stands under,
+-- where the horizon is a quarter of the way down the frame at the top rung and
+-- one flat blue reads as a wall of paint. A battle is a staged shot with its own
+-- placed camera whose horizon sits above the frame entirely, so it keeps the
+-- flat fill it has always had -- there is no gradient to see from down there,
+-- and the arena's look is not this rung's to change.
+local function skyFor(map)
+  local sky = VoxelScene.skyColor(map, skyStrength(Voxel.angle))
+  if not sky then return nil end
+  return Sky.dress(sky)
+end
+
+VoxelScene._skyFor = skyFor           -- named for the suite
+VoxelScene._skyStrength = skyStrength
+
+-- A facing as a yaw about +Y, kept for callers that reason about which way
+-- an entity points (the mod exports it). The character cards themselves
+-- never yaw -- they face south and lean, like the flat game.
+local YAW = {
+  down = 0,
+  up = math.pi,
+  right = math.pi / 2,
+  left = -math.pi / 2,
+}
+
+-- The ground height a cell stands at, so a character on a ledge stands on
+-- top of it rather than sunk into it. Uses the same bottom-left collision
+-- tile the engine walks on (Map:cellTile).
+local function groundAt(map, cellX, cellY)
+  -- Off the map, cellTile border-extends into the map's borderBlock --
+  -- which on maps ringed with trees is a RAISED tile. The only entity
+  -- ever standing off-map is the player mid seam-step (placed one cell
+  -- before the connection entry), and the ground actually rendered
+  -- there is the departed neighbour's flat walkway: height 0. Without
+  -- this, crossing into such a map hoisted the walker tree-high for
+  -- exactly one step -- the "hops like a ledge" seam bug.
+  if not map:inBounds(cellX, cellY) then return 0 end
+  local shapes = TileShape.forMap(map)
+  local s = shapes[map:cellTile(cellX, cellY)]
+  if not s then return 0 end
+  -- a recessed class (water) still supports whatever stands on it; only
+  -- raised ground lifts the model.  Stairs never do: the class height is
+  -- the flight's TALL end, but the player enters at floor level and the
+  -- warp fires as they step in -- lifting them onto the geometry read as
+  -- climbing an invisible block
+  if s.art == "stair" then return 0 end
+  return s.h > 0 and s.h or 0
+end
+
+VoxelScene.YAW = YAW
+-- shared with the overworld battle, which stands its mons on map cells and
+-- needs the same answer about what height "the floor" is there
+VoxelScene.groundAt = groundAt
+
+-- Camera-ward pull distance for billboards (and the grass rows, which
+-- must keep their relative depth to feet): just enough that a leaned-back
+-- slab clears the wall it leans over. The lean flattens toward top-down,
+-- so the needed pull grows exactly as real occlusion stops mattering.
+function VoxelScene.pull(a)
+  return 6 + math.max(0, 16 * math.cos(a) - 8) / math.max(math.sin(a), 0.2)
+end
+
+-- The sheet frame and mirror flag the 2D path would draw for this pose
+-- (same tables as SpriteRenderer). Shared by the billboard pass and the
+-- shadow pass so a walking character's shadow swings its legs too.
+local function frameFor(def, facing, phase, flip)
+  local SR = require("src.render.SpriteRenderer")
+  local frame, mirror = 0, false
+  if (def.frames or 1) > 1 then
+    frame = (def.walker and phase == 1) and SR.WALK[facing]
+            or SR.STAND[facing]
+    mirror = facing == "right"
+      or ((facing == "down" or facing == "up") and phase == 1 and flip)
+  end
+  return frame, mirror
+end
+
+-- FALLBACK ONLY (see castShadows below). Draw one entity's drop shadow as
+-- a decal: its current sprite frame as a single quad, flattened onto the
+-- ground along the sun line (Voxel3D.shadowMatrix). Runs inside
+-- beginShadows, which supplies the translucent black; the texture is only
+-- consulted for its alpha, so no palette work is needed.
+local function drawShadow(sprite, px, py, facing, phase, flip, gh, lift)
+  local def = sprite.def
+  local frame, mirror = frameFor(def, facing, phase, flip)
+  local mesh = SpriteBillboards.shadowQuad(def, frame)
+  if not mesh then return end
+  Voxel3D.draw(mesh, sprite:resolveImage(),
+               Voxel3D.shadowMatrix(px, py, gh, lift, mirror))
+end
+
+-- Where a billboard character's card stands: on the middle of its cell at
+-- height `y`, pivoted at the feet and tipped back by exactly the camera's
+-- pitch. The slab is built centred on its sprite plane (z = 0), so only the
+-- x anchor shifts; the relief bulges symmetrically front and back of it.
+--
+-- Shared by the solid draw and the silhouette below, so the two can never
+-- drift apart -- a silhouette standing anywhere but exactly behind the
+-- figure would read as a second character.
+local function billboardMatrix(px, py, y, mirror)
+  local Voxel = V.require("VoxelState")
+  local m = Mat4.mul(Mat4.translate(px + 8, y, py + 8),
+                     Mat4.rotateX(Voxel.angle - math.pi / 2))
+  if mirror then m = Mat4.mul(m, Mat4.scale(-1, 1, 1)) end
+  return Mat4.mul(m, Mat4.translate(-8, 0, 0))
+end
+
+local function billboardPull()
+  local Voxel = V.require("VoxelState")
+  return VoxelScene.pull(math.max(Voxel.angle, 0.05))
+end
+
+-- An authored FIGURE's card -- a person the tileset draws INTO a piece of
+-- furniture, cut out by the profile's mask (Structures.buildFigures). It is
+-- a sprite, so it gets the sprite treatment: the mesh arrives in its own
+-- local space with its feet on y = 0, and this stands it at its drawn
+-- position and tips it back by exactly the camera's pitch -- the same
+-- pivot-at-the-feet lean billboardMatrix gives a character, so the man on
+-- the Pokemon Center couch reads face-on at every tilt like the NPCs
+-- around him. No cell centring: unlike a character he is not standing on a
+-- cell, he is standing where he was drawn, which may straddle two.
+local function figureMatrix(f, offX, offZ)
+  local Voxel = V.require("VoxelState")
+  return Mat4.mul(Mat4.translate(f.wx + (offX or 0), f.y, f.wz + (offZ or 0)),
+                  Mat4.rotateX(Voxel.angle - math.pi / 2))
+end
+
+-- What the sun sees: the same card UNLEANED and flattened, exactly as
+-- Voxel3D.casterMatrix does it for a character.
+local function figureCaster(f, offX, offZ)
+  return Mat4.mul(
+    Mat4.translate(f.wx + (offX or 0), f.y, f.wz + (offZ or 0)),
+    Mat4.scale(1, 1, 0))
+end
+
+-- Every figure on `map`, drawn with `draw(mesh, model, caster)`.
+local function eachFigure(map, offX, offZ, draw)
+  for _, f in ipairs(ChunkMesher.figures(map) or {}) do
+    draw(f.mesh, figureMatrix(f, offX, offZ), figureCaster(f, offX, offZ))
+  end
+end
+
+-- Draw one posed entity. Returns true if 3D geometry carried it, false
+-- when nothing could be built and the caller should fall back.
+-- `colors` is the 4-color world palette the entity stands under in the SGB
+-- modes (nil under RED++/trueColor): the 2D path colorizes sprites with a
+-- screen-space shader the voxel canvas never runs through, so the model's
+-- texture gets the palette baked in instead (TerrainAtlas.forSprite).
+-- `lift` raises the figure off the ground plane (ledge hops arc UP in 3D,
+-- where the 2D path could only slide the sprite north).
+local function drawEntity(sprite, px, py, facing, phase, flip, gh, colors,
+                          lift)
+  local def = sprite.def
+  local tex = sprite:resolveImage()
+  if colors and not def.trueColor then
+    tex = TerrainAtlas.forSprite(def.image, colors) or tex
+  end
+  local y = gh + (lift or 0)
+
+  -- pick the very frame the 2D path would draw (same tables). The card
+  -- always faces SOUTH -- the direction the 2D game implies -- and only
+  -- LEANS BACK, pivoting at its feet, by exactly the camera's pitch, so
+  -- at every tilt level the sprite reads face-on like the flat game.
+  -- No camera-tracking yaw: every sprite leans in parallel.
+  local frame, mirror = frameFor(def, facing, phase, flip)
+  local mesh = SpriteBillboards.mesh(def, frame)
+  if not mesh then return false end
+  -- Camera-ward pull (applied per vertex in the shader, along each
+  -- vertex's own eye ray, so it is a PURE depth bias with zero screen
+  -- drift): lets the leaned-back head win against the wall it leans
+  -- OVER while a character genuinely BEHIND a building is dozens of
+  -- pixels deeper and still loses, so real occlusion works.
+  -- the same card UNLEANED -- and SNUGGED, exactly as the sun stored it
+  -- (castShadows draws this mesh through ShadowMap.snug) -- is where each
+  -- vertex asks whether the light reached it; see ShadowMap.snug for why
+  -- the lookup must match the stored transform to the letter
+  Voxel3D.draw(mesh, tex, billboardMatrix(px, py, y, mirror),
+               billboardPull(),
+               ShadowMap.snug(Voxel3D.casterMatrix(px, py, y, mirror)))
+  return true
+end
+
+VoxelScene.drawEntity = drawEntity
+
+-- The player's silhouette, for wherever the scenery is standing in front of
+-- them (Voxel3D.beginGhost inverts the depth test around this call).
+--
+-- The same flat card the solid pass and the sun pass draw. That it has no
+-- self-overlap is what makes it safe here: with the depth test inverted, a
+-- mesh carrying both front and back faces would read its own back faces as
+-- "behind something" and repaint the figure on open ground, occluded or
+-- not. One quad cannot do that, and cannot double-blend into a mottled
+-- patch either. A silhouette is an outline, so an outline is the right
+-- mesh for it.
+local function drawGhost(p)
+  local def = p.sprite.def
+  local frame, mirror = frameFor(def, p.facing, p.phase, p.flip)
+  local mesh = SpriteBillboards.shadowQuad(def, frame)
+  if not mesh then return end
+  local tex = p.sprite:resolveImage()
+  if p.colors and not def.trueColor then
+    tex = TerrainAtlas.forSprite(def.image, p.colors) or tex
+  end
+  local y = p.gh + (p.lift or 0)
+  Voxel3D.draw(mesh, tex, billboardMatrix(p.px, p.py, y, mirror),
+               billboardPull())
+end
+
+-- Render the world. `state` is the OverworldState; `vw`/`vh` the world view
+-- size in world pixels; `w`/`h` the pixel size of the canvas to render
+-- into; `paletteFor(map)` yields a map's 4-color world palette (nil in the
+-- color modes whose atlas is already true color). Returns the finished
+-- canvas, or nil if the 3D pass could not run (headless, no depth support)
+-- so the caller can fall back to 2D.
+-- The last live-set key, so eviction only runs when the neighbourhood
+-- actually changes (a map crossing), not every frame.
+local lastLiveKey = nil
+
+-- Request everything `state`'s frame wants and evict what it no longer
+-- does; returns the current map's terrain mesh (or nil while it builds)
+-- and the neighbour meshes ready to draw. render() calls this for the
+-- frame it is drawing, and the pipeline's update hook calls it EVERY
+-- frame -- including the frames a warp's Transition covers, when the
+-- world pass is off. That update-side call is what lets a door fade hide
+-- the destination's build: the map swaps behind the fade, and waiting
+-- for the first visible frame to request meshes would show the flat
+-- fallback while the first slices run.
+function VoxelScene.prefetch(state)
+  local Voxel = V.require("VoxelState")
+
+  -- The live set is the current map plus its rendered neighbours. When
+  -- it changes, everything outside it (and the previous set, which
+  -- ChunkMesher retains so stepping into a house keeps the town warm)
+  -- is evicted -- meshes released, analysis dropped -- so memory stays
+  -- bounded by the neighbourhood instead of growing with every area
+  -- ever visited.
+  local liveKey = state.map.id
+  local live = { [state.map.id] = true }
+  for _, nb in ipairs(state.neighbors or {}) do
+    live[nb.map.id] = true
+    liveKey = liveKey .. "|" .. nb.map.id
+  end
+  if liveKey ~= lastLiveKey then
+    lastLiveKey = liveKey
+    ChunkMesher.setLive(live)
+    -- RED++ bakes one atlas per map, so its animated copy is per map too
+    -- and is bounded by the same neighbourhood
+    TerrainAtlas.setLive(live)
+  end
+
+  -- masks: where connected neighbour BODIES sit, so the border ring is
+  -- suppressed under them (see runGeometry)
+  local masks = {}
+  for _, nb in ipairs(state.neighbors or {}) do
+    masks[#masks + 1] = { nb.ox, nb.oy,
+                          nb.ox + nb.map.def.width * 32,
+                          nb.oy + nb.map.def.height * 32 }
+  end
+
+  -- Builds are asynchronous (ChunkMesher.pump runs in the pipeline's
+  -- update): request what this frame wants and draw what is ready.
+  -- The current map draws its body-only mesh while the full one (the
+  -- border ring) is still building -- a seam crossing promotes a
+  -- neighbour whose body is already cached, and the ring pops in a few
+  -- frames later, mostly hidden behind the map just left. A neighbour
+  -- missing its body-only mesh draws its cached FULL mesh instead -- a
+  -- crossing demotes the map just left, and it must not vanish from
+  -- behind the player while its body variant builds; its ring is
+  -- already masked out under this map's body, so the stand-in is safe.
+  local terrain = ChunkMesher.request(state.map, false, masks, true)
+  if not terrain then
+    terrain = ChunkMesher.peek(state.map, true)
+  end
+  local nbMesh = {}
+  for i, nb in ipairs(state.neighbors or {}) do
+    nbMesh[i] = ChunkMesher.request(nb.map, true)
+                or ChunkMesher.peek(nb.map, false)
+  end
+  Voxel.ready = terrain ~= nil
+  return terrain, nbMesh
+end
+
+-- Capture every entity's pose for this frame. pose() advances the hop /
+-- surf bob / spinner timers, so it must be called EXACTLY once per entity
+-- per frame -- the sun pass and the character pass then read the same
+-- answer instead of disagreeing by a tick. Ghost NPCs live on a neighbour
+-- map, so their position, ground lookup and palette all belong to that
+-- map. pose() returns the VISUAL y (ledge hops arc it, surfing bobs it);
+-- the difference from the entity's base y becomes vertical LIFT in 3D, so
+-- a hop rises off the ground instead of sliding north.
+-- Returns the pose list and, separately, the PLAYER's entry in it (nil
+-- during a Fly animation, which draws the player itself and is skipped
+-- below). Only that one entry gets the see-through treatment: NPCs and the
+-- ghosts standing on a neighbour map are left to honest occlusion, because
+-- it is only your own character you cannot afford to lose behind a roof.
+local function posesOf(state, spriteColors)
+  local colors = spriteColors(state.map)
+  local posed = {}
+  local me = nil
+  for _, g in ipairs(state.ghosts or {}) do
+    local sprite, vx, vy, facing, phase, flip = g.npc:pose()
+    posed[#posed + 1] = {
+      sprite = sprite, px = vx + g.ox, py = g.npc.py + g.oy,
+      facing = facing, phase = phase, flip = flip,
+      gh = groundAt(g.map or state.map, g.npc.cellX, g.npc.cellY),
+      lift = g.npc.py - vy, colors = spriteColors(g.map or state.map),
+    }
+  end
+  for _, e in ipairs(state.entities or {}) do
+    if not (state.flyAnim and e == state.player) then
+      local sprite, vx, vy, facing, phase, flip = e:pose()
+      posed[#posed + 1] = {
+        sprite = sprite, px = vx, py = e.py,
+        facing = facing, phase = phase, flip = flip,
+        gh = groundAt(state.map, e.cellX, e.cellY),
+        lift = e.py - vy, colors = colors,
+      }
+      if e == state.player then me = posed[#posed] end
+    end
+  end
+  return posed, me
+end
+
+-- ------- the glint's drive
+--
+-- A reflection is something the VIEWPOINT does, so the window glint is fed
+-- by the camera's own travel rather than by a clock: its phase advances
+-- with distance covered and its strength fades in over a few steps of
+-- walking and back out within a beat of standing still. Stand still and
+-- the glass is still; move and the light crosses it.
+-- The rate is slow on purpose: the sweep pattern lives in the pane's own
+-- texels (see the scene shader), so this is a FRACTION of a texel per world
+-- pixel walked -- one full pass of the glint across a pane per eight or so
+-- cells of travel, with no frame ever jumping it far enough to strobe.
+VoxelScene.GLINT_RATE = 0.05     -- radians of sweep per world pixel travelled
+VoxelScene.GLINT_IN = 0.12      -- strength gained per moving frame
+VoxelScene.GLINT_OUT = 0.08     -- and lost per resting frame
+
+function VoxelScene.glintStep(g, cx, cy)
+  local dist = 0
+  if g.x then
+    dist = math.abs(cx - g.x) + math.abs(cy - g.y)
+  end
+  g.x, g.y = cx, cy
+  g.phase = ((g.phase or 0) + dist * VoxelScene.GLINT_RATE) % (2 * math.pi)
+  if dist > 0.05 then
+    g.amp = math.min(1, (g.amp or 0) + VoxelScene.GLINT_IN)
+  else
+    g.amp = math.max(0, (g.amp or 0) - VoxelScene.GLINT_OUT)
+  end
+  return g
+end
+
+local glint = {}
+
+-- A stamp of everything the sun pass depends on. Nothing in it moving
+-- means the shadow map it produced last frame is still exactly right, and
+-- redrawing the whole world from the sun would buy nothing -- which is
+-- most of a dialog, a menu, or any moment standing still.
+local sigBuf = {}
+local function shadowSignature(terrain, nbMesh, posed, cx, cy, vw, vh)
+  local n = 0
+  local function put(v)
+    n = n + 1
+    sigBuf[n] = v
+  end
+  -- quarter-pixel camera granularity: the light frustum is snapped to
+  -- whole texels anyway, each a third of a world pixel
+  put(math.floor(cx * 4))
+  put(math.floor(cy * 4))
+  -- the view size and the camera PITCH are both what the light frustum is
+  -- fitted to (a lower camera sees further north, so the box grows), so a
+  -- zoom step, a window resize or a rung change invalidates the map even
+  -- standing perfectly still
+  put(vw); put(vh)
+  put(math.floor((V.require("VoxelState").angle or 0) * 512))
+  -- the sun itself: the cycle swings the shear as the clock runs, and a map
+  -- lit from somewhere new must be redrawn from there too. Quantised by the
+  -- rig's own step (DayNight.rigTime), so a running cycle redraws the map a
+  -- few times a minute rather than every frame.
+  put(math.floor(ShadowMap.KX * 128))
+  put(math.floor(ShadowMap.KZ * 128))
+  put(tostring(terrain))
+  for i = 1, #nbMesh do put(tostring(nbMesh[i])) end
+  for _, p in ipairs(posed) do
+    put(p.sprite.def.image)
+    put(p.px); put(p.py); put(p.gh); put(p.lift or 0)
+    put(p.facing); put(p.phase); put(p.flip and 1 or 0)
+  end
+  for i = n + 1, #sigBuf do sigBuf[i] = nil end
+  return table.concat(sigBuf, ",")
+end
+
+-- The sun pass: render the scene once from the light, so the main pass can
+-- ask any fragment whether the sun reached it. Every caster the main pass
+-- draws goes in -- the terrain mesh, which is where buildings, trees,
+-- ledges, signs and every prop live, plus one UPRIGHT card per character
+-- (Voxel3D.casterMatrix; the leaning slab is a trick for the camera, not
+-- for the sun) -- so shadows land on walls, roofs, ledges and passing NPCs
+-- as readily as on the floor.
+--
+-- Runs BEFORE Voxel3D.beginScene, because canvases do not nest. Grass is
+-- left out on purpose: thousands of tufts would cast a speckle no bigger
+-- than the pixels it lands on, at the cost of the mesh being drawn twice.
+local function castShadows(state, terrain, nbMesh, posed, cx, cy, vw, vh,
+                           atlasFor)
+  if not ShadowMap.available() then return end
+  local sig = shadowSignature(terrain, nbMesh, posed, cx, cy, vw, vh)
+  if not ShadowMap.stale(sig) then return end
+  if not ShadowMap.begin(cx, cy, vw, vh) then return end
+
+  ShadowMap.draw(terrain, atlasFor(state.map), nil)
+  for i, nb in ipairs(state.neighbors or {}) do
+    ShadowMap.draw(nbMesh[i], atlasFor(nb.map),
+                   Mat4.translate(nb.ox, 0, nb.oy))
+  end
+  -- flower billboards live outside the terrain mesh (they draw after the
+  -- characters, pulled -- see render), but the sun still sees them: a
+  -- handful of cutouts per meadow, unlike the grass left out below.
+  -- Every thin card from here down is SNUGGED toward the sun along its own
+  -- ray (ShadowMap.snug) so its shadow keeps contact with its feet instead
+  -- of starting a bias-width away.
+  ShadowMap.draw(ChunkMesher.flowers(state.map), atlasFor(state.map),
+                 ShadowMap.snug(nil))
+  for _, nb in ipairs(state.neighbors or {}) do
+    ShadowMap.draw(ChunkMesher.flowers(nb.map), atlasFor(nb.map),
+                   ShadowMap.snug(Mat4.translate(nb.ox, 0, nb.oy)))
+  end
+  -- authored figures cast too, for the same reason the flowers do: a
+  -- handful of cards per map, and a person with no shadow reads as pasted on
+  eachFigure(state.map, 0, 0, function(mesh, _, caster)
+    ShadowMap.draw(mesh, atlasFor(state.map), ShadowMap.snug(caster))
+  end)
+  for _, nb in ipairs(state.neighbors or {}) do
+    eachFigure(nb.map, nb.ox, nb.oy, function(mesh, _, caster)
+      ShadowMap.draw(mesh, atlasFor(nb.map), ShadowMap.snug(caster))
+    end)
+  end
+  for _, p in ipairs(posed) do
+    local def = p.sprite.def
+    local frame, mirror = frameFor(def, p.facing, p.phase, p.flip)
+    local mesh = SpriteBillboards.shadowQuad(def, frame)
+    if mesh then
+      ShadowMap.draw(mesh, p.sprite:resolveImage(),
+                     ShadowMap.snug(
+                       Voxel3D.casterMatrix(p.px, p.py, p.gh + (p.lift or 0),
+                                            mirror)))
+    end
+  end
+
+  ShadowMap.finish(sig)
+end
+
+function VoxelScene.render(state, w, h, vw, vh, paletteFor)
+  -- With nothing cached at all (the first frame of a fresh toggle),
+  -- return nil: the engine keeps the 2D path for the frame and
+  -- Voxel.ready holds the camera tween at flat, so the switch waits
+  -- invisibly instead of freezing or tilting an empty stage.
+  local terrain, nbMesh = VoxelScene.prefetch(state)
+  if not terrain then return nil end
+
+  local cam = state.camera
+  local cx, cy = cam.x + vw / 2, cam.y + vh / 2
+
+  -- the hour's light, before anything is cast or drawn: point the shared
+  -- rig at the clock (or at noon, indoors -- a cave at midnight is exactly
+  -- as dark as a cave at noon) and set the tint the scene shader multiplies
+  -- every surface by. A CANOPY map (Viridian Forest) is the case between:
+  -- the rig stays at noon and no sky is painted, but the hour's tint still
+  -- falls through the leaves -- night reaches a forest floor.
+  local outdoor = state.map.def and Map.isOutdoor(state.map.def) or false
+  DayNight.applyRig(outdoor)
+  Voxel3D.tint = DayNight.tint(outdoor or DayNight.isCanopy(state.map))
+  -- and the window glass: the tileset's own panes (found in its art --
+  -- GlassMask), lit after dark. Outdoors only, like everything the clock
+  -- touches, which also keeps any pane-shaped art in an interior tileset
+  -- from picking up a glint.
+  local GlassMask = V.require("GlassMask")
+  Voxel3D.glassMask = outdoor and GlassMask.texture(state.map.tileset) or nil
+  Voxel3D.glassNight = outdoor and DayNight.windowLight() or 0
+  local g = VoxelScene.glintStep(glint, cx, cy)
+  Voxel3D.glassPhase, Voxel3D.glassGlint = g.phase, g.amp
+
+  local function atlasFor(map)
+    return TerrainAtlas.forMap(map, modeColors(paletteFor, map))
+  end
+
+  -- sprite palettes only exist in the SGB modes; under RED++ the OBP bake
+  -- inside sprite:resolveImage() already colors the sheet
+  local function spriteColors(map)
+    if PaletteFX.usesGbcPack() then return nil end
+    return modeColors(paletteFor, map)
+  end
+
+  local posed, me = posesOf(state, spriteColors)
+  castShadows(state, terrain, nbMesh, posed, cx, cy, vw, vh, atlasFor)
+
+  if not Voxel3D.beginScene(w, h, cx, cy, vw, vh, skyFor(state.map)) then
+    return nil
+  end
+
+  Voxel3D.draw(terrain, atlasFor(state.map), nil)
+  for i, nb in ipairs(state.neighbors or {}) do
+    Voxel3D.draw(nbMesh[i], atlasFor(nb.map),
+                 Mat4.translate(nb.ox, 0, nb.oy))
+  end
+
+  -- Without a shadow map (headless, or a driver that could not make the
+  -- canvas) the old flat decals stand in: ground-only, characters only,
+  -- but better than a world with nothing under anybody. They go down
+  -- first, as decals the characters then stand over -- depth-tested
+  -- against the terrain just drawn (a shadow behind a building stays
+  -- hidden) but never depth-writing, so the grass pass at the end of the
+  -- frame still wins its feet-overdraw fights.
+  if not Voxel3D.shadowsActive() then
+    Voxel3D.beginShadows()
+    for _, p in ipairs(posed) do
+      drawShadow(p.sprite, p.px, p.py, p.facing, p.phase, p.flip, p.gh,
+                 p.lift)
+    end
+    Voxel3D.endShadows()
+  end
+
+  -- Sprite sheets from here to the figure pass: their texture coordinates
+  -- mean nothing to the tileset-shaped glass mask, so the glass is off or
+  -- the panes' atlas positions stripe the cast with lamplight at night
+  Voxel3D.glass(false)
+
+  -- The player's silhouette goes down BEFORE the characters, so the only
+  -- thing it can meet in the depth buffer is the WORLD -- terrain, buildings,
+  -- trees. Drawn after the solid pass it would meet the player's own card
+  -- instead, and every fragment of a figure sits behind the one that just
+  -- wrote it, so the silhouette would paint over the player at all times.
+  -- Every character then draws on top as usual, which leaves the silhouette
+  -- showing in exactly one situation: where the world hides them.
+  if me then
+    Voxel3D.beginGhost()
+    drawGhost(me)
+    Voxel3D.endGhost()
+  end
+
+  -- Characters carry no wireframe out here, whatever the V-GRID row says.
+  -- The seams are what makes the WORLD read as built out of voxels, and
+  -- the people walking around in it are the one thing that should read as
+  -- drawn instead -- a grid over a 16x16 sprite lands a line every couple
+  -- of display pixels and turns a face into a mesh. (The battle pass makes
+  -- the opposite call for its own combatants, deliberately: that is a
+  -- staged shot rather than the world being walked around in -- see
+  -- BattleBillboard.)
+  --
+  -- Characters, normally depth-tested: the camera-ward pull inside
+  -- drawEntity resolves the lean-over-the-wall-in-front case, and a
+  -- character genuinely behind a building is far deeper and loses the
+  -- test, so buildings and trees really occlude.
+  Voxel3D.seams(false)
+  for _, p in ipairs(posed) do
+    drawEntity(p.sprite, p.px, p.py, p.facing, p.phase, p.flip, p.gh,
+               p.colors, p.lift)
+  end
+  -- back on for everything textured from the atlas again -- figures, grass
+  -- and flowers all sample it, where the mask's coordinates are honest
+  Voxel3D.glass(true)
+  -- Authored figures, alongside the characters and with the same lean and
+  -- the same camera-ward pull -- they ARE characters as far as the artwork
+  -- is concerned, just ones the tileset draws instead of a sprite sheet.
+  -- Drawn after the walkers so a player standing in front of the couch
+  -- wins the overlap, which is the order the flat game draws them in.
+  local figPull = billboardPull()
+  eachFigure(state.map, 0, 0, function(mesh, model, caster)
+    Voxel3D.draw(mesh, atlasFor(state.map), model, figPull,
+                 ShadowMap.snug(caster))
+  end)
+  for _, nb in ipairs(state.neighbors or {}) do
+    eachFigure(nb.map, nb.ox, nb.oy, function(mesh, model, caster)
+      Voxel3D.draw(mesh, atlasFor(nb.map), model, figPull,
+                   ShadowMap.snug(caster))
+    end)
+  end
+  -- and the seams are back on for the terrain art that follows: grass and
+  -- flowers are the world's own drawing, not people
+  Voxel3D.seams(true)
+  -- tall grass last, pulled camera-ward exactly as far as the characters
+  -- were (same per-vertex shader bias, so grass never drifts either):
+  -- relative depth between a walker and the tuft row south of their feet
+  -- is preserved, so the row still overdraws feet -- the 3D version of
+  -- the GB's grass-over-feet trick -- while grass keeps losing to the
+  -- buildings it genuinely stands behind (far deeper than the pull).
+  local Voxel = V.require("VoxelState")
+  local pull = VoxelScene.pull(math.max(Voxel.angle, 0.05))
+  Voxel3D.draw(ChunkMesher.grass(state.map), atlasFor(state.map), nil, pull)
+  for _, nb in ipairs(state.neighbors or {}) do
+    Voxel3D.draw(ChunkMesher.grass(nb.map), atlasFor(nb.map),
+                 Mat4.translate(nb.ox, 0, nb.oy), pull)
+  end
+  -- flower billboards: pulled like the characters and the grass, MINUS
+  -- the depth of 8 world pixels along the view (8 sin a -- the camera
+  -- looks along (0, -cos a, -sin a), so that is exactly one tile row of
+  -- northness). A pure depth handicap with zero screen drift: every
+  -- flower is judged as if it stood one tile row further north. The
+  -- character card's feet plane sits at its cell's MIDDLE (py + 8), so
+  -- a flower on the walker's own cell (z +4 or +12 across the cell)
+  -- lands behind the card and the player obscures the patch they stand
+  -- ON, while the nearest flower of the cell south (+20) stays in front
+  -- and keeps overdrawing their feet.
+  local fpull = math.max(0, pull - 8 * math.sin(math.max(Voxel.angle, 0.05)))
+  -- flowers are snugged casters too, so they read their own shadowing
+  -- through the same snugged transform the sun stored them with
+  Voxel3D.draw(ChunkMesher.flowers(state.map), atlasFor(state.map), nil,
+               fpull, ShadowMap.snug(nil))
+  for _, nb in ipairs(state.neighbors or {}) do
+    Voxel3D.draw(ChunkMesher.flowers(nb.map), atlasFor(nb.map),
+                 Mat4.translate(nb.ox, 0, nb.oy), fpull,
+                 ShadowMap.snug(Mat4.translate(nb.ox, 0, nb.oy)))
+  end
+
+  return Voxel3D.endScene()
+end
+
+return VoxelScene

--- a/mods/dramatic_shape/lib/VoxelState.lua
+++ b/mods/dramatic_shape/lib/VoxelState.lua
@@ -1,0 +1,161 @@
+-- Voxel world mode: the camera angle and its tween.
+--
+-- Deliberately the same shape as src/render/Tilt.lua -- level 0 is off and
+-- 1..3 are the same 15/35/50 degree ladder, eased the same way. What
+-- differs is what the renderer does with the angle: tilt projects the flat
+-- world canvas as one rigid plane, voxel mode drives a real 3D camera over
+-- extruded terrain and voxel character models.
+--
+-- And because it is a real camera over real geometry, it has a rung tilt
+-- could never have: 75 degrees, low enough to read as a diorama shot from
+-- table height. Tilt's flat plane degenerates into a horizon line there,
+-- but geometry only gets more of itself to show.
+--
+-- The LEVEL is not ours. The engine's render_pipelines plumbing owns it --
+-- the options row, the hotkey, the ladder labels, persistence in
+-- save.options.pipelines.voxel, and the mutual exclusion with tilt -- and
+-- hands it to update() every frame. All this module keeps is the eased
+-- ANGLE that level implies, because the tween is renderer state and only
+-- the renderer knows what to do with a half-raised camera.
+--
+-- Purely presentational, like tilt and survey zoom: nothing here reaches
+-- collision, movement, triggers or scripts.
+
+local Voxel = {}
+
+-- FULL is a PRESET, not another angle: one rung that puts the whole mode in
+-- its intended state at once -- this camera, the miniature blur at full, the
+-- horizon flat, the view fitted -- so a player who wants "the diorama" picks
+-- it rather than assembling it from four rows. It sits directly after OFF
+-- because that is the order those two get used in.
+--
+-- Its ANGLE is 35 degrees, the same as the rung of that name. The duplicate
+-- in the table is deliberate: the ladder is a list of what each rung LOOKS
+-- like, and two rungs may look the same while meaning different things.
+Voxel.ANGLES_DEG = { 0, 35, 15, 35, 50, 75 }
+Voxel.ANGLE_LABELS = { "OFF", "FULL", "15", "35", "50", "75" }
+Voxel.MAX_LEVEL = #Voxel.ANGLES_DEG - 1
+
+-- the rung FULL sits on, so nothing has to hunt for it by label
+Voxel.FULL_LEVEL = 1
+
+function Voxel.isFull(level)
+  return (level or Voxel.level) == Voxel.FULL_LEVEL
+end
+
+-- ------- what the hotkey walks
+--
+-- The ANGLE rungs only, with FULL left out. The key is a display-mode
+-- cycler: pressing it should change the camera and nothing else, and FULL
+-- reaches in and rewrites four other settings. Landing on it by accident,
+-- mid-walk, would silently turn the blur to maximum and flatten the horizon
+-- with no indication that a keypress had done so. FULL stays on the OPTIONS
+-- row, which is where a preset that changes other rows belongs.
+Voxel.HOTKEY_ORDER = { 0, 2, 3, 4, 5 }   -- OFF, 15, 35, 50, 75
+
+-- The rung a press moves to from `level`.
+--
+-- A level that is not on the key's path -- FULL, reached from the menu --
+-- steps on from whichever rung shows the SAME camera it does. FULL is 35
+-- degrees, so a press from it goes to 50 rather than back to 35, and the key
+-- never appears to do nothing. Matched by ANGLE rather than by a hardcoded
+-- rung, so retuning FULL moves the key's answer with it.
+function Voxel.nextHotkeyLevel(level)
+  level = level or Voxel.level
+  local order = Voxel.HOTKEY_ORDER
+  local at = nil
+  for i, rung in ipairs(order) do
+    if rung == level then at = i break end
+  end
+  if not at then
+    local deg = Voxel.ANGLES_DEG[level + 1]
+    for i, rung in ipairs(order) do
+      if Voxel.ANGLES_DEG[rung + 1] == deg then at = i break end
+    end
+  end
+  if not at then return order[1] end
+  return order[at % #order + 1]
+end
+
+Voxel.level = 0
+Voxel.angle = 0
+Voxel.from = 0
+Voxel.goal = 0
+Voxel.t = 1
+
+-- Whether the scene has terrain to show for the current map. VoxelScene
+-- maintains it every frame; while the first mesh of a fresh toggle is
+-- still building, update() holds the camera tween at flat -- the 2D
+-- fallback IS the flat pose, so the switch waits invisibly instead of
+-- tilting an empty stage (or, before builds went asynchronous, freezing
+-- the whole frame for seconds).
+Voxel.ready = true
+
+Voxel.TWEEN_TIME = 0.25
+-- Camera distance as a multiple of the view height, and the matching field
+-- of view. Kept equal to Tilt.FOCAL so a given angle frames the world the
+-- same way in both modes; Voxel3D derives the FOV from it.
+Voxel.FOCAL = 1.0
+
+local function ease(t)
+  return t * t * (3 - 2 * t)
+end
+
+local function goalFor(level)
+  return math.rad(Voxel.ANGLES_DEG[level + 1] or 0)
+end
+
+function Voxel.setLevel(level)
+  level = math.floor(tonumber(level) or 0)
+  if level < 0 then level = 0 end
+  if level > Voxel.MAX_LEVEL then level = Voxel.MAX_LEVEL end
+  local goal = goalFor(level)
+  if goal ~= Voxel.goal or level ~= Voxel.level then
+    Voxel.from = Voxel.angle
+    Voxel.goal = goal
+    Voxel.t = 0
+    -- leaving flat: presume no terrain until the scene reports some, so
+    -- the tween's very first frame already waits instead of easing over
+    -- an empty stage (render() confirms readiness the same frame when
+    -- the meshes are already cached)
+    if Voxel.angle == 0 and goal > 0 then Voxel.ready = false end
+  end
+  Voxel.level = level
+end
+
+function Voxel.reset()
+  Voxel.level, Voxel.angle = 0, 0
+  Voxel.from, Voxel.goal, Voxel.t = 0, 0, 1
+end
+
+function Voxel.levelLabel(level)
+  return Voxel.ANGLE_LABELS[(level or Voxel.level) + 1] or "OFF"
+end
+
+-- The pipeline's per-frame tick. `level` is what the engine currently has
+-- the mode set to, so a hotkey press or an options row lands here as a new
+-- goal to ease toward rather than as a jump.  dt is real frame time, so
+-- fast-forward does not speed the camera up.
+function Voxel.update(dt, level)
+  if level ~= nil and level ~= Voxel.level then Voxel.setLevel(level) end
+  -- hold at flat until there is geometry to tilt over; easing OUT (goal
+  -- below the current angle) never waits
+  if Voxel.angle == 0 and Voxel.goal > 0 and not Voxel.ready then
+    return
+  end
+  if Voxel.t < 1 then
+    Voxel.t = math.min(1, Voxel.t + dt / Voxel.TWEEN_TIME)
+    Voxel.angle = Voxel.from + (Voxel.goal - Voxel.from) * ease(Voxel.t)
+  else
+    Voxel.angle = Voxel.goal
+  end
+end
+
+-- True while voxel mode is on *or* still easing out -- i.e. whenever the
+-- renderer must take the 3D path instead of the flat blit. Mirrors
+-- Tilt.active so the two gate the same way.
+function Voxel.active()
+  return Voxel.level > 0 or Voxel.angle > 0
+end
+
+return Voxel

--- a/mods/dramatic_shape/lib/WorldCurve.lua
+++ b/mods/dramatic_shape/lib/WorldCurve.lua
@@ -1,0 +1,101 @@
+-- Voxel world mode: the curved world -- the Animal Crossing horizon.
+--
+-- Every vertex is pushed DOWN by the square of its horizontal distance from
+-- the camera's focus:
+--
+--     y' = y - k * ((x - cx)^2 + (z - cz)^2)
+--
+-- and that is the whole effect. The ground you are standing on stays flat
+-- (a quadratic is nearly zero near its vertex -- at half a tile out the drop
+-- is a hundredth of a pixel), and the falloff accelerates with distance, so
+-- the far edge of the map bends away and rolls over a near horizon. The
+-- town reads as sitting on top of a small sphere.
+--
+-- WHAT IT IS NOT is a fisheye. A fisheye is a LENS -- a screen-space
+-- warp -- and it bends straight lines everywhere, including right in front
+-- of the player, and resamples every pixel to do it. On pixel art that
+-- means a blurred, crawling image and a bent HUD. This bends the WORLD
+-- instead: one line in the vertex shader, straight lines near the camera
+-- stay straight, and not a single pixel is resampled, so the art stays as
+-- crisp as it was.
+--
+-- Two properties are what keep it readable rather than nauseating, and both
+-- fall out of displacing along Y only:
+--
+--   Things stay UPRIGHT. The drop depends on where a column stands, not on
+--   how tall it is, so a building's whole column moves together -- the
+--   world tips away, the buildings on it do not lean.
+--   Shadows and the voxel grid RIDE ALONG. Both are worked out before the
+--   bend -- the shadow map in flat world space, the wireframe in model
+--   space -- so the bend carries them with it exactly as if it had been
+--   painted on. Nothing has to be recomputed and the light frustum never
+--   moves.
+--
+-- The strength is scaled by the VIEW HEIGHT, so a rung looks the same at
+-- every zoom: `amount` is the drop, in view-heights, one view-height out.
+
+-- the mod namespace (see main.lua): V.require loads a sibling module
+local V = ...
+
+local ModSetting = V.require("ModSetting")
+
+local WorldCurve = {}
+
+WorldCurve.KEY = "curve"
+WorldCurve.LABEL = "V-CURVE"
+
+-- The ladder, calibrated against the FAR EDGE of the visible ground -- a
+-- little over two view-heights out at the low camera rungs. Since the drop
+-- goes as the square, that edge falls `amount * 4` view-heights while the
+-- ground within a screen of the player barely moves, which is the whole
+-- shape of the effect: flat where you are playing, rolling where you are
+-- only looking.
+--
+-- 1 is a hint of roll at the frame edges, 2 is the Animal Crossing read,
+-- 3 is as far as it goes before the horizon closes inside the next block
+-- of the town -- which stops being a look and starts being an occlusion
+-- bug, since what has rolled away is still there to walk into. (The first
+-- cut ran 0.18/0.35/0.60 and every rung of it was a marble.)
+WorldCurve.AMOUNTS = { 0, 0.05, 0.10, 0.18 }
+
+WorldCurve.setting = ModSetting.new(WorldCurve.KEY, WorldCurve.LABEL,
+                                    { 0, 1, 2, 3 },
+                                    { "OFF", "1", "2", "3" })
+
+function WorldCurve.level()
+  return WorldCurve.setting:get() or 0
+end
+
+function WorldCurve.active()
+  return WorldCurve.level() > 0
+end
+
+-- The quadratic's coefficient for a view `vh` world pixels tall: the drop
+-- in world pixels per squared world pixel of distance. Zero when off, which
+-- is also the shader's "skip it" signal.
+function WorldCurve.k(vh)
+  local amount = WorldCurve.AMOUNTS[WorldCurve.level() + 1] or 0
+  if amount <= 0 or not vh or vh <= 0 then return 0 end
+  return amount / vh
+end
+
+-- The same displacement the vertex shader applies, for the callers that
+-- have to agree with it on the CPU -- Voxel3D.project, which anchors the
+-- overworld's 2D field FX (the "!" bubble, the fishing rod, the Fly bird)
+-- to their ground points. Miss this and every one of them floats off its
+-- own feet the moment the ground under it bends.
+function WorldCurve.drop(k, cx, cy, wx, wz)
+  if k <= 0 then return 0 end
+  local dx, dz = wx - cx, wz - cy
+  return (dx * dx + dz * dz) * k
+end
+
+function WorldCurve.row()
+  return WorldCurve.setting:row()
+end
+
+function WorldCurve.sync(value)
+  WorldCurve.setting:sync(value)
+end
+
+return WorldCurve

--- a/mods/dramatic_shape/main.lua
+++ b/mods/dramatic_shape/main.lua
@@ -1,0 +1,751 @@
+-- Dramatic Shape Voxel Mod: a full 3D diorama overworld, shipped as a
+-- rendering pipeline mod.
+--
+-- The engine's render_pipelines registry (src/mods/Schemas.lua) lets a mod
+-- own part of the frame.  This mod registers two:
+--
+--   voxel      a drawWorld pipeline.  Instead of the flat tile blit, the
+--              overworld's terrain is extruded into real geometry, walked
+--              by a depth-buffered 3D camera, with characters as leaning
+--              sprite slabs and a shadow map throwing real cast shadows
+--              across whatever they land on.  Occlusion is the depth
+--              buffer, not a y-sort: walk behind a building and the
+--              building is simply in front.
+--
+--   tiltshift  a worldPresent pipeline -- the stage that post-processes
+--              the finished world BEFORE the UI composites over it.  A
+--              tilt-shift blur that sells the miniature-model look, on the
+--              diorama only, leaving text boxes and menus crisp.
+--
+-- Everything a display mode needs beyond the two draw functions -- the
+-- OFF/15/35/50 ladder, the options rows, the hotkeys, persistence in
+-- save.options.pipelines, the free-roam gate, the mutual exclusion with
+-- the engine's TILT mode -- is engine plumbing driven by the records
+-- below.  This file declares; lib/ draws.
+--
+-- Nothing here reaches collision, movement, triggers or scripts.  Voxel
+-- mode is purely presentational: it changes what the world LOOKS like and
+-- nothing about what it IS.
+
+local mod = ...
+
+-- ------- the mod namespace
+--
+-- lib/ modules require each other through V rather than package.path: a
+-- mod directory is not on it, and may live inside a mounted .love archive
+-- that plain require cannot reach.  Each module is loaded once, with V
+-- passed in as its vararg (`local V = ...`).
+
+local V = { mod = mod, path = mod.path }
+
+local function chunkFor(rel)
+  local source = mod:read(rel)
+  if not source then
+    error(("DRAMATIC_SHAPE: %s is missing -- reinstall the mod"):format(rel), 0)
+  end
+  local chunk, err = load(source, "@" .. mod.path .. "/" .. rel)
+  if not chunk then
+    error(("DRAMATIC_SHAPE: %s did not compile: %s"):format(rel, tostring(err)), 0)
+  end
+  return chunk
+end
+
+local modules = {}
+function V.require(name)
+  local hit = modules[name]
+  if hit ~= nil then return hit end
+  local value = chunkFor("lib/" .. name .. ".lua")(V)
+  modules[name] = value
+  return value
+end
+
+local dataFiles = {}
+function V.data(name)
+  local hit = dataFiles[name]
+  if hit ~= nil then return hit end
+  local value = chunkFor("data/" .. name .. ".lua")(V)
+  dataFiles[name] = value
+  return value
+end
+
+-- ------- pipelines
+
+local Voxel = V.require("VoxelState")
+local Voxel3D = V.require("Voxel3D")
+local VoxelScene = V.require("VoxelScene")
+local TiltShift = V.require("TiltShift")
+local ChunkMesher = V.require("ChunkMesher")
+local VoxelGrid = V.require("VoxelGrid")
+local WorldCurve = V.require("WorldCurve")
+local OverworldBattle = V.require("OverworldBattle")
+local BattleExit = V.require("BattleExit")
+local DayNight = V.require("DayNight")
+
+-- Forward declaration: the voxel pipeline's update hook (registered below)
+-- calls this, and it is defined further down with the settings it drives.
+-- Declared rather than left global -- a mod writing to _G would leak into
+-- every other mod's namespace.
+local applyFull
+
+-- The last VOID FILL the terrain was meshed under; see the update hook.
+-- The scene canvas's size, in FRAMEBUFFER PIXELS.
+--
+-- `ctx.width/height` are the window measured in LOVE UNITS
+-- (love.graphics.getDimensions), but the engine composites a pipeline's
+-- returned canvas with `draw(canvas, 0, 0, 0, 1/dpiX, 1/dpiY)` -- a scale
+-- that only covers the window when the canvas is at PIXEL resolution.
+-- Sizing it in units costs the DPI scale TWICE: the canvas is that much
+-- smaller, then it is drawn that much smaller again, so the diorama lands
+-- in the top-left corner at 1/dpi of the screen.  Desktop never sees it --
+-- units and pixels are the same thing there -- but on Android the DPI scale
+-- is the display density (2.625 on a 420dpi panel), and the world came out
+-- a third of the size in each direction.
+--
+-- So ask for the pixel dimensions rather than trusting the ctx.  That is
+-- the number a fixed engine would hand over, so this keeps working either
+-- way instead of double-correcting.  It also squares the FX pass: ctx.scale
+-- is ALREADY in pixels per world pixel (Zoom.scale over Renderer:fitScale,
+-- which measures the drawable), so the closures ctx.drawFx runs were being
+-- scaled for a canvas 2.6x bigger than the one they drew into.
+local function sceneSize(ctx)
+  if love.graphics and love.graphics.getPixelDimensions then
+    local pw, ph = love.graphics.getPixelDimensions()
+    if pw and ph and pw > 0 and ph > 0 then return pw, ph end
+  end
+  return ctx.width, ctx.height
+end
+
+local voidFill = { last = nil }
+function voidFill.check()
+  local TileRenderer = require("src.render.TileRenderer")
+  local now = TileRenderer.voidFill
+  if voidFill.last ~= nil and now ~= voidFill.last then
+    ChunkMesher.invalidate()   -- no map id: every ring on every map is stale
+  end
+  voidFill.last = now
+end
+
+mod.content.render_pipelines:register("voxel", {
+  label = "VOXEL",
+  levels = Voxel.ANGLE_LABELS,
+  -- 3 is the engine's TILT key, which this mode supersedes -- see the
+  -- hotkey block near the bottom of this file for how it is claimed
+  hotkey = "3",
+  -- above tiltshift, so the two sort together in the options list with the
+  -- mode first and its post-process under it
+  priority = 20,
+
+  -- Headless runs and drivers without a depth canvas or shader support
+  -- answer false here, and the engine keeps the vanilla 2D path -- which
+  -- is why no caller ever has to guard for a missing 3D pass.
+  available = function()
+    return Voxel3D.available()
+  end,
+
+  -- the engine hands over the live level; we ease the camera toward it.
+  -- pump() advances queued mesh builds inside a few-millisecond budget,
+  -- so entering voxel mode (and streaming neighbours while walking)
+  -- costs frames nothing visible -- the old synchronous build froze the
+  -- first frame for seconds. prefetch() runs here as well as in the
+  -- draw, because update ticks even while a warp's Transition covers
+  -- the screen: the destination's meshes start building the moment the
+  -- map swaps behind the fade, and the fade-covered frames get a wider
+  -- pump slice -- so stepping out of a door lands on terrain that is
+  -- already there instead of a flat flash.
+  update = function(dt, level)
+    -- FULL is a preset, so it is applied ON THE PRESS rather than held every
+    -- frame: it SETS the other rows and then leaves them alone. Holding them
+    -- would make the zoom keys and the wheel dead while the mode was on, and
+    -- would fight anyone who changed one deliberately.
+    applyFull(level)
+    Voxel.update(dt, level)
+    -- the day/night clock, on the same always-running tick: Pipelines.update
+    -- runs whatever the level, so time passes with the mode off, through
+    -- battles and menus, and a CYCLE evening falls mid-fight exactly as it
+    -- would mid-walk
+    DayNight.update(dt)
+    -- The overworld battle rides this hook rather than owning a pipeline of
+    -- its own, because it owns no pass of the FRAME: it draws under a battle
+    -- screen the engine composites, which is not a stage the registry has.
+    -- What it needs is a tick that keeps running once the overworld stops
+    -- being the top state, and this is one -- Game:update calls
+    -- Pipelines.update unconditionally, so it survives the transition wipe
+    -- and the whole battle. Ahead of the active() gate below, because a 3D
+    -- battle does not require the free-roam mode to be switched on.
+    OverworldBattle.update(dt)
+    -- VOID FILL picks the block the border ring is made of, and in this
+    -- mode that ring is BAKED INTO THE MESH rather than drawn each frame.
+    -- So the option has to reach the cache or nothing happens on screen
+    -- until the meshes are dropped for some other reason -- which reads
+    -- exactly like the option doing nothing at all. Polled rather than
+    -- hooked because the engine changes it from three places (the options
+    -- row, applyOptions on load, TileRenderer.setVoidFill) and none of
+    -- them announces it. Ahead of the active() gate, so switching it
+    -- while voxel mode is OFF still invalidates what is cached.
+    voidFill.check()
+    if not Voxel.active() then return end
+    local Game = require("src.core.Game")
+    local ow = Game and Game.overworld
+    if ow and ow.map and ow.camera then
+      pcall(VoxelScene.prefetch, ow)
+    end
+    ChunkMesher.pump(Game and Game.stack
+                     and Game.stack:top() ~= ow)
+  end,
+
+  drawWorld = function(ctx)
+    -- Terrain and characters are geometry; the field FX stay ordinary 2D
+    -- draws composited on top, anchored through the same camera the 3D
+    -- pass used (ctx.drawFx below).  The scene renders at the window's
+    -- PIXEL resolution (see sceneSize) so the 3D pass is crisp rather than
+    -- a magnified low-res image, while the FX closures keep drawing in
+    -- world-pixel units.
+    local sw, sh = sceneSize(ctx)
+    local canvas = VoxelScene.render(ctx.state, sw, sh,
+                                     ctx.vw, ctx.vh, ctx.paletteFor)
+    if not canvas then return nil end   -- fall back to the 2D path
+    if Voxel3D.beginOverlay() then
+      ctx.drawFx(function(wx, wy) return Voxel3D.project(wx, 0, wy) end,
+                 ctx.scale)
+      Voxel3D.endOverlay()
+    end
+    return canvas
+  end,
+
+  invalidate = function()
+    Voxel3D.invalidate()
+    OverworldBattle.invalidate()
+    ChunkMesher.invalidate()   -- no map id = every cached mesh
+  end,
+})
+
+mod.content.render_pipelines:register("tiltshift", {
+  label = "T-SHIFT",
+  levels = TiltShift.LABELS,
+  -- 6 is free: no engine branch claims it, so this one alone reaches the
+  -- registry by the documented route
+  hotkey = "6",
+  priority = 10,
+
+  update = function(dt, level)
+    TiltShift.update(dt, level)
+  end,
+
+  -- worldPresent, not present: the blur belongs on the diorama, not on the
+  -- dialog box in front of it.  A pass-through when the level is 0 or the
+  -- shader is unavailable, so the frame is untouched in every other case.
+  worldPresent = function(canvas)
+    return TiltShift.apply(canvas)
+  end,
+
+  invalidate = function()
+    TiltShift.invalidate()
+  end,
+})
+
+-- ------- this mod's own settings
+--
+-- Neither of these is a pipeline: they own no pass of the frame, they
+-- PARAMETERISE the voxel one, so they have nothing to put in drawWorld or
+-- present and the registry would rightly reject them.  Plain mod settings
+-- instead -- see ModSetting for where they persist and how the two rows
+-- each ends up on stay in step.
+
+-- ------- the FULL preset
+--
+-- Everything the mode wants switched to at once. Applied when the VOXEL row
+-- ARRIVES at FULL and not again, so the player can still move the camera or
+-- the zoom afterwards -- it is a starting point, not a lock.
+--
+-- Leaving FULL deliberately does NOT undo any of it. A preset that reverted
+-- would throw away whatever the player had changed since, and "put it back
+-- how it was" is not a thing this can know.
+local fullWas = nil
+
+applyFull = function(level)
+  local isFull = Voxel.isFull(level)
+  local was = fullWas
+  fullWas = isFull
+  if not isFull or was == true or was == nil then return end
+
+  local Game = require("src.core.Game")
+  local Pipelines = require("src.render.Pipelines")
+  local Zoom = require("src.render.Zoom")
+  local opts = Game.save and Game.save.options
+  if not opts then return end
+
+  -- the miniature blur at its strongest: FULL is the diorama look, and the
+  -- tilt-shift is most of what makes it read as a model
+  Pipelines.setLevel("tiltshift", Pipelines.maxLevel("tiltshift"))
+  Pipelines.syncOptions(opts)
+  -- the horizon flat. The curve bends the world away from a walking player,
+  -- which fights a fixed diorama framing
+  WorldCurve.setting:setIndex(1, Game)
+  -- and the view fitted to the window
+  opts.zoom = 0
+  Zoom.applyOptions(opts)
+  -- battles on the map too: FULL means the whole mode, and a fight is where
+  -- half of it is spent. Set rather than forced -- the row is gone from the
+  -- menu while FULL is on, but a save that already had it off gets it on.
+  OverworldBattle.setting:setIndex(1, Game)
+  -- and the battle screen the staged fight is composed for. WIDE re-lays that
+  -- screen out on a 304x144 surface, which moves every anchor the arena camera
+  -- is solved against (OverworldBattle.forceOG); FULL has just switched staged
+  -- fights on, so the layout follows them.
+  OverworldBattle.forceOG(Game)
+  -- and the sky on the clock on the wall: FULL pins DAYTIME to SYNC. Unlike
+  -- the rest of the preset this one IS held, not just set -- the row is off
+  -- the menu while FULL owns it (the rows hook below), so a value changed
+  -- under it could never be seen or changed back.
+  DayNight.forceSync(Game)
+  if Game.writeOptions then pcall(Game.writeOptions, Game) end
+end
+
+-- Whether a fight can be staged on the map, as far as the OPTIONS menu is
+-- concerned: 3D-BTL is on, or FULL is selected -- which owns that row and
+-- switches it on. Deliberately NOT gated on Voxel3D.available(): the engine
+-- offers a pipeline's row whether or not the hardware can run it
+-- (Pipelines.rows), so this mode's rows say ON on a machine without a depth
+-- buffer too, and a menu that claims 3D battles are on must not also offer the
+-- layout they cannot be drawn in.
+local function stagedBattles()
+  local Pipelines = require("src.render.Pipelines")
+  return OverworldBattle.enabled() or Voxel.isFull(Pipelines.level("voxel"))
+end
+
+local SETTINGS = {
+  { VoxelGrid.setting, "One-pixel wireframe along every voxel edge." },
+  { WorldCurve.setting,
+    "Bend the world down over the horizon, Animal Crossing style." },
+  { OverworldBattle.setting,
+    "Fight on the map: the battle draws over the nearest clear ground, "
+    .. "shot over the shoulder with a slow parallax drift." },
+  { DayNight.setting,
+    "What time it is outdoors: pin the sky to DAY, NIGHT, DUSK or DAWN, "
+    .. "let CYCLE run it -- ten minutes of sun, ten of moon, with the "
+    .. "shadows, the sky and the light following -- or SYNC it to the "
+    .. "clock on the wall, so Kanto's evening falls when yours does." },
+}
+
+local schema = {}
+for i, entry in ipairs(SETTINGS) do
+  schema[i] = entry[1]:schema(entry[2])
+end
+mod.options:define(schema)
+
+-- ------- this mod's hotkeys
+--
+--   3  VOXEL    cycle the camera ladder      (was 6; skips FULL)
+--   5  V-GRID   toggle the wireframe         (new)
+--   6  T-SHIFT  cycle the blur ladder        (was 9)
+--   7  V-CURVE  cycle the horizon bend       (new)
+--   8  3D-BTL   toggle overworld battles     (new)
+--
+-- Only 6 arrives by the documented route. Game:keypressed answers the
+-- engine's own display keys FIRST and returns -- 2 COLORS, 3 TILT, 4 ZOOM,
+-- 5 GBC FX -- and only then offers the key to Pipelines.hotkey, expressly
+-- so "a pipeline can never shadow one" (Schemas, render_pipelines.hotkey).
+-- 3 and 5 are two of those, and 7 and 8 belong to plain mod settings that
+-- own no pass and so have no registry to claim a key from at all.
+--
+-- So this wraps Game:keypressed. It is the invasive option and it is the
+-- only one: polling the keyboard in update() would fire alongside the
+-- engine's handler rather than instead of it, so 3 would cycle this mode
+-- AND the engine's TILT on the same press.
+--
+-- Consequences worth being explicit about: while this mod is enabled, TILT
+-- (3) and GBC FX (5) are unreachable by key. Both are still reachable on
+-- the OPTIONS menu, and TILT is the one this mode supersedes anyway -- the
+-- registry already forces it off whenever a world pipeline takes the pass.
+--
+-- Everything the engine does around a pipeline hotkey has to happen here
+-- too, so the work is DELEGATED rather than reimplemented: Pipelines.hotkey
+-- applies its own gate and ladder, and the three lines after it are the
+-- engine's own (syncOptions, the tilt exclusion, writeOptions).
+
+local HOTKEYS = {
+  ["3"] = "pipeline",           -- voxel, by its declared hotkey
+  ["6"] = "pipeline",           -- tiltshift, likewise
+  ["5"] = VoxelGrid.setting,
+  ["7"] = WorldCurve.setting,
+  ["8"] = OverworldBattle.setting,
+}
+
+do
+  local Game = require("src.core.Game")
+  local Pipelines = require("src.render.Pipelines")
+  local inner = Game.keypressed
+
+  function Game:keypressed(key)
+    local claim = HOTKEYS[key]
+    local top = self.stack and self.stack:top()
+    -- A screen with its own key handler gets the key first, exactly as the
+    -- engine's first branch does: typing a nickname must not toggle a
+    -- render mode. Only free-roam presses are ours to take.
+    if claim and not (top and top.onKeyPressed) then
+      if claim == "pipeline" then
+        -- 3 walks the ANGLE rungs and steps over FULL (Voxel.HOTKEY_ORDER),
+        -- so the registry's plain "advance one and wrap" is not what it
+        -- wants; 6 still is. The gate is the registry's own either way.
+        local stepped = false
+        if key == "3" then
+          if Pipelines.canToggle("voxel", top, self.overworld) then
+            Pipelines.setLevel("voxel",
+              Voxel.nextHotkeyLevel(Pipelines.level("voxel")))
+            stepped = true
+          end
+        else
+          stepped = Pipelines.hotkey(key, top, self.overworld) and true
+        end
+        if stepped then
+          Pipelines.syncOptions(self.save.options)
+          -- 3 is the key that used to turn TILT on and sits next to the one
+          -- that used to turn GBC FX on, and this mod has taken both away.
+          -- A player who left either running before enabling the mod would
+          -- otherwise have no way back to off, and both fight the diorama:
+          -- TILT is the flat fake of what this mode does for real, and GBC
+          -- FX is a full-screen present pass over the top of it. So the
+          -- VOXEL key clears them on EVERY press, not just the press that
+          -- switches the mode on -- cycling back round to OFF leaves them
+          -- off too, which is the state the key is now the only route to.
+          if key == "3" then
+            self.save.options.tilt = 0
+            self.save.options.gbcfx = 0
+            require("src.render.GBCFX").setLevel(0)
+          end
+          require("src.render.Tilt").setLevel(self.save.options.tilt or 0)
+          self:writeOptions()
+          return
+        end
+      elseif Pipelines.canToggle("voxel", top, self.overworld) then
+        -- All three answer to the voxel pass's own free-roam gate --
+        -- borrowed from the registry rather than restated, so a press
+        -- mid-warp or mid-cutscene is refused for the wireframe exactly when
+        -- it would be for the mode itself. Two of them parameterise that
+        -- pass; the third (3D-BTL) decides what a battle is drawn over, and
+        -- wants the same gate for a different reason: the answer is read
+        -- when the fight starts, so flipping it from inside one would be a
+        -- switch that appeared to do nothing.
+        claim:cycle(self)
+        -- 8 is one of the two ways staged battles get switched on, and they
+        -- pin BATTLE LAYOUT to OG (see the rows hook). The other two keys
+        -- parameterise the pass and leave the layout alone; the guard answers
+        -- for all three, so nothing here has to know which key it was.
+        if stagedBattles() then OverworldBattle.forceOG(self) end
+        return
+      end
+    end
+    return inner(self, key)
+  end
+end
+
+-- ------- the mode's rows, kept together
+--
+-- The engine splices a pipeline's row in beside TILT, because a display mode
+-- belongs with the other display modes; a mod's own ui.options.rows
+-- additions land at the END of the list. That left this mod's four rows in
+-- two places with unrelated engine rows between them, which reads as two
+-- unrelated features rather than one mode with settings.
+--
+-- So the plain settings are inserted directly after the last of this mod's
+-- PIPELINE rows instead of appended. Nothing else moves: the block lands
+-- where the engine already decided display modes go.
+local function insertGrouped(out, extra)
+  local anchor = nil
+  for i, row in ipairs(out) do
+    local id = type(row) == "table" and row.id
+    if id == "pipeline:voxel" or id == "pipeline:tiltshift" then anchor = i end
+  end
+  if not anchor then
+    for _, row in ipairs(extra) do out[#out + 1] = row end
+    return out
+  end
+  for i, row in ipairs(extra) do table.insert(out, anchor + i, row) end
+  return out
+end
+
+-- FULL owns every one of those settings, so while it is selected they are
+-- taken off the menu rather than left to be changed under it -- including
+-- T-SHIFT, which is a pipeline row the engine put there. A row that no
+-- longer decides anything is worse than no row.
+local function dropRow(out, id)
+  for i = #out, 1, -1 do
+    if type(out[i]) == "table" and out[i].id == id then table.remove(out, i) end
+  end
+  return out
+end
+
+-- call next() first and decorate what comes back, so every other mod's
+-- rows survive this one
+mod.hooks:wrap("ui.options.rows", function(next, game, rows)
+  local out = next(game, rows)
+  if type(out) ~= "table" then return out end
+  local Pipelines = require("src.render.Pipelines")
+  -- BATTLE LAYOUT is the ENGINE's row, and this is the one place the mod takes
+  -- one away. While a fight can be staged on the map, OG is the only layout it
+  -- can be composed in (OverworldBattle.forceOG), so the value is pinned there
+  -- and the row comes off the list on the same reasoning as the rows FULL owns:
+  -- a row that no longer decides anything is worse than no row. Nothing is
+  -- lost by switching 3D-BTL off -- the row is back, WIDE and all, on the same
+  -- keypress.
+  if stagedBattles() then
+    OverworldBattle.forceOG(game)
+    dropRow(out, "battleLayout")
+  end
+  if Voxel.isFull(Pipelines.level("voxel")) then
+    -- FULL keeps every mod row off the menu (the early return skips the
+    -- insert below), and holds DAYTIME at SYNC while the row is unreachable
+    DayNight.forceSync(game)
+    return dropRow(out, "pipeline:tiltshift")
+  end
+  local extra = {}
+  for _, entry in ipairs(SETTINGS) do extra[#extra + 1] = entry[1]:row() end
+  return insertGrouped(out, extra)
+end)
+
+-- The mod manager writes and persists on its own, so the only thing left
+-- to do is move our cached index and pick the new value up.
+mod.events:on("mod.options_changed", function(payload)
+  if not (payload and payload.mod == mod.id) then return end
+  for _, entry in ipairs(SETTINGS) do
+    if payload.key == entry[1].key then entry[1]:sync(payload.value) end
+  end
+  -- 3D-BTL switched on from the manager's page pins BATTLE LAYOUT exactly as
+  -- the OPTIONS row does. The manager persists its own value; this is the one
+  -- that has to follow it.
+  if stagedBattles() then OverworldBattle.forceOG() end
+  -- and DAYTIME changed from the manager's page while FULL owns it snaps
+  -- straight back to SYNC -- the OPTIONS row is hidden, but the manager's is
+  -- not, and FULL's pin must hold against both
+  local Pipelines = require("src.render.Pipelines")
+  if Voxel.isFull(Pipelines.level("voxel")) then DayNight.forceSync() end
+end)
+
+-- ------- keeping the geometry in step with the world
+--
+-- Terrain meshes are derived from a map's block layer, so anything that
+-- rewrites a block (a cut tree, a smashed rock, a script's replaceBlock)
+-- has to drop that map's cached mesh or the 3D world keeps showing the
+-- tree that is no longer there.  The 2D tile renderer invalidates its own
+-- caches off the same edit.
+
+-- refresh, not invalidate: the stale mesh keeps drawing while the
+-- replacement builds in the background, so a one-block edit (Cut, a
+-- door stamp, the tree regrowing on re-entry) repopulates in place
+-- instead of blinking the whole scene down to the flat 2D path
+mod.events:on("world.block_replaced", function(payload)
+  local mapId = payload and (payload.mapId or (payload.map and payload.map.id))
+  if mapId then ChunkMesher.refresh(mapId) end
+end)
+
+-- The event above is the ANNOUNCED edit -- OverworldState:replaceBlock
+-- emits it, which is the path Victory Road's barriers and a script's
+-- replaceBlock take. Several edits do not go through it:
+--
+--   Cut          swaps the tree block and rebuilds the 2D renderer
+--   the regrowth restores those blocks when the map is re-entered
+--   card-key doors are stamped closed on floor load
+--
+-- all of them writing the block layer directly. Meshes derived from that
+-- layer went stale with no announcement -- the cut tree stayed standing,
+-- and after a round trip through a door the stump stayed cut because this
+-- map's mesh survives in the cache (that is what prevLive is for).
+--
+-- The engine could announce each of those, and an earlier cut of this
+-- work changed it to. That is the wrong place: it edits the game for one
+-- mod's benefit, and every future path that writes a block has to
+-- remember to do the same. They all funnel through ONE choke point --
+-- Map:setBlock -- so wrap that from here instead. Map is a plain
+-- metatable shared by every map instance, so this covers all of them,
+-- including paths written after this mod.
+--
+-- Read back rather than trust the argument: setBlock silently ignores an
+-- out-of-bounds write, and a stamp that rewrites a block with the value
+-- it already held (the door code guards for this, the regrowth does not)
+-- is not a change and must not throw the mesh away.
+do
+  local Map = require("src.world.Map")
+  if not Map.dramaticShapeBlockHook then
+    local setBlock = Map.setBlock
+    Map.setBlock = function(self, bx, by, block)
+      local before = self:blockAt(bx, by)
+      setBlock(self, bx, by, block)
+      if self.id and self:blockAt(bx, by) ~= before then
+        ChunkMesher.refresh(self.id)
+      end
+    end
+    Map.dramaticShapeBlockHook = true
+  end
+end
+
+-- A reloaded map is rebuilt from scratch (warps that re-enter the same map,
+-- hot reload), so its mesh is stale for the same reason -- with one
+-- exception, and it is the common one.
+--
+-- A palette switch reloads the map ONLY to rebuild its atlas
+-- (PaletteFX.setMode -> reloadMap(id, "colors")). The geometry that comes
+-- back is identical: this mesher reads block layout and tile ids and never
+-- reads colour, and the palette lives entirely in the texture TerrainAtlas
+-- hands back per frame -- which is keyed BY palette, so the new colours are
+-- already built by the time the next frame draws.
+--
+-- Dropping the mesh anyway cost a visible flash of the flat 2D world on
+-- every palette toggle. Mesh builds are asynchronous, so the frames between
+-- the drop and the first finished mesh have no terrain to draw, and
+-- drawWorld returning nil IS the 2D fallback. Keeping the geometry lets the
+-- new colours land on the diorama already on screen, in one frame, which is
+-- what a palette toggle should look like from inside voxel mode.
+mod.events:on("map.reloaded", function(payload)
+  if payload and payload.reason == "colors" then return end
+  local mapId = payload and (payload.mapId or (payload.map and payload.map.id))
+  if mapId then ChunkMesher.invalidate(mapId) end
+end)
+
+-- ------- rows come and go, so the menu has to notice
+--
+-- OptionsMenu builds its row list ONCE, when it is opened, and then reads
+-- that list every frame. So stepping the VOXEL row onto or off FULL changed
+-- which rows the hook would return but not which rows were on screen -- the
+-- settings FULL owns stayed visible until the menu was closed and reopened,
+-- and a player who stepped off FULL could not see the rows come back.
+--
+-- Rebuilt in place, and only on a step that changes the LIST: crossing FULL,
+-- or toggling 3D-BTL, which is the other row that owns one (BATTLE LAYOUT).
+-- Every other rung returns the same list, and rebuilding on all of them would
+-- rerun every mod's ui.options.rows hook once per keypress. The cursor is
+-- clamped rather than reset, so it stays on the row it was just used on
+-- instead of jumping to the top when the list below it shortens.
+do
+  local OptionsMenu = require("src.ui.OptionsMenu")
+  if not OptionsMenu.dramaticShapeFullHook then
+    local Pipelines = require("src.render.Pipelines")
+    local inner = OptionsMenu.update
+
+    local function idAt(menu, index)
+      local row = menu.rows and menu.rows[index or 1]
+      return type(row) == "table" and row.id or nil
+    end
+
+    function OptionsMenu:update(dt)
+      local before = Pipelines.level("voxel")
+      local hadBattles = OverworldBattle.enabled()
+      local wasOn = idAt(self, self.index)
+      inner(self, dt)
+      local after = Pipelines.level("voxel")
+      local crossedFull = after ~= before
+                          and (Voxel.isFull(before) or Voxel.isFull(after))
+      if crossedFull or OverworldBattle.enabled() ~= hadBattles then
+        local rebuilt = OptionsMenu.new(self.game)
+        self.rows = rebuilt.rows
+        -- Follow the row the cursor was ON rather than the slot it was in:
+        -- 3D-BTL takes BATTLE LAYOUT off the list ABOVE itself, which would
+        -- otherwise slide the cursor onto the row under the one just used.
+        for i = 1, #self.rows do
+          if wasOn and idAt(self, i) == wasOn then self.index = i; break end
+        end
+        local cancel = #self.rows + 1
+        if (self.index or 1) > cancel then self.index = cancel end
+      end
+    end
+
+    OptionsMenu.dramaticShapeFullHook = true
+  end
+end
+
+-- ------- battles on the map
+--
+-- The wraps this needs -- OverworldState:pushBattle, BattleState:draw and
+-- BattleState:drawHUDs -- all live in lib/OverworldBattle.lua, which is
+-- where the reasoning for each one is written down. Installed once, here,
+-- so this file keeps naming every engine seam the mod touches.
+OverworldBattle.install()
+
+-- The overworld's own pushBattle is the choke point for a wild encounter or
+-- a trainer, and it is wrapped. A battle that arrives some other way -- a
+-- link battle, a script pushing a BattleState directly -- reaches this
+-- instead, which stages the arena from wherever the player is standing.
+-- Nothing visible is lost by being late: the cull only has to beat the
+-- battle screen, and the wipe those battles skip is where it would have
+-- shown.
+mod.events:on("battle.started", function(payload)
+  OverworldBattle.ensure(payload and payload.battle)
+end)
+
+-- Both mons face the camera, so the player's side wants its FRONT pic where
+-- the battle screen would have used the back one. The engine's own
+-- pokemon.sprite hook is the seam for exactly this: it is asked for every
+-- battle pic with the side it is resolving, so swapping one side's answer
+-- needs no battle code at all -- and every path that builds a battler goes
+-- through it, including a Transform mid-fight.
+--
+-- next() first, so a sprite-replacing mod loaded before this one still gets
+-- the last word on WHICH art is used; this only changes which SIDE is asked
+-- for.
+mod.hooks:wrap("pokemon.sprite", function(next, path, ctx)
+  local out = next(path, ctx)
+  if not (ctx and ctx.kind == "battle" and ctx.side == "back") then
+    return out
+  end
+  if not OverworldBattle.wantsFront() then return out end
+  local def = ctx.data and ctx.data.pokemon and ctx.data.pokemon[ctx.species]
+  return (def and def.spriteFront) or out
+end)
+
+-- Every ending path emits this, including a battle skipped before it drew,
+-- so this is where the map's cast comes back.
+mod.events:on("battle.ended", function()
+  OverworldBattle.finish()
+end)
+
+-- ------- and the way back out
+--
+-- The engine wipes INTO a battle with one of the original's eight transitions
+-- and cuts straight OUT of it. That cut is between two very different cameras
+-- in this mode, so while voxel mode is on the battle fades out, closes behind
+-- the black, and the map fades up. The two seams it needs -- BattleState:finish
+-- and Renderer:endFrame -- and the reasoning for each live in lib/BattleExit.lua.
+--
+-- Declared as a transitions record rather than a constant in that file, so the
+-- fade is retunable in data exactly like the eight wipes it answers, and a total
+-- conversion can make it as long or as short as its own pacing wants.
+mod.content.transitions:register(BattleExit.ID, {
+  frames = BattleExit.FRAMES,
+})
+
+BattleExit.install()
+
+-- ------- what time it is
+--
+-- The cycle's clock rides the SAVE SLOT (save.modData, via mod.save): what
+-- time it is in Kanto is a fact about that journey, like where the player is
+-- standing. Written on the engine's save.writing event -- the moment before
+-- the bytes hit disk -- and read back whenever a save is opened or begun. A
+-- save with no clock in it starts at day; that is DayNight.restore's
+-- fallback, and also the DAYTIME row's own default.
+mod.events:on("save.writing", function()
+  DayNight.store()
+end)
+
+mod.events:on("save.loaded", function()
+  DayNight.restore()
+end)
+
+mod.events:on("save.created", function()
+  DayNight.restore()
+end)
+
+-- The engine's own time-of-day seam. OverworldState:timeOfDay() is an
+-- eternal "DAY" until a mod answers here; answering it hands the period to
+-- the map.palette hook (ctx.tod) and music.select, so a palette or music
+-- pack keyed to night works with this mod's clock for free. next() first: a
+-- mod loaded before this one that already moved the time keeps its answer.
+mod.hooks:wrap("world.tod", function(next, tod, ctx)
+  local out = next(tod, ctx)
+  if out ~= tod then return out end
+  return DayNight.tod()
+end)
+
+mod.exports.version = "1.2.1"
+-- exposed so a companion mod can pin its own tiles' shapes or read the
+-- camera without reaching into this mod's file layout
+mod.exports.lib = V

--- a/mods/dramatic_shape/manifest.json
+++ b/mods/dramatic_shape/manifest.json
@@ -1,0 +1,19 @@
+{
+  "id": "DRAMATIC_SHAPE",
+  "name": "Dramatic Shape Voxel Mod",
+  "version": "1.2.1",
+  "api": 2,
+  "entry": "main.lua",
+  "profile": "content",
+  "category": "GRAPHICS",
+  "game_version": "0.0.0-dev || >=0.1.37 <2.0.0",
+  "priority": 100,
+  "dependencies": [],
+  "optional_dependencies": [],
+  "conflicts": [],
+  "permissions": [
+    "engine_internals"
+  ],
+  "affects_link": false,
+  "description": "A full 3D diorama overworld: extruded terrain, depth-buffered occlusion, voxel characters and a tilt-shift miniature pass -- and battles fought on the map itself, shot over the shoulder at the nearest clear ground with a slow parallax drift and a depth-of-field pass. Registers two render pipelines and claims hotkeys 3, 5, 6, 7 and 8 -- 3 and 5 displace the engine's TILT and GBC FX keys, both still reachable on the OPTIONS menu. Presentational only: it changes what a battle is drawn over, never where anybody stands."
+}

--- a/mods/dramatic_shape/mod.card
+++ b/mods/dramatic_shape/mod.card
@@ -1,0 +1,42 @@
+-- Sharing metadata (25-community-and-ecosystem.md 3.2).  Read by tooling
+-- and the manager detail pane; never by the loader's merge.
+return {
+  summary = "The overworld as a 3D diorama, and battles fought on it: real occlusion, tilt-shift, over-the-shoulder fights.",
+  author = "DramaticShape",
+  contact = "https://github.com/DramaticShape/DRAMATIC_SHAPE",
+  tags = { "graphics", "3d", "voxel", "render-pipeline", "presentation",
+           "battle" },
+  differences = {
+    changed = {
+      "with VOXEL on, the overworld draws as 3D geometry instead of flat tiles",
+      "occlusion comes from a depth buffer rather than a y-sort, so buildings really hide what is behind them",
+      "with 3D-BTL on, a battle draws over the map's nearest clear ground instead of over a white field",
+      "the map's NPCs are culled for the length of a battle, so the wipe plays over an empty map",
+      "a battle's letterbox voids go black rather than white, because the battle canvas is no longer white",
+      "VOXEL and the engine's TILT are mutually exclusive -- turning one on switches the other off",
+      "hotkeys 3 and 5 are taken over from the engine's TILT and GBC FX; both remain on the OPTIONS menu",
+      "the VOXEL key (3) turns TILT and GBC FX off on every press -- both fight the diorama, and 3 is now the only key that reaches either",
+    },
+    added = {
+      "VOXEL options row and hotkey 3 (OFF / 15 / 35 / 50 / 75 degrees)",
+      "T-SHIFT options row and hotkey 6 (OFF / 1 / 2 / 3), the miniature blur",
+      "V-GRID on hotkey 5 and V-CURVE on hotkey 7",
+      "3D-BTL on hotkey 8 (ON / OFF, on by default), battles fought on the world map",
+      "an over-the-shoulder battle camera on a slow parallax orbit, with a depth-of-field pass that holds both mons sharp",
+      "a sky behind the diorama at the 75-degree rung, outdoor maps only, coloured by the active palette mode",
+      "a hand-authored tile shape profile (data/voxel_heights.lua) a mod can extend",
+    },
+    known = {
+      "needs shader and depth-canvas support; without them the rows still cycle but the world stays 2D and battles draw plainly",
+      "a map with no 3x6 clearing falls back to a 1x4 one, and a map with neither draws the plain battle screen",
+      "the arena is where the CAMERA goes -- nobody is moved, so a fight staged across the map is a shot of that ground, not a trip to it",
+      "the battle backdrop renders at the GB's 160x144 to match the pics composited over it, so it is chunkier than the free-roam pass",
+      "menus and cutscenes are unaffected -- outside a battle the mode only draws the free-roam overworld",
+      "terrain meshes are cached per map, so the first frame after entering a large map costs a build",
+    },
+  },
+  credits = {
+    { who = "pret/pokered", for_ = "the tile and sprite data the geometry is derived from" },
+  },
+  compat = { engine = ">=0.1.37 <2.0.0", modApi = 2 },
+}


### PR DESCRIPTION
Vendor the DramaticShapeVoxelMod (v1.2.1) into mods/dramatic_shape/ so the 3D voxel diorama ships with the game and is toggleable from the in-game mod manager, rather than being a separate download.

It's a native mod API 2 render-pipeline mod: it registers a `voxel` drawWorld pipeline (extruded terrain, depth-buffered occlusion, voxel character slabs, shadow map) and a `tiltshift` worldPresent post-pass, plus over-the-shoulder 3D battles fought on the map. Purely presentational -- nothing reaches collision, movement, triggers, or scripts.

Bundled the runtime + metadata only: manifest.json, mod.card, README.md, main.lua, lib/ (31 modules), data/ (voxel_heights, battle_arenas). Left out the authoring-only trees the mod's own .modkitignore excludes -- tests/ probes and the Python voxel-carving tools -- and its dev CHANGELOG.

The engine's Manifest.validate accepts it (api 2, game_version "0.0.0-dev || >=0.1.37 <2.0.0", which matches this engine's 0.0.0-dev / modApi 2), all 31 Lua files parse clean, and scripts/test.sh stays green.

Note: bundled mods default to enabled, so 3D-BTL (on-map battles) is on out of the box and hotkeys 3/5 shift from TILT/GBC FX to VOXEL/V-GRID (both still reachable from OPTIONS). The voxel free-roam camera itself still defaults OFF. The mod has no LICENSE of its own yet -- worth adding one before redistributing the packaged game.


Claude-Session: https://claude.ai/code/session_01Q6bFAiQyZ5jDmewsbB4LG9