### PR TITLE
Fix revived Pokemon not receiving experience share

### DIFF
--- a/src/inventory/ItemEffects.lua
+++ b/src/inventory/ItemEffects.lua
@@ -324,6 +324,11 @@ function ItemEffects.use(data, save, itemId, target, battle, moveIndex, ow)
     require("src.core.Sound").play(data, "Heal_HP")
     -- a revive takes the same .healHP -> .doneHealing route, animating up
     -- from the fainted mon's 0 HP (#252)
+    -- re-add to participants so the revived mon gets its share of exp
+    -- at battle end (onFaint clears the flag; revive must restore it)
+    if battle and battle.participants then
+      battle.participants[target] = true
+    end
     return "consumed", { Strings("%s\nis revitalized!", monName(data, target)) },
            { healedFrom = 0 }
   end


### PR DESCRIPTION
## Fixes #648

**Root cause:** When a Pokemon faints, `onFaint()` at `BattleState.lua:3523` removes it from the battle participant set (`self.participants[mon] = nil`). The revive item restores HP but never re-adds the mon to participants, so at `awardExp()` the revived mon passes the HP check but fails the participant gate -- getting no experience share.

**Fix:** `src/inventory/ItemEffects.lua:326-329` — After restoring HP, re-add the revived mon to `battle.participants`. This ensures `awardExp()` finds it and includes it in the `alive` list for experience distribution.