### PR TITLE
fix: Oak's intro white field stops short of the dialogue box

### DIFF
--- a/src/ui/OakSpeech.lua
+++ b/src/ui/OakSpeech.lua
@@ -20,6 +20,16 @@ local OakSpeech = {}
 OakSpeech.__index = OakSpeech
 OakSpeech.isOpaque = true
 
+-- The speech is a white field with a pic on it, and its dialogue box docks to
+-- the WINDOW's bottom edge (Renderer:setUIAnchor, via TextBox).  The white it
+-- fills below is only the 160x144 UI canvas, so once the box moved to the
+-- window edge the two stopped touching: black letterbox showed between the
+-- bottom of Oak's white and the top of the box he is speaking from.  Filling
+-- the voids with the paper shade -- the same opt-in a battle uses -- puts the
+-- box back on the field.  Not a literal 1,1,1: the canvas is colorized, so
+-- endFrame matches it with PaletteFX.paperShade.
+OakSpeech.letterboxWhite = true
+
 -- FadeInIntroPic runs a 6-step palette fade; MovePicLeft wipes the mon
 -- sprite in from the right.  Both play out before the beat's text prints.
 local FADE_FRAMES = 24
@@ -611,6 +621,15 @@ function OakSpeech:draw()
     love.graphics.draw(self.walkSheet, self.walkQuad, 64, 60)
   end
   if self.shrinkText then
+    -- This is a REPLICA of the dialogue box that just closed, redrawn at
+    -- TextBox's own rect (BOX_TX..BOX_TH = 0,12,20,6) so the last page holds
+    -- while the pic shrinks.  The real box rides the bottom anchor, so this
+    -- one has to as well -- otherwise the text visibly jumps up a letterbox
+    -- on the frame the real box is swapped for this copy.
+    local r = self.game and self.game.renderer
+    if r and r.setUIAnchor then
+      r:setUIAnchor(0, 12 * 8, 20 * 8, 6 * 8, "bottom")
+    end
     Font.drawBox(0, 12, 20, 6)
     love.graphics.setColor(0, 0, 0, 1)
     for i, line in ipairs(self.shrinkText) do

--- a/tests/drivers/oak_speech_letterbox_test.lua
+++ b/tests/drivers/oak_speech_letterbox_test.lua
@@ -1,0 +1,67 @@
+-- Driver: Oak's intro white field must reach the dialogue box.
+--
+-- The speech fills white over the 160x144 UI canvas, but TextBox docks to the
+-- WINDOW's bottom edge (Renderer:setUIAnchor).  In a letterboxed window that
+-- left black between the bottom of the white and the top of the box.
+-- OakSpeech.letterboxWhite fills the voids with the paper shade instead.
+--
+-- Needs a window that actually letterboxes -- an exact multiple of 160x144
+-- has no voids to get wrong -- so it resizes before shooting.
+--   POKEPORT_DRIVER=tests/drivers/oak_speech_letterbox_test.lua lovec .
+return function(game)
+  local U = dofile("tests/drivers/util.lua")
+  local DIR = os.getenv("SHOT_DIR") or "/tmp/shots"
+  local OakSpeech = require("src.ui.OakSpeech")
+
+  local function speechUp()
+    for _, s in ipairs(game.stack.states or {}) do
+      if getmetatable(s) == OakSpeech then return s end
+    end
+    return nil
+  end
+
+  -- 1000x700 is not a multiple of 160x144, so the UI blits at 4x (640x576)
+  -- with real bars above/below -- exactly where the seam shows
+  love.window.setMode(1000, 700)
+  U.wait(30)
+
+  U.wait(5)
+  U.tap(game, "start") -- skip the intro movie
+  U.wait(20)
+  U.tap(game, "a")     -- title -> menu
+  U.wait(20)
+  U.tap(game, "a")     -- NEW GAME
+  U.wait(30)
+
+  local speech
+  for _ = 1, 600 do
+    speech = speechUp()
+    if speech then break end
+    U.wait(2)
+  end
+  if not speech then
+    U.log("FAIL never reached Oak's speech")
+    return
+  end
+  U.log("Oak speech is up; letterboxWhite =", tostring(OakSpeech.letterboxWhite))
+
+  -- page through, shooting a few beats: the pic + box together is the shot
+  -- that shows whether the white reaches the box
+  for i = 1, 4 do
+    for _ = 1, 200 do
+      local top = game.stack:top()
+      if top and top ~= speech and top.done then break end
+      U.tap(game, "a")
+      U.wait(2)
+      if not speechUp() then break end
+    end
+    if not speechUp() then break end
+    U.wait(20)
+    U.shot(game, DIR .. ("/oak_%d.png"):format(i))
+    U.tap(game, "a")
+    U.wait(20)
+  end
+
+  U.log("done")
+  U.wait(30)
+end


### PR DESCRIPTION
Oak's speech fills white over the 160x144 UI canvas, but its dialogue box docks to the **window** bottom edge (`Renderer:setUIAnchor`, via `TextBox`). In any letterboxed window that leaves black between the bottom of the white and the top of the box he is speaking from.

Opts into `letterboxWhite`, the same surround a battle already claims, so the voids take the paper shade and the two meet.

Also: the shrink beat redraws the last page itself as a replica at `TextBox`'s own rect while the pic shrinks. That copy now rides the same bottom anchor as the real box it stands in for — otherwise the text jumps up a letterbox on the frame of the swap.

Driver at `tests/drivers/oak_speech_letterbox_test.lua` (resizes to 1000x700 first — an exact multiple of 160x144 has no voids to get wrong).