### PR TITLE
Add 3X game speed and R2/L2 shoulder button speed hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ supported out of the box.
 | Key       | What it does                                         |
 | --------- | ---------------------------------------------------- |
 | `-` / `=` | Zoom out / in (overworld; also mouse wheel)          |
+| `1`       | Cycle GAME SPEED up (controller: R2 faster, L2 slower) |
 | `2`       | Cycle COLORS                                         |
 | `3`       | Cycle TILT (free-roam overworld)                     |
 | `4`       | Cycle ZOOM through every level (free-roam overworld) |
@@ -121,8 +122,8 @@ supported out of the box.
 | `F10`     | Open / close the mod manager                         |
 
 
-COLORS, TILT, ZOOM, GBC FX, and VOID FILL are also in the Options menu
-and persist in `options.lua`.
+COLORS, TILT, ZOOM, GBC FX, GAME SPEED, and VOID FILL are also in the
+Options menu and persist in `options.lua`.
 
 ### Low-end devices
 

--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -509,6 +509,24 @@ function Game:wheelmoved(_, dy)
   end
 end
 
+function Game:_cycleSpeed(dir)
+  if not (self.save and self.save.options) then return end
+  local busy
+  local ow = self.overworld
+  if ow then
+    local top = self.stack:top()
+    busy = ow.transitioning
+      or (top == ow and (
+           (ow.runner and ow.runner.isRunning and ow.runner:isRunning())
+        or (ow.scriptMoves and #ow.scriptMoves > 0)
+        or ow.engaging or ow.emote))
+  end
+  if busy then return end
+  local GameSpeed = require("src.core.GameSpeed")
+  self.save.options.speed = GameSpeed.cycle(self.save.options.speed, dir)
+  self:writeOptions()
+end
+
 function Game:keypressed(key)
   if self.stack and self.stack:top() and self.stack:top().onKeyPressed then
     self.stack:top():onKeyPressed(key)
@@ -545,6 +563,11 @@ function Game:keypressed(key)
     return
   elseif key == "=" then
     self:zoomStep(1)
+    return
+  elseif key == "1" then
+    -- cycle GAME SPEED (0.25X → 200X, logic only; audio unaffected);
+    -- R2/L2 on gamepad do the same (see gamepadpressed)
+    self:_cycleSpeed(1)
     return
   elseif key == "2" then
     -- cycle COLORS (GBC / OG / OG INV / GBC INV / CLASSIC); the pack change
@@ -626,6 +649,15 @@ function Game:gamepadpressed(joystick, button)
   -- a controller is being used: the touch overlay steps aside until the
   -- next screen touch (mobile only; a no-op elsewhere)
   TouchControls:noteGamepad()
+  -- shoulder buttons cycle GAME SPEED (R2/rightshoulder = faster,
+  -- L2/leftshoulder = slower; same as keyboard hotkey 1)
+  if button == "rightshoulder" then
+    self:_cycleSpeed(1)
+    return
+  elseif button == "leftshoulder" then
+    self:_cycleSpeed(-1)
+    return
+  end
   -- BindingsMenu's pad capture rides the same top-state routing as keys
   local top = self.stack and self.stack:top()
   if top and top.onGamepadPressed then

--- a/src/core/GameSpeed.lua
+++ b/src/core/GameSpeed.lua
@@ -18,7 +18,7 @@ local GameSpeed = {}
 -- attempt is long enough that the iteration loop, not the engine, is the
 -- bottleneck. Vsync caps how much a real frame can do, so past 10X the
 -- multiplier is increasingly a ceiling rather than a rate.
-GameSpeed.LEVELS = { 1, 2, 4, 10, 20, 30, 50, 75, 100,200 }
+GameSpeed.LEVELS = { 1, 2, 3, 4, 10, 20, 30, 50, 75, 100, 200 }
 GameSpeed.DEFAULT = 1
 
 function GameSpeed.levelLabel(v)


### PR DESCRIPTION
## Fixes #677

### Changes

**3X speed level** — Added `3` between `2` and `4` in `GameSpeed.LEVELS` (`src/core/GameSpeed.lua`). The Options Menu GAME SPEED row now cycles through: 1, 2, 3, 4, 10, 20, 30, 50, 75, 100, 200.

**Controller hotkeys (R2/L2)** — `rightshoulder` cycles speed up, `leftshoulder` cycles speed down. These are handled in `Game:gamepadpressed` before the Input bindings mapping, so they work independently of the player's button configuration without shadowing any GB button.

**Keyboard hotkey (1)** — Pressing `1` cycles speed up, matching the same pattern as hotkey `2` (colors), `3` (tilt), etc.

**Safety gate** — The `_cycleSpeed` helper blocks speed changes during transitions, scripted cutscenes, and link play (identical guard to the color-cycle hotkey at key 2).

### Files changed
| File | Change |
|------|--------|
| `src/core/GameSpeed.lua` | Added 3 to LEVELS list |
| `src/core/Game.lua` | Added `_cycleSpeed` method, keyboard `1` hotkey, gamepad shoulder button handling |
