### PR TITLE
fix(android): raise soft keyboard for launcher text fields

### DIFF
--- a/src/import/RomImporter.lua
+++ b/src/import/RomImporter.lua
@@ -1310,6 +1310,7 @@ end
 
 function RomImporter:update(dt)
   self.pulse = self.pulse + dt
+  self:_syncKeyboard()
   self:_updatePadCursor(dt)
   if self.ios and love.system.getPickedFile and self.workState ~= "working" then
     local path = love.system.getPickedFile()
@@ -4588,6 +4589,53 @@ function RomImporter:_findThumb(entry)
   end)
   self._findThumbs[entry.id] = ok and image or false
   return ok and image or nil
+end
+
+-- Mobile soft keyboard sync.  LOVE only delivers love.textinput while
+-- setTextInput(true) is active, and that call is what raises the Android/iOS
+-- keyboard; desktop has text input on by default, so this is mobile-only
+-- (mirrors tools/save-editor/Kit.lua's syncSoftKeyboard).  The launcher's
+-- text fields -- save-slot rename (#205), the add-mod-index prompt (#578)
+-- and the mod search field -- never enabled it, so on Android the player
+-- could neither type nor paste into them.
+function RomImporter:_kbdFieldRect()
+  local s = self._s or 1
+  local ox, oy, width, height = SafeArea.rect()
+  local appW = math.min(width, 1440 * s)
+  local appX = ox + (width - appW) / 2
+  -- the two modals are centered boxes; field offsets match the draws
+  if self._indexPrompt then
+    local dw = math.min(appW - 32 * s, 520 * s)
+    local dh = 168 * s
+    local dx = appX + (appW - dw) / 2
+    local dy = oy + (height - dh) / 2
+    return "index", dx + 16 * s, dy + 66 * s, dw - 32 * s, 32 * s
+  end
+  if self._rename then
+    local dw = math.min(appW - 32 * s, 420 * s)
+    local dh = 128 * s
+    local dx = appX + (appW - dw) / 2
+    local dy = oy + (height - dh) / 2
+    return "rename", dx + 16 * s, dy + 44 * s, dw - 32 * s, 30 * s
+  end
+  if self._findSearchFocus and self.findSearchRect then
+    local r = self.findSearchRect
+    return "search", r.x, r.y, r.width, r.height
+  end
+  return nil
+end
+
+function RomImporter:_syncKeyboard()
+  local id, fx, fy, fw, fh = self:_kbdFieldRect()
+  if id == self._kbdField then return end
+  if self._kbdField and self.android then
+    love.keyboard.setTextInput(false)
+  end
+  self._kbdField = id
+  if id and self.android then
+    love.keyboard.setTextInput(true, math.floor(fx), math.floor(fy),
+      math.floor(fw), math.floor(fh))
+  end
 end
 
 -- Open the "add an index" text prompt.  Deliberately a typed URL rather than a

--- a/tests/rom_importer_keyboard_test.lua
+++ b/tests/rom_importer_keyboard_test.lua
@@ -1,0 +1,95 @@
+-- Mobile soft keyboard: LOVE only delivers love.textinput while
+-- setTextInput(true) is active, and that call is what raises the Android/iOS
+-- keyboard.  The launcher's text fields -- the add-mod-index prompt (#578),
+-- the mod search field and the save-slot rename modal (#205) -- must raise it
+-- while the field is up and lower it when it closes; desktop has text input on
+-- by default and must be left alone (mirrors tools/save-editor/Kit.lua).
+-- Self-contained: `luajit tests/rom_importer_keyboard_test.lua`.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+if not _G.love then _G.love = require("tests.love_stub") end
+
+local S = require("tests.harness").suite("rom importer soft keyboard")
+local eq = S.eq
+local check = S.check
+
+local RomImporter = require("src.import.RomImporter")
+
+local saved = love.keyboard.setTextInput
+
+local calls = {}
+love.keyboard.setTextInput = function(enabled, x, y, w, h)
+  calls[#calls + 1] = { enabled = enabled, x = x, y = y, w = w, h = h }
+end
+
+local function freshImporter(android)
+  return setmetatable({
+    android = android == nil and true or android,
+    tab = "find",
+    slots = {},
+    pulse = 0,
+    _padAxis = {},
+    _padDir = {},
+    _findSearchFocus = false,
+  }, RomImporter)
+end
+
+-- No field up: the keyboard stays down.
+calls = {}
+local ri = freshImporter()
+ri:update(0.016)
+eq(#calls, 0, "no field means no keyboard")
+
+-- Opening the add-an-index prompt raises the keyboard over the field (#578).
+calls = {}
+ri = freshImporter()
+ri:_promptAddIndex()
+ri:update(0.016)
+eq(#calls, 1, "prompt raises the keyboard")
+eq(calls[1].enabled, true, "prompt enables text input")
+check(calls[1].x == math.floor(calls[1].x)
+  and calls[1].y == math.floor(calls[1].y),
+  "prompt passes an integer field rect")
+
+-- Closing the prompt lowers it again.
+ri._indexPrompt = nil
+ri:update(0.016)
+eq(#calls, 2, "closing the prompt lowers the keyboard")
+eq(calls[2].enabled, false, "prompt close disables text input")
+
+-- The search field raises and lowers the same way, over its own rect.
+calls = {}
+ri = freshImporter()
+ri.findSearchRect = { x = 40, y = 80, width = 300, height = 30 }
+ri._findSearchFocus = true
+ri:update(0.016)
+eq(#calls, 1, "search focus raises the keyboard")
+eq(calls[1].enabled, true, "search focus enables text input")
+eq(calls[1].x, 40, "search raises over the field rect")
+eq(calls[1].y, 80, "search raises over the field rect")
+ri._findSearchFocus = false
+ri:update(0.016)
+eq(#calls, 2, "search blur lowers the keyboard")
+eq(calls[2].enabled, false, "search blur disables text input")
+
+-- The save-slot rename modal raises over its own rect (#205).
+calls = {}
+ri = freshImporter()
+ri:_beginRename("red", "missing")
+ri:update(0.016)
+eq(#calls, 1, "rename modal raises the keyboard")
+eq(calls[1].enabled, true, "rename enables text input")
+ri._rename = nil
+ri:update(0.016)
+eq(#calls, 2, "closing the rename modal lowers the keyboard")
+eq(calls[2].enabled, false, "rename close disables text input")
+
+-- Desktop is untouched: no field needs a raise, and a modal must not lower
+-- anything either (setTextInput is global SDL state).
+calls = {}
+ri = freshImporter(false)
+ri:_promptAddIndex()
+ri:update(0.016)
+eq(#calls, 0, "desktop never touches the soft keyboard")
+
+love.keyboard.setTextInput = saved
+S.finish()

--- a/tests/run_tests.lua
+++ b/tests/run_tests.lua
@@ -3366,6 +3366,9 @@ runSuites({ "tests/rom_importer_android_pick_test.lua" })
 -- ---------------------------------------------- Android mod / save SAF pick
 runSuites({ "tests/rom_importer_android_mod_pick_test.lua" })
 
+-- ---------------------------------------------- launcher soft keyboard (#578)
+runSuites({ "tests/rom_importer_keyboard_test.lua" })
+
 -- ---------------------------------------------- import with no picker (#482)
 runSuites({ "tests/rom_importer_no_picker_test.lua" })
 runSuites({ "tests/rom_importer_double_pick_test.lua" })


### PR DESCRIPTION
CLOSES #578

Mobile LOVE only delivers `love.textinput` while `love.keyboard.setTextInput(true)` is active, and that call is what raises the Android/iOS soft keyboard. The launcher's text fields -- the add-mod-index prompt, the mod search field and the save-slot rename modal -- never enabled it, so on Android the player could neither type nor paste an index URL.

Mirrors `tools/save-editor/Kit.lua`'s `syncSoftKeyboard` in `RomImporter:_syncKeyboard()`, driven from `update` on field-change; mobile-only, so desktop (text input on by default) is untouched.

- 17-check ROM-free suite `tests/rom_importer_keyboard_test.lua` (registered in `run_tests.lua`), run via `luajit tests/rom_importer_keyboard_test.lua`
- `scripts/test.sh` all ROM-free tiers pass; luacheck clean