### PR TITLE
Start champion theme when rival dialogue ends, not at battle

### DIFF
--- a/data/scripts/story.lua
+++ b/data/scripts/story.lua
@@ -981,10 +981,15 @@ M.VICTORY_ROAD_3F = {
 local championsRoomRivalScript = {
   { "face_player" },                                        -- 1
   { "check_flag", "EVENT_BEAT_CHAMPION_RIVAL_THIS_RUN" },   -- 2
-  { "jump_if_true", 25 },                                   -- 3  past end
+  { "jump_if_true", 26 },                                   -- 3  past end
   { "show_text", "_ChampionsRoomRivalIntroText" },          -- 4
-  { "rival_battle", "OPP_RIVAL3", 1 },                      -- 5
-  { "jump_if_false", 25 },                                  -- 6  past end
+  -- ChampionsRoomRivalReadyToBattleScript plays MUSIC_FINAL_BATTLE after
+  -- the intro text, before the battle itself (#706); pushBattle's wipe-time
+  -- playBattle("final") then no-ops on the same song, so the theme stays
+  -- continuous into the fight
+  { "play_music", "Music_FinalBattle" },                    -- 5
+  { "rival_battle", "OPP_RIVAL3", 1 },                      -- 6
+  { "jump_if_false", 26 },                                  -- 6  past end
   { "set_flag", "EVENT_BEAT_CHAMPION_RIVAL_THIS_RUN" },     -- 7
   { "set_flag", "EVENT_BEAT_CHAMPION_RIVAL" },              -- 8
   -- ChampionsRoomRivalDefeatedScript re-displays TEXT_CHAMPIONSROOM_RIVAL,


### PR DESCRIPTION
## Fixes #706

### Root cause

The Elite Four champion script (`data/scripts/story.lua`) showed the rival's intro text and then jumped straight into `rival_battle`. The battle theme only started when `OverworldState:pushBattle` fired `Music.playBattle("final")` at the transition wipe — i.e. when the battle actually began.

In the original game, `ChampionsRoomRivalReadyToBattleScript` plays `MUSIC_FINAL_BATTLE` right after the dialogue ends, before the battle starts.

### Fix

- Added a `play_music Music_FinalBattle` row between the intro text and the `rival_battle` row in `championsRoomRivalScript`.
- Bumped the two past-the-end jump targets (`jump_if_true 25` / `jump_if_false 25`) to `26`, since the script now has 25 rows (the jumps must point past the last row).
- The wipe-time `playBattle("final")` in `pushBattle` then no-ops on the already-playing song (`Music.play` dedupes by song), so the theme stays continuous into the fight.

### Verification

- Script structure verified: row 5 = `play_music Music_FinalBattle`, row 6 = `rival_battle`, jumps point to row 26 (past end).
- `tests/parity_B.lua` — 27/31, same as before the change (the 4 failures are pre-existing fixture gaps: no HALL_OF_FAME/CHAMPIONS_ROOM maps in the ROM-free fixture).
