### PR TITLE
Fix PP UP max PP not shown on stats/summary screen

### DIFF
--- a/src/ui/SummaryMenu.lua
+++ b/src/ui/SummaryMenu.lua
@@ -203,7 +203,8 @@ function SummaryMenu:draw()
         local mdef = data.moves[mv.id]
         Font.draw(mdef.name, 16, y)
         Font.draw(Strings("PP"), 88, y + 8)
-        Font.draw(("%2d/%2d"):format(mv.pp, mdef.pp), 112, y + 8)
+        local maxPP = mdef.pp + (mv.ppUps or 0) * math.floor(mdef.pp / 5)
+        Font.draw(("%2d/%2d"):format(mv.pp, maxPP), 112, y + 8)
       else
         Font.draw("-", 16, y)
         Font.draw("--", 112, y + 8)


### PR DESCRIPTION
## Fixes #641

**Root cause:** The SummaryMenu (pause-menu stats screen, also reachable in-battle via PKMN → STATS) displayed base PP as max PP, ignoring PP Up bonuses. After using a PP UP on a move with 5 base PP, the screen showed `6/5` instead of `6/6`.

**Fix:** `src/ui/SummaryMenu.lua:206` — Calculate maxPP with the PP Up bonus using the same formula as every other location in the codebase: `basePP + ppUps * floor(basePP / 5)`.

Every other PP display (battle fight menu detail box, ETHER restore, Pokemon Center heal, link protocol, save editor) already uses this formula. The SummaryMenu was the sole outlier.