### PR TITLE
Fix PC B-button navigation and hole-fall sound effect

### DIFF
--- a/data/scripts/seafoam.lua
+++ b/data/scripts/seafoam.lua
@@ -56,6 +56,7 @@ for mapId, holes in pairs(HOLE_FALLS) do
   M[mapId].onStep = function(game, ow, x, y)
     for _, h in ipairs(holes) do
       if x == h[1] and y == h[2] then
+        require("src.core.Sound").play(game.data, "Faint_Fall")
         ow:startWarpTo(h[3], h[4], h[5], ow.player.facing)
         return true
       end

--- a/data/scripts/story.lua
+++ b/data/scripts/story.lua
@@ -942,6 +942,7 @@ M.VICTORY_ROAD_3F = {
   -- fall is onStep, not a collision block.
   onStep = function(game, ow, x, y)
     if x == 23 and y == 15 then
+      require("src.core.Sound").play(game.data, "Faint_Fall")
       ow:startWarpTo("VICTORY_ROAD_2F", 22, 16, ow.player.facing)
       return true
     end

--- a/data/scripts/story6.lua
+++ b/data/scripts/story6.lua
@@ -118,6 +118,7 @@ local MANSION_HOLES = {
 M.POKEMON_MANSION_3F.onStep = function(game, ow, x, y)
   for _, h in ipairs(MANSION_HOLES) do
     if x == h[1] and y == h[2] then
+      require("src.core.Sound").play(game.data, "Faint_Fall")
       ow:startWarpTo(h[3], h[4], h[5], ow.player.facing)
       return true
     end

--- a/src/world/OverworldController.lua
+++ b/src/world/OverworldController.lua
@@ -2580,8 +2580,13 @@ function OverworldState:openPC(onDone)
   -- (engine/menus/pokemon_pc.asm gates on EVENT_MET_BILL; we reach that
   -- when Bill hands over the SS Ticket)
   local metBill = flags.EVENT_MET_BILL or flags.EVENT_GOT_SS_TICKET
+  -- keepOpen so B in the sub-PC returns here instead of exiting the
+  -- PC session (#695); the sub-PC screens (BoxMenu, PlayerPC) already
+  -- use keepOpen for their own rows, matching the original ROM's flow
+  -- where the main menu stays underneath.
   table.insert(items, {
     label = metBill and "BILL'S PC" or Strings("SOMEONE'S PC"),
+    keepOpen = true,
     onSelect = function()
       require("src.core.Sound").play(Game.data, "Enter_PC")
       Screens.push(Game, "BoxMenu")
@@ -2592,6 +2597,7 @@ function OverworldState:openPC(onDone)
   -- the player's item storage is always available
   table.insert(items, {
     label = (Game.save.player.name or "RED") .. "'s PC",
+    keepOpen = true,
     onSelect = function()
       Screens.push(Game, "PlayerPC")
       done()
@@ -2602,6 +2608,7 @@ function OverworldState:openPC(onDone)
   if flags.EVENT_GOT_POKEDEX then
     table.insert(items, {
       label = Strings("PROF.OAK's PC"),
+      keepOpen = true,
       onSelect = function()
         self:openOaksPC(done)
       end,
@@ -3774,7 +3781,9 @@ function OverworldState:takeWarp(warpDef)
     self:startWarpTo(destMap, x, y, facing)
     return
   elseif pad == "hole" then
-    -- falling through a hole: no door SFX, no walk-out step
+    -- falling through a hole: Faint_Fall plays while the player drops,
+    -- matching the boulder-hole Faint_Thud at line 3618 (#694)
+    require("src.core.Sound").play(Game.data, "Faint_Fall")
     self:startWarpTo(destMap, x, y, facing)
     return
   end


### PR DESCRIPTION
## Fixes #695 + #694

### #695 — Pressing B on the PC should go back, not close

**Root cause:** The three PC main-menu items (Bill's PC, player's PC, Prof. Oak's PC) were missing `keepOpen = true`. When one was selected, `Menu.lua:93` popped the PC main menu off the stack, so pressing B in BoxMenu or PlayerPC returned to the overworld instead of the PC main menu.

**Fix:** Added `keepOpen = true` to all three PC main-menu items in `src/world/OverworldController.lua:openPC()`. This matches the pattern already used by BoxMenu and PlayerPC's own sub-rows.

The log-off sound (`Turn_Off_PC`) still only plays when B is pressed on the main PC menu (via `onCancel = logOff`), which is the correct behavior from the original ROM.

### #694 — Missing sound effect when falling from boulder holes

**Root cause:** All four hole-fall code paths called `startWarpTo()` without playing a sound effect:

| File | Location |
|------|----------|
| `data/scripts/seafoam.lua` | Seafoam Islands hole warps |
| `data/scripts/story.lua` | Victory Road 3F hole |
| `data/scripts/story6.lua` | Pokemon Mansion 3F holes |
| `src/world/OverworldController.lua` | Warp-tile-based hole detection (`takeWarp`) |

**Fix:** Added `Sound.play(game.data, "Faint_Fall")` before each `startWarpTo()` call. `Faint_Fall` is the companion to `Faint_Thud` (already played when boulders fall into holes at `OverworldController.lua:3618`). Teleporter pads already play `Teleport_Exit1` via the same code path — this adds parity for hole falls.

**Files changed:** 4 files, +13/-1 lines