### PR TITLE
Play rival encounter music when rival leaves Oak's Lab after battle

### DIFF
--- a/data/scripts/oaks_lab.lua
+++ b/data/scripts/oaks_lab.lua
@@ -325,9 +325,14 @@ return {
       table.insert(rows, { "jump_if_false", base + 6 })
       table.insert(rows, { "show_text", "_OaksLabRivalIPickedTheWrongPokemonText" })
       table.insert(rows, { "show_text", "_OaksLabRivalSmellYouLaterText" })
+      -- OaksLabRivalStartsExitScript: parting shot, rival exit fanfare, then
+      -- walk out past the player.  The fanfare was dropped here (#683) -- the
+      -- parcel scene above already plays Music_MeetRival on both arrival and
+      -- departure (lines 144-146), and this exit should match (#596).
+      table.insert(rows, { "stop_music" })
+      table.insert(rows, { "play_music", "Music_MeetRival" })
       table.insert(rows, { "move_npc_to", 1, 4, 11 })
       table.insert(rows, { "hide_object", "OAKS_LAB", "OAKSLAB_RIVAL" })
-      -- restore the lab theme once he's walked out, same as the Yellow port
       table.insert(rows, { "play_music", "Music_OaksLab" })
       ow.runner:run(rows, { npc = rival })
       return true

--- a/data/scripts/oaks_lab_yellow.lua
+++ b/data/scripts/oaks_lab_yellow.lua
@@ -287,10 +287,12 @@ return {
       table.insert(rows, { "label", "lost_lab" })
       table.insert(rows, { "set_field", "rivalStarter", 3 })
       table.insert(rows, { "label", "exit" })
-      -- OaksLabRivalStartsExitScript: parting shot, walk out past the
-      -- player, restore the lab theme
+      -- OaksLabRivalStartsExitScript: parting shot, rival exit fanfare, then
+      -- walk out past the player (#683).
       table.insert(rows, { "wait", 20 })
       table.insert(rows, { "show_text", "_OaksLabRivalSmellYouLaterText" })
+      table.insert(rows, { "stop_music" })
+      table.insert(rows, { "play_music", "Music_MeetRival" })
       table.insert(rows, { "move_npc_to", RIVAL, 4, 11 })
       table.insert(rows, { "hide_object", "OAKS_LAB", "OAKSLAB_RIVAL" })
       table.insert(rows, { "play_music", "Music_OaksLab" })


### PR DESCRIPTION
## Fixes #683

### Root Cause
The Oak's Lab onStep rival battle sequence plays Music_MeetRival when the rival approaches (fixed in #596), but it was missing from the rival's departure walk-out. The parcel scene elsewhere in oaks_lab.lua already uses the correct double-fanfare pattern -- Music_MeetRival plays on both the rival's arrival (line 114) and departure (line 145).

The post-battle onStep exit jumped straight from the "Smell you later!" text to move_npc_to without the rival encounter fanfare, so the rival left silently to Music_OaksLab.

### Changes
- data/scripts/oaks_lab.lua: Added stop_music + play_music Music_MeetRival before the rival's walk-out, matching the parcel scene pattern.
- data/scripts/oaks_lab_yellow.lua: Same fix applied to the Yellow version.

### Script flow (after fix)
1. show_text "I'll take you on!" -> stop_music -> play_music Music_MeetRival (approach fanfare)
2. start_battle OPP_RIVAL1 -> battle theme
3. show_text "Smell you later!"
4. stop_music -> play_music Music_MeetRival (exit fanfare, NEW)
5. move_npc_to 4,11 (rival walks out to rival theme)
6. play_music Music_OaksLab (lab music restored)

This matches the parcel scene's double-fanfare pattern from the original ROM.
