### PR TITLE
Add AYN Thor second-screen (dual-screen) support behind ENABLE DS option

### DIFF
--- a/mobile/android/love/src/jni/love/src/common/android.cpp
+++ b/mobile/android/love/src/jni/love/src/common/android.cpp
@@ -201,6 +201,60 @@ bool showFilePicker(const char *destFilename)
 	return result;
 }
 
+bool hasSecondaryDisplay()
+{
+	JNIEnv *env = (JNIEnv*) SDL_AndroidGetJNIEnv();
+	jclass activity = env->FindClass("org/love2d/android/GameActivity");
+
+	jmethodID method = env->GetStaticMethodID(activity, "hasSecondaryDisplay", "()Z");
+	jboolean result = env->CallStaticBooleanMethod(activity, method);
+
+	env->DeleteLocalRef(activity);
+	return result;
+}
+
+bool presentUIFrame(const char *pixels, size_t size, int w, int h)
+{
+	if (pixels == nullptr || w <= 0 || h <= 0)
+		return false;
+	if (size != (size_t) w * (size_t) h * 4)
+		return false;
+
+	JNIEnv *env = (JNIEnv*) SDL_AndroidGetJNIEnv();
+	jclass activity = env->FindClass("org/love2d/android/GameActivity");
+
+	jmethodID method = env->GetStaticMethodID(activity, "pushUIFrame", "([BII)Z");
+
+	jbyteArray jpixels = env->NewByteArray((jsize) size);
+	env->SetByteArrayRegion(jpixels, 0, (jsize) size, (const jbyte *) pixels);
+	jboolean result = env->CallStaticBooleanMethod(activity, method, jpixels, (jint) w, (jint) h);
+	env->DeleteLocalRef(jpixels);
+
+	env->DeleteLocalRef(activity);
+	return result;
+}
+
+bool pollSecondScreenTouch(int &action, float &x, float &y)
+{
+	JNIEnv *env = (JNIEnv*) SDL_AndroidGetJNIEnv();
+	jclass activity = env->FindClass("org/love2d/android/GameActivity");
+
+	jmethodID method = env->GetStaticMethodID(activity, "pollSecondScreenTouch", "()[F");
+	jfloatArray result = (jfloatArray) env->CallStaticObjectMethod(activity, method);
+	env->DeleteLocalRef(activity);
+
+	if (result == nullptr)
+		return false;
+
+	jfloat *elems = env->GetFloatArrayElements(result, nullptr);
+	action = (int) elems[0];
+	x = elems[1];
+	y = elems[2];
+	env->ReleaseFloatArrayElements(result, elems, JNI_ABORT);
+	env->DeleteLocalRef(result);
+	return true;
+}
+
 bool showCreateDocument(const char *suggestedName)
 {
 	if (suggestedName == nullptr || suggestedName[0] == '\0')

--- a/mobile/android/love/src/jni/love/src/common/android.h
+++ b/mobile/android/love/src/jni/love/src/common/android.h
@@ -74,6 +74,35 @@ bool showFilePicker(const char *destFilename = nullptr);
  **/
 bool showCreateDocument(const char *suggestedName = nullptr);
 
+/**
+ * Whether GameActivity has found a secondary (Presentation-category) Android
+ * Display and attached a rendering surface to it -- e.g. the AYN Thor's
+ * bottom panel. False on single-screen devices/desktop, and false until the
+ * Java side has finished attaching (see GameActivity.attachSecondaryDisplay).
+ * Mods should check this before calling presentUIFrame every frame.
+ **/
+bool hasSecondaryDisplay();
+
+/**
+ * Copies an RGBA8 pixel buffer (w*h*4 bytes, row-major, no padding -- the
+ * same layout love.graphics.Canvas:newImageData():getString() returns) to
+ * the secondary display's Bitmap and requests a redraw. A no-op returning
+ * false if hasSecondaryDisplay() is false or the buffer size doesn't match
+ * w*h*4. See GameActivity.pushUIFrame.
+ **/
+bool presentUIFrame(const char *pixels, size_t size, int w, int h);
+
+/**
+ * Reverse channel for presentUIFrame: pops the oldest pending touch on the
+ * secondary display, if any. action is 0 (down), 1 (move), 2 (up) or 3
+ * (cancel); x/y are in the same pixel space as the w/h a presentUIFrame
+ * call last used. Returns false (leaving the outputs untouched) when
+ * nothing is queued -- callers should poll every frame they care about
+ * input, draining until it returns false, since more than one touch can
+ * queue between polls. See GameActivity.pollSecondScreenTouch.
+ **/
+bool pollSecondScreenTouch(int &action, float &x, float &y);
+
 /*
  * Helper functions for the filesystem module
  */

--- a/mobile/android/love/src/jni/love/src/modules/system/System.cpp
+++ b/mobile/android/love/src/jni/love/src/modules/system/System.cpp
@@ -202,6 +202,39 @@ bool System::pickFile(const char *kind) const
 #endif
 }
 
+bool System::hasSecondaryDisplay() const
+{
+#ifdef LOVE_ANDROID
+	return love::android::hasSecondaryDisplay();
+#else
+	return false;
+#endif
+}
+
+bool System::presentUIFrame(const std::string &pixels, int w, int h) const
+{
+#ifdef LOVE_ANDROID
+	return love::android::presentUIFrame(pixels.data(), pixels.size(), w, h);
+#else
+	LOVE_UNUSED(pixels);
+	LOVE_UNUSED(w);
+	LOVE_UNUSED(h);
+	return false;
+#endif
+}
+
+bool System::pollSecondScreenTouch(int &action, float &x, float &y) const
+{
+#ifdef LOVE_ANDROID
+	return love::android::pollSecondScreenTouch(action, x, y);
+#else
+	LOVE_UNUSED(action);
+	LOVE_UNUSED(x);
+	LOVE_UNUSED(y);
+	return false;
+#endif
+}
+
 bool System::createFile(const char *suggestedName) const
 {
 #ifdef LOVE_ANDROID

--- a/mobile/android/love/src/jni/love/src/modules/system/System.h
+++ b/mobile/android/love/src/jni/love/src/modules/system/System.h
@@ -118,6 +118,38 @@ public:
 	virtual bool pickFile(const char *kind = nullptr) const;
 
 	/**
+	 * Whether a secondary (Presentation-category) display is attached and
+	 * ready -- e.g. the bottom panel on an AYN Thor. Android only; always
+	 * false elsewhere. See love::android::hasSecondaryDisplay.
+	 **/
+	virtual bool hasSecondaryDisplay() const;
+
+	/**
+	 * Sends an RGBA8 pixel buffer to the secondary display and requests a
+	 * redraw there. pixels must be exactly w*h*4 bytes (row-major, no
+	 * padding) -- the layout Canvas:newImageData():getString() returns.
+	 * Android only; always false elsewhere. See love::android::presentUIFrame.
+	 *
+	 * @param pixels Raw RGBA8 bytes.
+	 * @param w Width in pixels of the buffer.
+	 * @param h Height in pixels of the buffer.
+	 * @return Whether the frame was accepted (false if no secondary display
+	 *         is attached, or the buffer size didn't match w*h*4).
+	 **/
+	virtual bool presentUIFrame(const std::string &pixels, int w, int h) const;
+
+	/**
+	 * Reverse channel for presentUIFrame: pops the oldest pending touch on
+	 * the secondary display. action is 0 (down), 1 (move), 2 (up) or 3
+	 * (cancel); x/y are in the same pixel space as the w/h a presentUIFrame
+	 * call last used. Android only; always false elsewhere. See
+	 * love::android::pollSecondScreenTouch.
+	 *
+	 * @return Whether a touch was popped (false if none was queued).
+	 **/
+	virtual bool pollSecondScreenTouch(int &action, float &x, float &y) const;
+
+	/**
 	 * Shows the platform's native "create / save a file" UI (Android SAF
 	 * ACTION_CREATE_DOCUMENT). Copies staged pending_export.sav from the app
 	 * save directory to the user-chosen URI. See GameActivity.showCreateDocument.

--- a/mobile/android/love/src/jni/love/src/modules/system/wrap_System.cpp
+++ b/mobile/android/love/src/jni/love/src/modules/system/wrap_System.cpp
@@ -109,6 +109,49 @@ int w_createFile(lua_State *L)
 	return 1;
 }
 
+int w_hasSecondaryDisplay(lua_State *L)
+{
+	luax_pushboolean(L, instance()->hasSecondaryDisplay());
+	return 1;
+}
+
+// pixels: a string of raw RGBA8 bytes, e.g. from
+// canvas:newImageData():getString() -- exactly w*h*4 bytes, or this
+// returns false without sending anything.
+int w_presentUIFrame(lua_State *L)
+{
+	size_t len = 0;
+	const char *pixels = luaL_checklstring(L, 1, &len);
+	int w = (int) luaL_checkinteger(L, 2);
+	int h = (int) luaL_checkinteger(L, 3);
+	luax_pushboolean(L, instance()->presentUIFrame(std::string(pixels, len), w, h));
+	return 1;
+}
+
+// Returns a table {action=0|1|2|3, x=.., y=..} for the oldest pending
+// second-screen touch (action: 0 down, 1 move, 2 up, 3 cancel; x/y in the
+// same pixel space as the w/h the last presentUIFrame call used), or nil
+// if none is queued. Callers should loop until nil since more than one
+// touch can queue between polls.
+int w_pollSecondScreenTouch(lua_State *L)
+{
+	int action = 0;
+	float x = 0, y = 0;
+	if (!instance()->pollSecondScreenTouch(action, x, y))
+	{
+		lua_pushnil(L);
+		return 1;
+	}
+	lua_newtable(L);
+	lua_pushinteger(L, action);
+	lua_setfield(L, -2, "action");
+	lua_pushnumber(L, x);
+	lua_setfield(L, -2, "x");
+	lua_pushnumber(L, y);
+	lua_setfield(L, -2, "y");
+	return 1;
+}
+
 int w_hasBackgroundMusic(lua_State *L)
 {
 	lua_pushboolean(L, instance()->hasBackgroundMusic());
@@ -126,6 +169,9 @@ static const luaL_Reg functions[] =
 	{ "vibrate", w_vibrate },
 	{ "pickFile", w_pickFile },
 	{ "createFile", w_createFile },
+	{ "hasSecondaryDisplay", w_hasSecondaryDisplay },
+	{ "presentUIFrame", w_presentUIFrame },
+	{ "pollSecondScreenTouch", w_pollSecondScreenTouch },
 	{ "hasBackgroundMusic", w_hasBackgroundMusic },
 	{ 0, 0 }
 };

--- a/mobile/android/love/src/main/java/org/love2d/android/GameActivity.java
+++ b/mobile/android/love/src/main/java/org/love2d/android/GameActivity.java
@@ -31,6 +31,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -38,12 +39,16 @@ import java.util.Map;
 
 import android.Manifest;
 import android.app.AlertDialog;
+import android.app.Presentation;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.res.AssetManager;
+import android.graphics.Bitmap;
+import android.graphics.Paint;
+import android.hardware.display.DisplayManager;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Bundle;
@@ -96,6 +101,246 @@ public class GameActivity extends SDLActivity {
     public int safeAreaLeft = 0;
     public int safeAreaBottom = 0;
     public int safeAreaRight = 0;
+
+    // Secondary-display support (e.g. the bottom panel on an AYN Thor,
+    // exposed by Android as a Presentation-category Display -- see
+    // mobile/ANDROID.md and docs on love.system.hasSecondaryDisplay /
+    // love.system.presentUIFrame). Static because the JNI bridge in
+    // src/common/android.cpp calls these as static methods, matching the
+    // rest of this class's existing statics (gamePath, vibrator, etc).
+    private static Presentation secondaryPresentation = null;
+    private static UIFrameView secondaryView = null;
+
+    // A plain View that just blits whatever Bitmap it's given. Deliberately
+    // NOT part of SDL's/LÖVE's GL surface or event loop -- it's a second,
+    // independent Android window, fed frames explicitly via pushUIFrame
+    // rather than sharing LÖVE's renderer or draw thread.
+    private static class UIFrameView extends View {
+        private Bitmap frame;
+        private final Paint paint = new Paint();
+        private boolean touchDown = false;
+
+        UIFrameView(Context context) {
+            super(context);
+            setBackgroundColor(0xFFFFFFFF); // matches the white GB-style
+                                             // panels (Font.drawBox, etc.)
+                                             // pushed frames are drawn
+                                             // with, while no frame has
+                                             // arrived yet or outside the
+                                             // letterboxed content rect
+            paint.setFilterBitmap(false); // nearest-neighbour: pushed frames
+                                           // are pixel art, same as the main
+                                           // screen's integer-scale pipeline
+        }
+
+        void setFrame(Bitmap bitmap) {
+            frame = bitmap;
+            postInvalidate();
+        }
+
+        // Shared by onDraw and onTouchEvent so the letterbox math (and thus
+        // the coordinate space touches get reported in) can never drift
+        // from what is actually on screen. Returns null if there is nothing
+        // sane to compute against yet (no frame, zero-size view).
+        private android.graphics.RectF contentRect() {
+            if (frame == null) {
+                return null;
+            }
+            int vw = getWidth();
+            int vh = getHeight();
+            int fw = frame.getWidth();
+            int fh = frame.getHeight();
+            if (vw <= 0 || vh <= 0 || fw <= 0 || fh <= 0) {
+                return null;
+            }
+            float scale = Math.min((float) vw / fw, (float) vh / fh);
+            float dw = fw * scale;
+            float dh = fh * scale;
+            float left = (vw - dw) / 2f;
+            float top = (vh - dh) / 2f;
+            return new android.graphics.RectF(left, top, left + dw, top + dh);
+        }
+
+        @Override
+        protected void onDraw(android.graphics.Canvas canvas) {
+            super.onDraw(canvas);
+            android.graphics.RectF dst = contentRect();
+            if (dst != null) {
+                canvas.drawBitmap(frame, null, dst, paint);
+            }
+        }
+
+        // Reverse channel for pushUIFrame: reports taps back in the pushed
+        // frame's own pixel space (clamped to its bounds), so Lua-side
+        // hit-testing (see src/render/SecondScreenInput.lua) can work
+        // against the exact coordinates it drew at, independent of the
+        // panel's actual resolution or the letterbox offset. Single-touch
+        // only -- plenty for menu taps, and multi-touch on a status/menu
+        // panel is not a case worth the extra complexity yet.
+        @Override
+        public boolean onTouchEvent(MotionEvent event) {
+            android.graphics.RectF dst = contentRect();
+            if (dst == null) {
+                return true;
+            }
+            int action;
+            switch (event.getAction() & MotionEvent.ACTION_MASK) {
+                case MotionEvent.ACTION_DOWN:
+                    action = 0;
+                    touchDown = true;
+                    break;
+                case MotionEvent.ACTION_MOVE:
+                    if (!touchDown) return true;
+                    action = 1;
+                    break;
+                case MotionEvent.ACTION_UP:
+                    action = 2;
+                    touchDown = false;
+                    break;
+                default: // CANCEL and anything else: treat as a cancel
+                    action = 3;
+                    touchDown = false;
+                    break;
+            }
+            float scale = dst.width() / frame.getWidth();
+            float fx = (event.getX() - dst.left) / scale;
+            float fy = (event.getY() - dst.top) / scale;
+            fx = Math.max(0f, Math.min((float) frame.getWidth(), fx));
+            fy = Math.max(0f, Math.min((float) frame.getHeight(), fy));
+            queueSecondScreenTouch(action, fx, fy);
+            return true;
+        }
+    }
+
+    // Queued taps on the second screen, drained by pollSecondScreenTouch
+    // (called from love::android::pollSecondScreenTouch in android.cpp,
+    // itself driven by love.system.pollSecondScreenTouch). Capped so a
+    // Lua side that stops polling (wrong phase, second screen torn down
+    // mid-gesture) cannot grow this unboundedly; dropping the OLDEST entry
+    // once full keeps the most current finger position, which is the one
+    // that matters for a menu tap.
+    private static final int MAX_QUEUED_SECOND_SCREEN_TOUCHES = 64;
+    private static final ArrayDeque<float[]> secondScreenTouchQueue = new ArrayDeque<>();
+
+    private static synchronized void queueSecondScreenTouch(int action, float x, float y) {
+        if (secondScreenTouchQueue.size() >= MAX_QUEUED_SECOND_SCREEN_TOUCHES) {
+            secondScreenTouchQueue.pollFirst();
+        }
+        secondScreenTouchQueue.addLast(new float[] { action, x, y });
+    }
+
+    // {action, x, y} for the oldest queued touch, or null if none is
+    // pending. action: 0 = down, 1 = move, 2 = up, 3 = cancel. x/y are in
+    // the same pixel space as the w/h a presentUIFrame call last used.
+    @Keep
+    public static synchronized float[] pollSecondScreenTouch() {
+        return secondScreenTouchQueue.pollFirst();
+    }
+
+    // Looks for a Presentation-category secondary display (DisplayManager's
+    // term for a display meant to host separate content, as opposed to a
+    // mirrored one) and, if found, shows a Presentation with a UIFrameView
+    // on it. Safe to call more than once; a no-op after the first display is
+    // attached. Called from onCreate; does nothing on single-screen devices.
+    private void attachSecondaryDisplay() {
+        if (secondaryPresentation != null) {
+            return;
+        }
+
+        DisplayManager displayManager = (DisplayManager) getSystemService(Context.DISPLAY_SERVICE);
+        if (displayManager == null) {
+            return;
+        }
+
+        Display[] presentationDisplays =
+            displayManager.getDisplays(DisplayManager.DISPLAY_CATEGORY_PRESENTATION);
+        if (presentationDisplays.length == 0) {
+            Log.d("GameActivity", "No secondary (presentation) display found.");
+            return;
+        }
+
+        // First presentation display found; devices seen so far (AYN Thor)
+        // expose exactly one.
+        Display secondaryDisplay = presentationDisplays[0];
+        Presentation presentation = new Presentation(this, secondaryDisplay);
+        // A Presentation's Window is focusable by default, so a touch on it
+        // could pull KEY input focus (D-pad/A/B, delivered as key events by
+        // SDL) away from the main game window onto this one -- the second
+        // screen is touch-only UI and must never intercept physical button
+        // presses meant for gameplay. FLAG_NOT_FOCUSABLE only blocks that;
+        // touch delivery (onTouchEvent above) doesn't require window focus
+        // and is unaffected.
+        presentation.getWindow().setFlags(
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
+        UIFrameView view = new UIFrameView(presentation.getContext());
+        presentation.setContentView(view);
+
+        try {
+            presentation.show();
+        } catch (WindowManager.InvalidDisplayException e) {
+            Log.d("GameActivity", "Secondary display went away before show()", e);
+            return;
+        }
+
+        secondaryPresentation = presentation;
+        secondaryView = view;
+        Log.d("GameActivity", "Attached secondary display: " + secondaryDisplay);
+    }
+
+    // Counterpart to attachSecondaryDisplay: dismisses the Presentation so
+    // the second screen goes blank/closes whenever the main screen does
+    // (onPause -- home button, screen lock, task switch away). Safe to call
+    // when nothing is attached. hasSecondaryDisplay() correctly reports
+    // false once this runs, so Lua-side pushers (see
+    // src/render/SecondScreen.lua) stop on their own without needing to
+    // know the activity backgrounded -- attachSecondaryDisplay() re-shows
+    // it from onResume.
+    private void dismissSecondaryDisplay() {
+        if (secondaryPresentation == null) {
+            return;
+        }
+        secondaryPresentation.dismiss();
+        secondaryPresentation = null;
+        secondaryView = null;
+        synchronized (GameActivity.class) {
+            secondScreenTouchQueue.clear();
+        }
+        Log.d("GameActivity", "Dismissed secondary display (activity backgrounded)");
+    }
+
+    @Keep
+    public static boolean hasSecondaryDisplay() {
+        return secondaryPresentation != null && secondaryView != null;
+    }
+
+    // pixels: raw RGBA8 bytes, row-major, no padding -- w*h*4 bytes exactly,
+    // the same layout love.graphics.Canvas:newImageData():getString() hands
+    // back in Lua. Called from the JNI bridge in src/common/android.cpp
+    // (love::android::presentUIFrame), itself called from
+    // love.system.presentUIFrame. Runs on LÖVE's thread, not the UI thread,
+    // so the actual Bitmap update + invalidate is posted over to it.
+    @Keep
+    public static boolean pushUIFrame(byte[] pixels, int w, int h) {
+        if (secondaryView == null || pixels == null || w <= 0 || h <= 0) {
+            return false;
+        }
+        if (pixels.length != w * h * 4) {
+            return false;
+        }
+
+        final Bitmap bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
+        bitmap.copyPixelsFromBuffer(java.nio.ByteBuffer.wrap(pixels));
+
+        final UIFrameView view = secondaryView;
+        view.post(new Runnable() {
+            @Override
+            public void run() {
+                view.setFrame(bitmap);
+            }
+        });
+        return true;
+    }
 
     private static native void nativeSetDefaultStreamValues(int sampleRate, int framesPerBurst);
 
@@ -158,6 +403,8 @@ public class GameActivity extends SDLActivity {
             getWindow().getAttributes().layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER;
             shortEdgesMode = false;
         }
+
+        attachSecondaryDisplay();
     }
 
     @Override
@@ -287,6 +534,7 @@ public class GameActivity extends SDLActivity {
             Log.d("GameActivity", "Cancelling vibration");
             vibrator.cancel();
         }
+        dismissSecondaryDisplay();
         super.onDestroy();
     }
 
@@ -296,12 +544,14 @@ public class GameActivity extends SDLActivity {
             Log.d("GameActivity", "Cancelling vibration");
             vibrator.cancel();
         }
+        dismissSecondaryDisplay();
         super.onPause();
     }
 
     @Override
     public void onResume() {
         super.onResume();
+        attachSecondaryDisplay();
     }
 
     /**

--- a/mods/examples/example_second_screen/main.lua
+++ b/mods/examples/example_second_screen/main.lua
@@ -1,0 +1,80 @@
+-- Step 1 validation only: proves pixels drawn in Lua reach a real second
+-- Android display (love.system.hasSecondaryDisplay / .presentUIFrame,
+-- backed by GameActivity's Presentation on the AYN Thor's bottom panel --
+-- see mobile/android/love/src/main/java/org/love2d/android/GameActivity.java
+-- and src/common/android.cpp).
+--
+-- Deliberately does NOT touch BattleState or anything real yet. Once this
+-- shows a moving test pattern on the second screen, the next step is
+-- redirecting the actual battle action-menu / move-select draw calls here
+-- instead of this placeholder (see BattleState.lua's "menu"/"moveSelect"
+-- phase branches).
+--
+-- Hooks render.letterbox purely because it's an existing, confirmed
+-- per-frame hook point inside Renderer:endFrame -- not because this content
+-- has anything to do with letterboxing. A dedicated render.ui_canvas_ready
+-- hook (proposed separately) would be the real long-term hook point.
+
+local PixelCanvas = require("src.render.PixelCanvas")
+
+local W, H = 96, 48
+local PUSH_EVERY_N_FRAMES = 4 -- throttled: a canvas readback stalls the GPU,
+                              -- and the second screen doesn't need 60fps
+
+return function(mod)
+  -- LÖVE runs highdpi on Android (conf.lua), so a plain newCanvas(W, H)
+  -- allocates its backing texture at the device's DPI-scaled size, not
+  -- W x H -- newImageData()'s buffer would then silently mismatch the
+  -- w*h*4 presentUIFrame is told to expect (android.cpp's size check) and
+  -- every frame gets dropped, leaving the panel showing nothing but its
+  -- default white background. PixelCanvas forces dpiscale=1 so the canvas
+  -- is really W x H texels.
+  local canvas = PixelCanvas.new(W, H)
+  local frame = 0
+  local haveSecondaryDisplay = false
+
+  mod.hooks:wrap("render.letterbox", function(next, info)
+    -- preserve whatever the base engine / other mods draw for the void art
+    next(info)
+
+    frame = frame + 1
+    if frame % PUSH_EVERY_N_FRAMES ~= 0 then return end
+
+    -- cheap to re-check each throttled tick; a device could plug/unplug a
+    -- presentation display (dock, wireless display) mid-session
+    haveSecondaryDisplay = love.system.hasSecondaryDisplay()
+    if not haveSecondaryDisplay then return end
+
+    love.graphics.push("all")
+    love.graphics.setCanvas(canvas)
+    love.graphics.clear(0.1, 0.1, 0.15, 1)
+
+    -- moving color bar so it's obvious on the actual device that frames are
+    -- actually updating, not just a single static push
+    local t = frame / 60
+    local barX = (t * 20) % W
+    love.graphics.setColor(0.9, 0.2, 0.3, 1)
+    love.graphics.rectangle("fill", barX, 0, 8, H)
+
+    love.graphics.setColor(1, 1, 1, 1)
+    love.graphics.print("2nd screen pipe OK", 4, 4)
+    love.graphics.print("frame " .. frame, 4, H - 16)
+
+    love.graphics.setCanvas()
+    love.graphics.pop()
+
+    local imageData = canvas:newImageData()
+    local ok = love.system.presentUIFrame(imageData:getString(), W, H)
+    if not ok then
+      mod.log:warn("presentUIFrame rejected the frame (size mismatch or display gone)")
+    end
+  end)
+
+  mod.events:on("game.ready", function()
+    if love.system.hasSecondaryDisplay() then
+      mod.log:info("Secondary display detected -- pushing test pattern.")
+    else
+      mod.log:info("No secondary display detected (expected on desktop/single-screen).")
+    end
+  end)
+end

--- a/mods/examples/example_second_screen/manifest.json
+++ b/mods/examples/example_second_screen/manifest.json
@@ -1,0 +1,16 @@
+{
+  "id": "example_second_screen",
+  "name": "Second Screen Pipe Test",
+  "version": "0.1.0",
+  "api": 2,
+  "entry": "main.lua",
+  "profile": "content",
+  "category": "DEBUG",
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "priority": 100,
+  "permissions": ["engine_internals"],
+  "dependencies": [],
+  "optional_dependencies": [],
+  "conflicts": [],
+  "description": "Step-1 validation mod: draws an animated test pattern to a small canvas and pushes it to a secondary Android display (e.g. an AYN Thor's bottom panel) every few frames, to prove the native pixel pipe works end to end before anything real (battle UI, party HUD) is redirected there."
+}

--- a/src/battle/BattleState.lua
+++ b/src/battle/BattleState.lua
@@ -22,6 +22,8 @@ local Party = require("src.pokemon.Party")
 local Pokemon = require("src.pokemon.Pokemon")
 local Runtime = require("src.mods.Runtime")
 local Screens = require("src.ui.Screens")
+local SecondScreen = require("src.render.SecondScreen")
+local SecondScreenInput = require("src.render.SecondScreenInput")
 local Status = require("src.battle.Status")
 local TrainerAI = require("src.battle.TrainerAI")
 local TurnOrder = require("src.battle.TurnOrder")
@@ -49,6 +51,50 @@ end
 function BattleState:wideLayout()
   return self:isWideBattleLayout()
 end
+
+-- The second screen stacks two independent strips in one push: dialogue on
+-- top (its own coordinate space, translated up from y=96 to y=0 -- see
+-- drawTextArea), battle controls below it (their EXISTING absolute
+-- coordinates, some starting as high as y=56, translated down by this
+-- offset so they land under the dialogue strip instead of overlapping
+-- it). SECOND_SCREEN_HEIGHT is exactly 144 (the controls' own extent) +
+-- this offset (the dialogue strip's height, same 20x6-tile box the main
+-- screen used for it).
+local SECOND_SCREEN_WIDTH = 160
+local SECOND_SCREEN_CONTROLS_Y_OFFSET = 48
+local SECOND_SCREEN_HEIGHT = 144 + SECOND_SCREEN_CONTROLS_Y_OFFSET
+
+-- Whether this frame's battle text -- dialogue or the interactive
+-- menu/move-select UI -- belongs on the AYN Thor's second screen
+-- (src/render/SecondScreen.lua) instead of the main GB canvas. The
+-- old-man demo menu (self.demo) is scripted, not real input, so it stays
+-- on the main screen even when a second screen is present.
+function BattleState:usesSecondScreenText()
+  return SecondScreen.available()
+    and (self.phase == "messages"
+         or self.phase == "moveSelect"
+         or self.phase == "mimicSelect"
+         or (self.phase == "menu" and not self.demo))
+end
+
+-- Whenever usesSecondScreenText() is true, the main screen's text-box rows
+-- (y96-144) go completely unused -- drawClassic scales the battle scene
+-- (HUDs/pics/anim layer) up to fill them instead of leaving them blank.
+-- SCENE_SCALE_Y (144/96) makes the content that used to fill rows 0-11
+-- exactly fill the whole 160x144 canvas height. SCENE_SCALE_X stays 1: an
+-- equal-axis scale would push the content past 160px wide and need
+-- cropping off each side to fit back in, which read as a hard, distracting
+-- cut rather than a clean fill -- full width, no crop, was the better
+-- tradeoff once actually seen on-device, even though it means pics/HUDs
+-- come out slightly taller than wide versus their original proportions.
+-- Not tied to a broader "second screen present" check: the "intro" phase
+-- doesn't redirect (usesSecondScreenText() is phase-specific), so it
+-- correctly keeps the unscaled classic view rather than fighting
+-- drawTextArea's own (unscaled) empty box for that same screen real estate.
+local SCENE_SCALE_X = 1
+local SCENE_SCALE_Y = 144 / 96
+local SCENE_SCALE_X_OFFSET = 0 -- no X scale means no re-centering needed;
+                                -- kept as a named hook in case that changes
 
 -- Renderer:setUISize asks the top state for its surface before anything draws
 function BattleState:uiSize()
@@ -1444,9 +1490,54 @@ function BattleState:tickFx()
   self:updateFx()
 end
 
+-- Which row a second-screen tap at y (160x144 space) landed nearest to,
+-- among `count` rows spaced 8px apart starting at baseY -- matches the
+-- moveSelect/mimicSelect move-list layout in drawTextArea (baseY 96/56).
+-- Clamped, so a tap above/below the list still picks the nearest end
+-- rather than being ignored.
+local function nearestRow(y, baseY, count)
+  local i = math.floor((y - baseY) / 8 + 0.5)
+  return math.max(1, math.min(count, i))
+end
+
 function BattleState:update(dt)
   self:tickFx()
   local input = self.game.input
+
+  -- AYN Thor second-screen touch: a completed tap sets this phase's
+  -- cursor to the tapped item and pulses a same-shape "a" press, so the
+  -- input:wasPressed("a") branches below handle it exactly like a real
+  -- button confirm -- no separate choice-handling logic to keep in sync.
+  -- The pulse lands on Input's *next* step (Game:step calls Input:step
+  -- before BattleState:update), a one-frame delay that's imperceptible
+  -- for a menu confirm.
+  if self:usesSecondScreenText() then
+    local tapX, tapY = SecondScreenInput.poll()
+    if tapX then
+      -- controls render translated down by this offset (drawTextArea) so
+      -- they sit below the dialogue strip; undo it here so the hit-test
+      -- math below can keep using the controls' original coordinates
+      -- unmodified. A tap during "messages" (dialogue has no controls to
+      -- hit) just falls through every branch below and is discarded.
+      tapY = tapY - SECOND_SCREEN_CONTROLS_Y_OFFSET
+      if self.phase == "menu" then
+        local colBound = self.safari and 80 or 112
+        local col = tapX < colBound and 0 or 1
+        local row = tapY < 120 and 0 or 1
+        self.menuIndex = row * 2 + col + 1
+        input:overlayPressed("a")
+        input:overlayReleased("a")
+      elseif self.phase == "moveSelect" then
+        self.moveIndex = nearestRow(tapY, 96, #self.player.curMoves)
+        input:overlayPressed("a")
+        input:overlayReleased("a")
+      elseif self.phase == "mimicSelect" then
+        self.mimicIndex = nearestRow(tapY, 56, #self.mimicMoves)
+        input:overlayPressed("a")
+        input:overlayReleased("a")
+      end
+    end
+  end
 
   -- safety net: HP/status changed outside a queued drain (level-up heals,
   -- field effects, bag cures) snaps once the queue is idle
@@ -4548,7 +4639,15 @@ end
 -- text box (window-layer content), so compositing an unshifted copy
 -- underneath ghosted every name in the vacated strip (#295).  The strip
 -- shows blank color 0 instead, like the hardware revealing empty BG.
-function BattleState:drawZonePass(src, sx, sy)
+-- scaleX/scaleY/offsetX: when the battle scene is scaled up to fill the
+-- rows the text box vacated (see drawClassic's sceneScale), src already
+-- contains the pre-scaled content -- baked that way during the bgCanvas
+-- bake pass, same transform -- so only the zone SCISSOR rects need
+-- converting to match where that content actually landed.
+-- love.graphics.setScissor is NOT affected by the active love.graphics
+-- transform (unlike draw calls), so this can't be handled by wrapping the
+-- loop in a push/scale instead.
+function BattleState:drawZonePass(src, sx, sy, scaleX, scaleY, offsetX)
   local PaletteFX = require("src.render.PaletteFX")
   local shader = PaletteFX.shader()
   local pals = self:sgbBattlePals()
@@ -4556,10 +4655,13 @@ function BattleState:drawZonePass(src, sx, sy)
   love.graphics.setColor(1, 1, 1, 1)
   love.graphics.setShader(shader)
   local shaking = sx ~= 0 or sy ~= 0
+  scaleX = scaleX or 1
+  scaleY = scaleY or 1
+  offsetX = offsetX or 0
   for _, z in ipairs(BATTLE_ZONES) do
     PaletteFX.sendColors(shader, PaletteFX.permute(pals[z.pal], bgp))
-    local zx, zy = z[1] * 8, z[2] * 8
-    local zw, zh = (z[3] - z[1] + 1) * 8, (z[4] - z[2] + 1) * 8
+    local zx, zy = z[1] * 8 * scaleX + offsetX, z[2] * 8 * scaleY
+    local zw, zh = (z[3] - z[1] + 1) * 8 * scaleX, (z[4] - z[2] + 1) * 8 * scaleY
     love.graphics.setScissor(zx, zy, zw, zh)
     if shaking then
       love.graphics.rectangle("fill", zx, zy, zw, zh)
@@ -4931,6 +5033,27 @@ function BattleState:drawHUDs(slide)
 end
 
 function BattleState:drawTextArea()
+  -- When present, the AYN Thor's second screen takes the whole box+content
+  -- for these phases -- draw it there instead of the main GB canvas, which
+  -- is left untouched (blank/showing the battle scene) for the duration.
+  local onSecondScreen = self:usesSecondScreenText()
+  if onSecondScreen then
+    SecondScreen.begin(SECOND_SCREEN_WIDTH, SECOND_SCREEN_HEIGHT)
+    if self.phase == "messages" then
+      -- Dialogue gets its own strip at the canvas top. Every coordinate
+      -- below assumes the main screen's text-box position (box top
+      -- y=96, lines at y=112/128) -- translate so that lands at y=0
+      -- instead, rather than duplicating the position math.
+      love.graphics.translate(0, -96)
+    else
+      -- Battle controls (menu/moveSelect/mimicSelect) keep their
+      -- existing absolute coordinates verbatim -- mimicSelect's box
+      -- starts as high as y=56 -- so shift the whole canvas down to
+      -- land them below the dialogue strip instead of overlapping it.
+      love.graphics.translate(0, SECOND_SCREEN_CONTROLS_Y_OFFSET)
+    end
+  end
+
   Font.drawBox(0, 12, 20, 6)
   love.graphics.setColor(0, 0, 0, 1)
   if self.phase == "messages" and (self.current or self.animPlaying) then
@@ -5046,6 +5169,10 @@ function BattleState:drawTextArea()
     end
     Font.drawCode(0xED, 8, (7 + self.mimicIndex) * 8)
   end
+
+  if onSecondScreen then
+    SecondScreen.finish()
+  end
 end
 
 function BattleState:draw()
@@ -5070,6 +5197,28 @@ function BattleState:drawClassic()
     sx = self.frame % 4 < 2 and 2 or -2
   end
   local slide = (self.introSlide or 0) * 4 -- intro slide-in offset
+  -- moveSelect/mimicSelect's menu box normally clips the player pic's rows
+  -- it would otherwise overwrite (drawPicsLayer's clipY); when that box
+  -- moved to the second screen instead, nothing draws over those rows on
+  -- the main screen any more, so let the pic show fully. Also gates the
+  -- scene scale-up (see SCENE_SCALE_X/Y above) -- both exist for the
+  -- exact same reason: the text box's territory on the main screen is
+  -- empty.
+  local skipMenuClip = self:usesSecondScreenText()
+  local sceneScale = skipMenuClip
+  -- "battle.sceneScale": a mod that composes its own battle camera/scene
+  -- (e.g. a 3D-diorama overlay compositing through
+  -- Renderer:setWorldOverride) can veto the scale-up for a frame it's
+  -- staging itself by hooking this and returning false -- the classic
+  -- pics/HUDs/anim layer then draw at their normal, unscaled positions
+  -- and BATTLE_ZONES scissors, which is what a mod doing its own
+  -- screen-space projection expects instead of having this transform
+  -- silently double-apply on top of its own. Unhooked, behavior is
+  -- unchanged from sceneScale above.
+  if sceneScale and Runtime.wantsHook("battle.sceneScale") then
+    sceneScale = Runtime.call("battle.sceneScale",
+      function(_, wanted) return wanted end, self, sceneScale) ~= false
+  end
 
   if self:colorMode() then
     -- SGB pipeline: gray BG canvas -> (wavy) -> zone recolor with the
@@ -5080,29 +5229,59 @@ function BattleState:drawClassic()
     g.setCanvas(self.bgCanvas)
     g.setColor(1, 1, 1, 1)
     g.rectangle("fill", 0, 0, 160, 144)
+    if sceneScale then
+      g.push()
+      g.translate(SCENE_SCALE_X_OFFSET, 0)
+      g.scale(SCENE_SCALE_X, SCENE_SCALE_Y)
+    end
     self:drawHUDs(slide)
+    if sceneScale then g.pop() end
     self:drawTextArea()
     if wavy then
       -- the mon pics are BG tiles on the GB, so SE_WAVY_SCREEN bends
       -- them too: bake them into the canvas as DMG grays and let the
       -- zone pass color them by region (exactly what the SGB did)
       self.grayPics = true
-      g.setScissor(0, 0, 160, 96) -- BG pics live above the text box
-      self:drawPicsLayer(slide, 0, 0)
+      -- BG pics live above the text box -- unless that box moved to the
+      -- second screen and freed the whole canvas (sceneScale)
+      g.setScissor(0, 0, 160, sceneScale and 144 or 96)
+      if sceneScale then
+        g.push()
+        g.translate(SCENE_SCALE_X_OFFSET, 0)
+        g.scale(SCENE_SCALE_X, SCENE_SCALE_Y)
+      end
+      self:drawPicsLayer(slide, 0, 0, nil, skipMenuClip)
+      if sceneScale then g.pop() end
       g.setScissor()
       self.grayPics = nil
     end
     g.setCanvas(prev)
-    self:drawZonePass(self:applyWavy(self.bgCanvas), sx, sy)
+    self:drawZonePass(self:applyWavy(self.bgCanvas), sx, sy,
+      sceneScale and SCENE_SCALE_X, sceneScale and SCENE_SCALE_Y,
+      sceneScale and SCENE_SCALE_X_OFFSET)
     if not wavy then
       -- the pics are BG tiles in rows 0-11 on the GB: they can never
       -- cover the text box, whatever the SE offsets do (a vertical
-      -- window shake moves the box down with everything else)
-      g.setScissor(0, 0, 160, 96 + math.max(0, sy))
-      self:drawPicsLayer(slide, sx, sy)
+      -- window shake moves the box down with everything else) -- unless,
+      -- again, sceneScale means there is no text box on this screen to
+      -- cover
+      g.setScissor(0, 0, 160, sceneScale and 144 or (96 + math.max(0, sy)))
+      if sceneScale then
+        g.push()
+        g.translate(SCENE_SCALE_X_OFFSET, 0)
+        g.scale(SCENE_SCALE_X, SCENE_SCALE_Y)
+      end
+      self:drawPicsLayer(slide, sx, sy, nil, skipMenuClip)
+      if sceneScale then g.pop() end
       g.setScissor()
     end
+    if sceneScale then
+      g.push()
+      g.translate(SCENE_SCALE_X_OFFSET, 0)
+      g.scale(SCENE_SCALE_X, SCENE_SCALE_Y)
+    end
     self:drawAnimLayer(true)
+    if sceneScale then g.pop() end
   else
     -- flat fallback (headless / no shader support): pre-colorized pics
     -- on white, no palette fades
@@ -5113,9 +5292,15 @@ function BattleState:drawClassic()
       love.graphics.push()
       love.graphics.translate(sx, sy)
     end
-    self:drawPicsLayer(slide, 0, 0)
+    if sceneScale then
+      love.graphics.push()
+      love.graphics.translate(SCENE_SCALE_X_OFFSET, 0)
+      love.graphics.scale(SCENE_SCALE_X, SCENE_SCALE_Y)
+    end
+    self:drawPicsLayer(slide, 0, 0, nil, skipMenuClip)
     self:drawHUDs(slide)
     self:drawAnimLayer(false)
+    if sceneScale then love.graphics.pop() end
     self:drawTextArea()
     if shaking then
       love.graphics.pop()

--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -11,6 +11,7 @@ local StateStack = require("src.core.StateStack")
 local TouchControls = require("src.core.TouchControls")
 local ModLoader = require("src.mods.Loader")
 local ModRuntime = require("src.mods.Runtime")
+local OverworldSecondScreen = require("src.render.OverworldSecondScreen")
 local Screens = require("src.ui.Screens")
 
 local Game = {}
@@ -351,6 +352,12 @@ function Game:draw()
   if ModRuntime.wantsHook("render.hud") then
     ModRuntime.call("render.hud", function() end, self, viewport)
   end
+  -- AYN Thor second screen: pause-menu column + non-pausing party status.
+  -- An independent output surface (its own canvas, its own
+  -- presentUIFrame push), so its position here relative to the
+  -- main-screen pipeline above is arbitrary -- it never touches
+  -- viewport/zones/the main canvas.
+  OverworldSecondScreen.draw(self)
   -- on-screen mobile controls: pure screen-space, over the finished frame
   TouchControls:draw()
 end
@@ -653,6 +660,7 @@ function Game:applyOptions(opts)
   end
   Input:applyBindings(opts.bindings)
   TouchControls:applyOptions(opts)
+  require("src.render.SecondScreen").applyOptions(opts)
   -- heal soft-bricked APK installs that already saved gbcfx > 0 (#136)
   if gbcCleared then self:writeOptions() end
 end

--- a/src/render/OverworldSecondScreen.lua
+++ b/src/render/OverworldSecondScreen.lua
@@ -1,0 +1,122 @@
+-- Composes the AYN Thor's second screen for the overworld: the pause menu
+-- (src/ui/StartMenu.lua) as a persistent left column, full height, plus a
+-- toggleable main panel to its right -- party status
+-- (src/render/PartyStatusHUD.lua) or the region map
+-- (src/render/TownMapPanel.lua), switched by tapping the tab strip above
+-- it. The menu column shows an inert preview while walking around and
+-- swaps to the live, input-driven instance the moment the player pauses
+-- -- "focus" is exactly which instance this draws each tick, not a
+-- separate flag to track and keep in sync.
+local SecondScreen = require("src.render.SecondScreen")
+local SecondScreenInput = require("src.render.SecondScreenInput")
+local PartyStatusHUD = require("src.render.PartyStatusHUD")
+local TownMapPanel = require("src.render.TownMapPanel")
+local StartMenu = require("src.ui.StartMenu")
+local Font = require("src.render.Font")
+local Theme = require("src.ui.Theme")
+
+local OverworldSecondScreen = {}
+
+local PUSH_EVERY_N_FRAMES = 4 -- snappier than PartyStatusHUD alone: the
+                               -- menu column wants to feel responsive
+                               -- once focused
+local TAB_TILES_H = 3 -- Font.drawBox needs >= 3 rows for one usable
+                       -- content row between its top/bottom border --
+                       -- the same height TownMap's own name banner uses
+local TAB_H = TAB_TILES_H * 8
+
+-- Both panels share one footprint (TownMapPanel.WIDTH/HEIGHT mirror
+-- PartyStatusHUD's) so switching tabs never resizes the canvas.
+local PANEL_W, PANEL_H = PartyStatusHUD.WIDTH, PartyStatusHUD.HEIGHT
+
+local PANELS = { pokemon = PartyStatusHUD, map = TownMapPanel }
+
+local frame = 0
+local mode = "pokemon" -- "pokemon" | "map" -- in-memory only, resets on relaunch
+
+local function findFocusedMenu(stack)
+  for i = 1, #(stack and stack.states or {}) do
+    local state = stack.states[i]
+    if state and state.screenId == "StartMenu" then return state end
+  end
+  return nil
+end
+
+-- Same ownership check PartyStatusHUD used when it owned its own
+-- begin/finish -- kept here now that this coordinator does instead.
+local function secondScreenClaimedByStack(stack)
+  for i = 1, #(stack and stack.states or {}) do
+    local state = stack.states[i]
+    if state and state.usesSecondScreenText and state:usesSecondScreenText() then
+      return true
+    end
+  end
+  return false
+end
+
+local function drawTabs()
+  Font.drawBox(0, 0, PANEL_W / 8, TAB_TILES_H)
+  love.graphics.setColor(0, 0, 0, 1)
+  local halfW = PANEL_W / 2
+  local pkmnLabel, mapLabel = "PKMN", "MAP"
+  local pkmnX = halfW / 2 - (#pkmnLabel * 8) / 2
+  local mapX = halfW + halfW / 2 - (#mapLabel * 8) / 2
+  Font.draw(pkmnLabel, pkmnX, 8)
+  Font.draw(mapLabel, mapX, 8)
+  Font.drawCode(Theme.cursor, (mode == "pokemon" and pkmnX or mapX) - 8, 8)
+  love.graphics.setColor(1, 1, 1, 1)
+end
+
+-- A completed tap landing on the tab strip (colW..colW+PANEL_W,
+-- 0..TAB_H) switches mode; anything else -- including a tap on the
+-- panel content below -- is ignored here, since neither panel currently
+-- reads touch input of its own.
+local function pollTabTap(colW)
+  local tapX, tapY = SecondScreenInput.poll()
+  if not tapX then return end
+  local localX, localY = tapX - colW, tapY
+  if localY < 0 or localY >= TAB_H or localX < 0 or localX >= PANEL_W then
+    return
+  end
+  mode = (localX < PANEL_W / 2) and "pokemon" or "map"
+end
+
+function OverworldSecondScreen.draw(game)
+  if not SecondScreen.available() then return end
+  if secondScreenClaimedByStack(game.stack) then return end
+
+  frame = frame + 1
+  if frame % PUSH_EVERY_N_FRAMES ~= 0 then return end
+
+  local focused = findFocusedMenu(game.stack)
+  local menu = focused
+  if not menu then
+    -- Rebuilt every throttled tick rather than cached: cheap table
+    -- construction, and it keeps the preview honest about newly
+    -- unlocked entries (POKéDEX, LINK) without needing to invalidate a
+    -- stale cached copy itself.
+    local ok, fresh = pcall(StartMenu.new, game)
+    if not ok or not fresh then return end
+    menu = fresh
+  end
+  if not menu.drawColumn then return end
+
+  local colW = (menu.tw + 2) * 8 -- box width plus a small margin
+  pollTabTap(colW)
+
+  SecondScreen.begin(colW + PANEL_W, TAB_H + PANEL_H)
+
+  local savedTx, savedTy = menu.tx, menu.ty
+  menu.tx, menu.ty = 0, 0
+  menu:drawColumn()
+  menu.tx, menu.ty = savedTx, savedTy
+
+  love.graphics.translate(colW, 0)
+  drawTabs()
+  love.graphics.translate(0, TAB_H)
+  ;(PANELS[mode] or PartyStatusHUD).drawRows(game)
+
+  SecondScreen.finish()
+end
+
+return OverworldSecondScreen

--- a/src/render/PartyStatusHUD.lua
+++ b/src/render/PartyStatusHUD.lua
@@ -1,0 +1,109 @@
+-- Non-pausing party-status overview on the AYN Thor's second screen: shows
+-- while walking around the overworld (or with a non-opaque overlay like a
+-- text box open on top of it) -- icon, nickname, level, HP bar and status
+-- condition for each party member. Never reads input and never blocks
+-- gameplay; contrast with src/battle/BattleState.lua's SecondScreen usage,
+-- which takes over the same panel for battle menus.
+--
+-- drawRows() draws only the rows themselves, at whatever origin/transform
+-- is already active -- src/render/OverworldSecondScreen.lua composes it
+-- alongside the pause-menu column on one shared canvas/push, so it owns
+-- SecondScreen.begin()/finish(). draw() is the standalone entry point
+-- (its own begin/finish, availability/ownership checks) for any other
+-- caller that wants just the party panel on its own.
+local SecondScreen = require("src.render.SecondScreen")
+local HudTiles = require("src.render.HudTiles")
+local Font = require("src.render.Font")
+local Strings = require("src.core.Strings")
+local PartyMenu = require("src.ui.PartyMenu")
+
+local PartyStatusHUD = {}
+
+local ROW_H = 24
+local MAX_ROWS = 6 -- a full party; the 144px content area is exactly 6 * 24
+local CONTENT_W, CONTENT_H = 160, 144
+local BORDER = 8 -- one tile, matching Font.drawBox's own border thickness
+-- Published so callers (src/render/OverworldSecondScreen.lua, draw()
+-- below) can size their canvas/layout around the bordered panel without
+-- hardcoding its dimensions redundantly.
+PartyStatusHUD.WIDTH = CONTENT_W + BORDER * 2
+PartyStatusHUD.HEIGHT = CONTENT_H + BORDER * 2
+
+local PUSH_EVERY_N_FRAMES = 20 -- party HP/status/order changes rarely --
+                                -- no need to stall the GPU every tick the
+                                -- way a live menu does
+
+local frame = 0
+
+-- Whether some other state already drew to the second screen this frame
+-- (see BattleState:usesSecondScreenText) -- the HUD yields the panel
+-- rather than racing it for the same push.
+local function secondScreenClaimedByStack(stack)
+  for i = 1, #(stack and stack.states or {}) do
+    local state = stack.states[i]
+    if state and state.usesSecondScreenText and state:usesSecondScreenText() then
+      return true
+    end
+  end
+  return false
+end
+
+function PartyStatusHUD.drawRows(game)
+  local party = game.save and game.save.party
+  if not party or #party == 0 then return end
+
+  -- The classic GB bordered box (corner + line glyphs) instead of a plain
+  -- fill, matching the pause-menu column's own Font.drawBox border. It
+  -- already fills its interior white, so no separate rectangle("fill")
+  -- is needed; content below is drawn inset by one tile (BORDER) to clear
+  -- the border glyphs, the same margin Menu:draw() leaves for its own box.
+  Font.drawBox(0, 0, PartyStatusHUD.WIDTH / 8, PartyStatusHUD.HEIGHT / 8)
+  love.graphics.push()
+  love.graphics.translate(BORDER, BORDER)
+  love.graphics.setColor(0, 0, 0, 1)
+
+  for i = 1, math.min(#party, MAX_ROWS) do
+    local mon = party[i]
+    local def = game.data.pokemon[mon.species]
+    local y = (i - 1) * ROW_H
+
+    -- PartyMenu.drawIcon expects white active (it draws full-color icon
+    -- art, not a tinted glyph) -- restore black after for the text below.
+    love.graphics.setColor(1, 1, 1, 1)
+    PartyMenu.drawIcon(game, mon, 2, y + 4, false, 0)
+    love.graphics.setColor(0, 0, 0, 1)
+
+    Font.draw(mon.nickname or def.name, 20, y + 1)
+    HudTiles.tile(0x6E, 104, y + 1) -- <LV>
+    Font.draw(tostring(mon.level), 112, y + 1)
+
+    -- grayFill=false always: unlike PartyMenu's canvas, this one never
+    -- goes through the main render pipeline's SGB zone pass, so the bar
+    -- needs its own direct per-pixel tint or it would just stay gray.
+    HudTiles.drawHPBar(game.data, 2.5, (y + 11) / 8, mon, nil, false)
+    Font.draw(("%3d/%3d"):format(math.max(0, mon.hp), mon.stats.hp), 96, y + 11)
+
+    if mon.hp <= 0 then
+      Font.draw(Strings("FNT"), 136, y + 1)
+    elseif mon.status then
+      Font.draw(mon.status, 136, y + 1)
+    end
+  end
+  love.graphics.pop()
+end
+
+function PartyStatusHUD.draw(game)
+  if not SecondScreen.available() then return end
+  if secondScreenClaimedByStack(game.stack) then return end
+  local party = game.save and game.save.party
+  if not party or #party == 0 then return end
+
+  frame = frame + 1
+  if frame % PUSH_EVERY_N_FRAMES ~= 0 then return end
+
+  SecondScreen.begin(PartyStatusHUD.WIDTH, PartyStatusHUD.HEIGHT)
+  PartyStatusHUD.drawRows(game)
+  SecondScreen.finish()
+end
+
+return PartyStatusHUD

--- a/src/render/SecondScreen.lua
+++ b/src/render/SecondScreen.lua
@@ -1,0 +1,90 @@
+-- Thin helper around love.system.hasSecondaryDisplay/presentUIFrame (see
+-- mobile/android/love/src/jni/love/src/common/android.cpp and
+-- GameActivity.java) for UI that lives on the AYN Thor's bottom panel
+-- instead of the main GB screen. Reuses the main screen's 160x144
+-- coordinate space so callers can draw with the same Font.* calls they'd
+-- use on the primary canvas; the Java side scales the pushed frame to fill
+-- whatever the panel's actual resolution is.
+--
+-- Uses PixelCanvas (not a plain love.graphics.newCanvas) because LÖVE
+-- always runs highdpi on Android (conf.lua) -- an undpiscaled canvas
+-- allocates its backing texture at the device's DPI-scaled size, not the
+-- WIDTH/HEIGHT asked for, so newImageData()'s buffer length would silently
+-- mismatch the w*h*4 this module tells the native side to expect and every
+-- frame would get dropped by the size check in android.cpp.
+local PixelCanvas = require("src.render.PixelCanvas")
+
+local SecondScreen = {}
+
+-- The main GB screen's own size; the default for callers that don't need
+-- anything larger (e.g. src/render/PartyStatusHUD.lua).
+local DEFAULT_WIDTH, DEFAULT_HEIGHT = 160, 144
+local PUSH_EVERY_N_FRAMES = 3 -- canvas readback stalls the GPU; menus are
+                               -- mostly static so this stays responsive
+
+local canvas
+local canvasW, canvasH
+local frame = 0
+
+-- Options row: ENABLE DS (src/ui/OptionsMenu.lua). Defaults on -- this
+-- whole module is already inert everywhere without
+-- love.system.hasSecondaryDisplay hardware, so opting out is the rare
+-- case, not the common one.
+local enabled = true
+
+-- Reads options.enableDS; Game:applyOptions calls this at boot and
+-- whenever options change, same as PaletteFX.applyOptions/Tilt.applyOptions
+-- etc. On a disabled transition, pushes one blank frame so the panel goes
+-- visibly inert instead of freezing on whatever it last drew.
+function SecondScreen.applyOptions(opts)
+  local want = (opts and opts.enableDS) ~= false
+  if enabled and not want and canvas
+     and love.system.hasSecondaryDisplay and love.system.hasSecondaryDisplay() then
+    love.graphics.push("all")
+    love.graphics.setCanvas(canvas)
+    love.graphics.clear(1, 1, 1, 1)
+    love.graphics.pop()
+    love.system.presentUIFrame(canvas:newImageData():getString(), canvasW, canvasH)
+  end
+  enabled = want
+end
+
+function SecondScreen.available()
+  return enabled and love.system.hasSecondaryDisplay ~= nil
+    and love.system.hasSecondaryDisplay()
+end
+
+-- Switches love.graphics onto the second-screen canvas, sized w x h
+-- (defaulting to the main screen's own 160x144 -- pass explicit ones for a
+-- taller/wider layout, e.g. BattleState's stacked dialogue/controls
+-- canvas). Pair with finish() once the caller's draw calls are done;
+-- push("all")/pop("all") means whatever canvas/color/scissor/transform was
+-- active before is restored afterward, so this nests safely inside an
+-- in-progress main-screen draw. The cached canvas is only recreated when
+-- the requested size actually changes, so callers sharing the default
+-- size never pay for a caller that asked for something bigger.
+function SecondScreen.begin(w, h)
+  w, h = w or DEFAULT_WIDTH, h or DEFAULT_HEIGHT
+  if not canvas or canvasW ~= w or canvasH ~= h then
+    canvas = PixelCanvas.new(w, h)
+    canvasW, canvasH = w, h
+  end
+  love.graphics.push("all")
+  love.graphics.setCanvas(canvas)
+  -- White, not black: every panel drawn here (Font.drawBox's own fill,
+  -- PartyStatusHUD's bordered panel) is white-on-black-border GB style,
+  -- so a black clear only showed as a stray dark void in whatever gap
+  -- wasn't covered by a panel that frame.
+  love.graphics.clear(1, 1, 1, 1)
+  return canvas
+end
+
+function SecondScreen.finish()
+  love.graphics.pop()
+  frame = frame + 1
+  if frame % PUSH_EVERY_N_FRAMES ~= 0 then return end
+  local imageData = canvas:newImageData()
+  love.system.presentUIFrame(imageData:getString(), canvasW, canvasH)
+end
+
+return SecondScreen

--- a/src/render/SecondScreenInput.lua
+++ b/src/render/SecondScreenInput.lua
@@ -1,0 +1,42 @@
+-- Reverse channel for src/render/SecondScreen.lua: turns queued touches on
+-- the AYN Thor's bottom panel (GameActivity.queueSecondScreenTouch /
+-- pollSecondScreenTouch, love::android::pollSecondScreenTouch in
+-- android.cpp) into completed taps in the same 160x144 coordinate space
+-- SecondScreen draws in.
+--
+-- poll() drains everything queued since the last call and reports where a
+-- press lifted, if one did. Calling it more than once per real frame (a
+-- fast-forwarded BattleState:update() can run several times per rendered
+-- frame) is safe -- each call only consumes what is queued at that point,
+-- so nothing is lost or double-counted.
+
+local SecondScreenInput = {}
+
+-- action codes, matching GameActivity.queueSecondScreenTouch
+local PRESS, RELEASE, CANCEL = 0, 2, 3
+
+local down = false
+
+-- Returns x, y (in SecondScreen's 160x144 space) for a tap that completed
+-- since the last call, or nil if none did. MOVE events are drained but
+-- otherwise ignored: menu taps only care about where a press lifted, not
+-- the path a finger took getting there.
+function SecondScreenInput.poll()
+  if not love.system.pollSecondScreenTouch then return nil end
+  local tapX, tapY
+  while true do
+    local ev = love.system.pollSecondScreenTouch()
+    if not ev then break end
+    if ev.action == PRESS then
+      down = true
+    elseif ev.action == RELEASE then
+      if down then tapX, tapY = ev.x, ev.y end
+      down = false
+    elseif ev.action == CANCEL then
+      down = false
+    end
+  end
+  return tapX, tapY
+end
+
+return SecondScreenInput

--- a/src/render/TownMapPanel.lua
+++ b/src/render/TownMapPanel.lua
@@ -1,0 +1,39 @@
+-- Region-map alternative to src/render/PartyStatusHUD.lua's party panel,
+-- selected by OverworldSecondScreen.lua's tab strip. Same bordered-panel
+-- footprint (WIDTH/HEIGHT match PartyStatusHUD's exactly) so switching
+-- tabs never resizes the second-screen canvas.
+local Font = require("src.render.Font")
+local PartyStatusHUD = require("src.render.PartyStatusHUD")
+local TownMap = require("src.ui.TownMap")
+
+local TownMapPanel = {}
+
+TownMapPanel.WIDTH = PartyStatusHUD.WIDTH
+TownMapPanel.HEIGHT = PartyStatusHUD.HEIGHT
+
+local BORDER = 8
+
+function TownMapPanel.drawRows(game)
+  Font.drawBox(0, 0, TownMapPanel.WIDTH / 8, TownMapPanel.HEIGHT / 8)
+  love.graphics.push()
+  love.graphics.translate(BORDER, BORDER)
+
+  -- Fresh instance every call (the caller already throttles how often
+  -- this runs): keeps the "you are here" marker honest about the
+  -- player's current map without needing to invalidate a stale cached
+  -- one. TownMap.new has no side effects until :update()/:draw() runs --
+  -- safe to build without pushing it onto game.stack, same as the
+  -- pause-menu idle preview in OverworldSecondScreen.lua. self.sel
+  -- already defaults to the player's own location (TownMap.new), and a
+  -- freshly-built self.blink is 0, so the marker/cursor this draws
+  -- default to visible with no blink-off flicker on a panel nobody is
+  -- reading frame-by-frame.
+  local ok, map = pcall(TownMap.new, game, {})
+  if ok and map then
+    pcall(map.draw, map)
+  end
+
+  love.graphics.pop()
+end
+
+return TownMapPanel

--- a/src/ui/OptionsMenu.lua
+++ b/src/ui/OptionsMenu.lua
@@ -357,6 +357,22 @@ local function buildRows(game)
         require("src.core.TouchControls"):applyOptions(o)
         return true
       end },
+    -- AYN Thor second screen (src/render/SecondScreen.lua): battle
+    -- text/controls, the pause-menu column, party status, the region
+    -- map. Everything gated on it funnels through
+    -- SecondScreen.available(), so this one row is the entire off
+    -- switch. Hidden where the hardware hook doesn't even exist (every
+    -- non-Android build), so the row costs those installs nothing.
+    { id = "enableDS", label = Strings("ENABLE DS"),
+      value = function(g)
+        return (g.save.options.enableDS ~= false) and Strings("ON") or Strings("OFF")
+      end,
+      step = function(g)
+        local o = g.save.options
+        o.enableDS = (o.enableDS == false)
+        require("src.render.SecondScreen").applyOptions(o)
+        return true
+      end },
   }
   -- issue #136: hide GBC FX on Android/iOS -- the present shader soft-bricks
   if not GBCFX.isSupported() then
@@ -380,6 +396,17 @@ local function buildRows(game)
       end
       rows = filtered
     end
+  end
+  -- ENABLE DS only where the hardware hook exists at all -- built
+  -- non-Android, or an Android build predating it, never define
+  -- love.system.hasSecondaryDisplay, so the row would just be a
+  -- permanently-inert ON/OFF toggle there.
+  if not love.system.hasSecondaryDisplay then
+    local filtered = {}
+    for _, row in ipairs(rows) do
+      if row.id ~= "enableDS" then filtered[#filtered + 1] = row end
+    end
+    rows = filtered
   end
   -- PIKACHU VOL only means something where the voice clips exist: Yellow
   -- (data.audio.pikaCries is the clip count the importer wrote).  Red/Blue

--- a/src/ui/PartyMenu.lua
+++ b/src/ui/PartyMenu.lua
@@ -239,6 +239,14 @@ local function drawIcon(game, mon, x, y, selected, counter)
   end
 end
 
+-- Exposed for src/render/PartyStatusHUD.lua, which draws the same party
+-- icon strip on the AYN Thor's second screen and shouldn't re-derive the
+-- icon registry lookup / OBP0 bake / mirrored-frame logic that lives here.
+-- Callers outside this file must set love.graphics color to white first
+-- (icons are full-color art, not a tinted glyph) and restore it after,
+-- same as the in-file call site below.
+PartyMenu.drawIcon = drawIcon
+
 function PartyMenu.new(game, opts)
   opts = opts or {}
   local self = setmetatable({}, PartyMenu)

--- a/src/ui/StartMenu.lua
+++ b/src/ui/StartMenu.lua
@@ -10,6 +10,7 @@ local Menu = require("src.ui.Menu")
 local Renderer = require("src.render.Renderer")
 local Runtime = require("src.mods.Runtime")
 local Screens = require("src.ui.Screens")
+local SecondScreen = require("src.render.SecondScreen")
 local Strings = require("src.core.Strings")
 
 local StartMenu = {}
@@ -160,6 +161,22 @@ function StartMenu.new(game)
       Font.draw(("%2d"):format(math.floor(safari.balls or 0)), 48, 24)
       love.graphics.setColor(1, 1, 1, 1)
     end
+  end
+
+  -- AYN Thor second screen: this is the pause menu, so once a second
+  -- screen exists its content lives there instead -- a persistent left
+  -- column (src/render/OverworldSecondScreen.lua), which frees the main
+  -- screen to keep showing the map uninterrupted while paused, the same
+  -- move BattleState's menus already made for battle. drawColumn keeps
+  -- the real draw logic (box/items/cursor, including the safari overlay
+  -- above) available for the coordinator to call against the
+  -- second-screen canvas; draw() itself becomes a no-op on the main
+  -- screen once a second screen is present, and falls back to the
+  -- classic on-screen menu exactly as before everywhere else.
+  menu.drawColumn = menu.draw
+  menu.draw = function(self)
+    if SecondScreen.available() then return end
+    self:drawColumn()
   end
   return menu
 end


### PR DESCRIPTION
Wires the AYN Thor's bottom touchscreen up as a genuine second display:

- Native bridge (mobile/android): love.system.hasSecondaryDisplay / presentUIFrame / pollSecondScreenTouch (JNI), with a real touch channel back into Lua and lifecycle handling (closes with the app, reattaches on resume).
- Battle (src/battle/BattleState.lua): dialogue and controls (menu/moveSelect/mimicSelect) move to the second screen, tap-to-select drives the same confirm logic a real button press would, and the freed main-screen space scales up to fill with the battle scene (BATTLE_ZONES color-zone scissors re-derived to match).
- Overworld (src/render/OverworldSecondScreen.lua and friends): a non-pausing party-status panel, a persistent pause-menu column that gains focus the moment the player pauses and returns it on unpause, and a region-map tab reusing the existing Town Map screen.
- battle.sceneScale mod hook so a third-party battle-camera mod can opt out of the scale transform for frames it composes itself.
- Everything funnels through SecondScreen.available() as a single chokepoint, gated behind a new ENABLE DS row in the Options menu (src/ui/OptionsMenu.lua), defaulting on.

Zero behavior change on any device without the hardware hook (love.system.hasSecondaryDisplay) or with ENABLE DS turned off.