### PR TITLE
fix: Play Oak's name confirmation lines

### DIFF
--- a/src/ui/OakSpeech.lua
+++ b/src/ui/OakSpeech.lua
@@ -46,6 +46,8 @@ local FALLBACKS = {
   _OakSpeechText3 = Strings.source("{PLAYER}!\fYour very own\nPOKéMON legend is\vabout to unfold!\fA world of dreams\nand adventures\vwith POKéMON\vawaits! Let's go!"),
   _IntroducePlayerText = Strings.source("First, what is\nyour name?"),
   _IntroduceRivalText = Strings.source("This is my grand-\nson. He's been\vyour rival since\vyou were a baby.\f...Erm, what is\nhis name again?"),
+  _YourNameIsText = Strings.source("Right! So your\nname is {PLAYER}!"),
+  _HisNameIsText = Strings.source("That's right! I\nremember now! His\vname is {RIVAL}!"),
 }
 
 local function textOr(game, key)
@@ -153,6 +155,14 @@ function OakSpeech.defaultSteps(speech)
       presetsFallback = { "RED", "ASH", "JACK" },
     },
     {
+      -- oak_speech.asm prints YourNameIsText right after the naming screen
+      -- returns ("Right! So your name is RED!"); the port went straight on
+      -- to the rival and dropped it, in every language.
+      id = "confirm_player_name",
+      kind = "say",
+      textKey = "_YourNameIsText",
+    },
+    {
       id = "ask_rival_name",
       kind = "say",
       textKey = "_IntroduceRivalText",
@@ -165,6 +175,12 @@ function OakSpeech.defaultSteps(speech)
       title = Strings("HIS NAME?"),
       presetsWho = "rival",
       presetsFallback = { "BLUE", "GARY", "JOHN" },
+    },
+    {
+      -- HisNameIsText, the rival's counterpart to the confirmation above
+      id = "confirm_rival_name",
+      kind = "say",
+      textKey = "_HisNameIsText",
     },
     {
       id = "legend",

--- a/tests/mod_ui_tests.lua
+++ b/tests/mod_ui_tests.lua
@@ -779,8 +779,9 @@ check(oak.demoSpecies == "NIDORINO" and oak.nameLen == 7,
 
 -- ------- intro.oak_speech.build
 local vanillaSteps = OakSpeech.defaultSteps(oak)
-check(#vanillaSteps == 9, "vanilla speech has nine steps")
-check(vanillaSteps[1].id == "oak_welcome" and vanillaSteps[9].id == "shrink",
+check(#vanillaSteps == 11, "vanilla speech has eleven steps")
+check(vanillaSteps[1].id == "oak_welcome"
+  and vanillaSteps[#vanillaSteps].id == "shrink",
   "vanilla speech anchors start and end")
 
 hooks:wrap("intro.oak_speech.build", function(nextFn, steps, speech)
@@ -799,7 +800,7 @@ hooks:removeOwner("fixture")
 
 hooks:wrap("intro.oak_speech.build", function() return 42 end, 0, "bad")
 built = oak:buildSteps()
-check(#built == 9 and built[1].id == "oak_welcome",
+check(#built == #vanillaSteps and built[1].id == "oak_welcome",
   "a non-table intro.oak_speech.build result degrades to vanilla")
 check(logged("intro.oak_speech.build returned"),
   "the intro build degrade is logged")


### PR DESCRIPTION
## What

Oak's intro never shows the two confirmation lines that follow the naming screens: "Right! So your name is RED!" and "That's right! I remember now! His name is BLUE!".

## Why it happens

`engine/movie/oak_speech/oak_speech.asm` prints six texts:

    OakSpeechText1 → 2A → 2B → IntroducePlayerText → [naming] →
    YourNameIsText → IntroduceRivalText → [naming] → HisNameIsText →
    OakSpeechText3

`OakSpeech.defaultSteps` only played four of them: after each naming step it went straight on to the next prompt. `_YourNameIsText` and `_HisNameIsText` are extracted into the cache like every other label, they were simply never referenced anywhere in `src/` or `data/`, so the data was there and unused.

This is version- and language-independent: the step table is the same for every import, so US Red drops the lines too.

## Fix

Two `kind = "say"` steps using the existing `textOr` path, so the ROM's own line is shown and the English `FALLBACKS` entry only covers a cache that predates the label. Step ids follow the documented convention that "ids are the stable anchors mods insert around", so a mod anchored on `name_player` or `ask_rival_name` keeps working.

## Tests

`tests/mod_ui_tests.lua` pinned the vanilla speech at nine steps and asserted `vanillaSteps[9].id == "shrink"` by index. Updated to eleven, and the end anchor now reads `vanillaSteps[#vanillaSteps]` so the next inserted step does not have to touch the assertion.

Worth noting for reviewers: those checks run from `tests/run_tests.lua`, which `scripts/test.sh` skips without `data/generated/`, so `--quick` stays green either way. They were verified by mounting an imported cache and running `run_tests.lua` directly.