### PR TITLE
Fix #596: missing rival battle music in Oak's Lab

### DIFF
--- a/data/scripts/oaks_lab.lua
+++ b/data/scripts/oaks_lab.lua
@@ -254,7 +254,12 @@ return {
        and y >= 6 then
       local rival = ow:npcByIndex(1)
       if not rival then return false end
+      -- OaksLabRivalChallengesPlayerScript swaps in the rival encounter
+      -- fanfare for the taunt/challenge exchange, same as the Yellow port
+      -- (oaks_lab_yellow.lua); it was silently dropped here (#596).
       local rows = {
+        { "stop_music" },
+        { "play_music", "Music_MeetRival" },
         { "show_text", "_OaksLabRivalIllTakeYouOnText" },         -- 1
       }
       -- the rival routes to a free cell beside the player
@@ -294,6 +299,8 @@ return {
       table.insert(rows, { "show_text", "_OaksLabRivalSmellYouLaterText" })
       table.insert(rows, { "move_npc_to", 1, 4, 11 })
       table.insert(rows, { "hide_object", "OAKS_LAB", "OAKSLAB_RIVAL" })
+      -- restore the lab theme once he's walked out, same as the Yellow port
+      table.insert(rows, { "play_music", "Music_OaksLab" })
       ow.runner:run(rows, { npc = rival })
       return true
     end


### PR DESCRIPTION
Fixes #596.

The rival battle in Oak's Lab was silent before and after the fight. The Yellow port of this script (oaks_lab_yellow.lua) plays Music_MeetRival before the "Hey wait! Let's check out our Pokemon!" line and restores Music_OaksLab after the rival walks out, but the Red/Blue script (oaks_lab.lua) never had that code.

Added the same two music calls to oaks_lab.lua's onStep rival challenge trigger.