### PR TITLE
feat: POKEPORT_NO_MODS boots with every mod disabled

### DIFF
--- a/CONTRIBUTING-mods.md
+++ b/CONTRIBUTING-mods.md
@@ -166,6 +166,30 @@ lowercases and de-dupes. A recommended starting set: `beginner`,
 `data-only`, `quality-of-life`, `hardcore`, `cosmetic`, `story`, `ruleset`,
 `audio`, `ui`, `total-conversion`.
 
+### Is it your mod, or the engine?
+
+Answer this before filing a bug against the engine -- and expect to be asked
+for it when you do.
+
+```sh
+POKEPORT_NO_MODS=1 ./scripts/run.sh              # macOS / Linux
+```
+```powershell
+$env:POKEPORT_NO_MODS = '1'; .\scripts\run.ps1   # Windows
+```
+
+Every installed mod is skipped for that run. Still happens? It is the
+engine. Gone? It is a mod -- boot normally and disable them one at a time to
+find which.
+
+This is a load-time skip, not an uninstall: the mod manager still lists
+everything, and **your per-mod enable choices are never written while it is
+set**, so a toggle in that session cannot overwrite the configuration you are
+bisecting against.
+
+Worth setting for driver and CI runs (`POKEPORT_DRIVER`) too, so a scripted
+run does not depend on whatever happens to be installed in that checkout.
+
 ---
 
 ## Route B — contributing an engine / mod-API change

--- a/src/mods/Loader.lua
+++ b/src/mods/Loader.lua
@@ -182,6 +182,11 @@ end
 function Loader:_saveState()
   -- a read-only injected fs keeps enable toggles in-memory only
   if not self.fs.write then return end
+  -- POKEPORT_NO_MODS force-disables everything for this run only.  This
+  -- writes `not disabled` for EVERY mod, so persisting from such a session --
+  -- one toggle in the mod manager is enough to call it -- would overwrite the
+  -- player's real enable choices with "all off".
+  if self.forceNoMods then return end
   local options = SaveData.loadOptions(self.fs)
   options.mods = options.mods or {}
   for id in pairs(self.mods) do
@@ -838,6 +843,17 @@ function Loader:load(data)
   require("src.mods.Builtins").install(self.content, data)
   self:_loadState()
   self:_discover()
+  -- POKEPORT_NO_MODS=1: boot with every mod off, for telling an engine bug
+  -- apart from a mod's without uninstalling anything.  After _discover so it
+  -- covers whatever is actually installed, and the manager still LISTS them
+  -- all -- this disables loading, it is not an uninstall.  Strictly a
+  -- run-time switch: _saveState refuses to persist while it is set.
+  if os.getenv("POKEPORT_NO_MODS") then
+    self.forceNoMods = true
+    for id in pairs(self.mods) do
+      self.disabled[id] = true
+    end
+  end
   -- Experimental mods stay off until the player opts in: a missing
   -- options.mods entry normally means enabled, but experimental flips that.
   do


### PR DESCRIPTION
"Does it still happen with mods off?" is the first question on any bug report from a modded build, and there is currently no way to answer it short of uninstalling or hand-editing options. Joins `POKEPORT_NO_DISCORD` and the rest of the `POKEPORT_*` family. Unset, nothing changes.

```sh
POKEPORT_NO_MODS=1 ./scripts/run.sh
```

A load-time skip, not an uninstall: the manager still lists everything, so you can boot mod-free to confirm, then boot normally and bisect by toggling.

`_saveState` is gated on the flag. It writes an entry for *every* mod, so one toggle in the manager during such a session would have persisted "all off" over the real per-mod choices, destroying the configuration being bisected against.

Docs under Route A in `CONTRIBUTING-mods.md`, since mod authors are the ones who most need "check whether the engine does this too" before filing.