### PR TITLE
iOS: a file picker dismissed by swiping locks out every later picker

### DIFF
--- a/mobile/ios/native/GRPickerBridge.swift
+++ b/mobile/ios/native/GRPickerBridge.swift
@@ -174,15 +174,27 @@ public final class GRPickerBridge: NSObject {
             // Without this the stacked present makes the picker auto-dismiss
             // with zero documents (observed as didPickDocumentsAt 0 urls)
             // and the user's pick silently does nothing.
+            guard var top = UIApplication.shared.windows
+                .first(where: { $0.isKeyWindow })?.rootViewController
+            else { return false }
+            // Self-heal before consulting the list. If UIKit is presenting
+            // nothing at all, any delegate still in it belongs to a sheet
+            // that is long gone, and treating it as live would lock the
+            // picker out for the rest of the session. Belt and braces with
+            // the dismissal callback above: that one closes the known hole,
+            // this one closes whatever hole iOS invents next.
+            if top.presentedViewController == nil, !liveDelegates.isEmpty {
+                NSLog("GRPickerBridge: clearing %d stale delegate(s)",
+                      liveDelegates.count)
+                liveDelegates.removeAll()
+            }
             guard liveDelegates.isEmpty else {
                 NSLog("GRPickerBridge: picker already active; ignoring re-present")
                 return true
             }
-            guard var top = UIApplication.shared.windows
-                .first(where: { $0.isKeyWindow })?.rootViewController
-            else { return false }
             while let presented = top.presentedViewController { top = presented }
             picker.delegate = delegate
+            picker.presentationController?.delegate = delegate
             liveDelegates.append(delegate)
             delegate.onFinish = { [weak delegate] in
                 liveDelegates.removeAll { $0 === delegate }
@@ -197,7 +209,8 @@ public final class GRPickerBridge: NSObject {
     }
 }
 
-private final class PickerDelegate: NSObject, UIDocumentPickerDelegate {
+private final class PickerDelegate: NSObject, UIDocumentPickerDelegate,
+                                    UIAdaptivePresentationControllerDelegate {
     private let onPick: ([URL]) -> Void
     var onFinish: (() -> Void)?
     init(onPick: @escaping ([URL]) -> Void) { self.onPick = onPick }
@@ -213,6 +226,20 @@ private final class PickerDelegate: NSObject, UIDocumentPickerDelegate {
         // No file was written; the Lua side's pending-file poll simply
         // never finds anything.
         NSLog("GRPickerBridge: picker cancelled")
+        onFinish?()
+    }
+
+    // Swiping the sheet down calls NEITHER of the two above: since iOS 13 an
+    // interactively dismissed picker reports only through the adaptive
+    // presentation delegate. Without this the delegate is never taken out of
+    // liveDelegates, the re-present guard below then swallows every later
+    // picker while still answering true -- so Lua arms its poll and waits for
+    // a file that no sheet is ever going to produce. That is the whole of the
+    // "Import ROM does nothing until you restart the app" report: the restart
+    // is not refreshing anything, it is clearing this array.
+    func presentationControllerDidDismiss(_ presentationController:
+                                          UIPresentationController) {
+        NSLog("GRPickerBridge: picker dismissed interactively")
         onFinish?()
     }
 }


### PR DESCRIPTION
Follow-up to #539, on the same file.

## The symptom

Import ROM does nothing. No file is copied, no error is shown, and the only
way back is to force-quit and reopen the app — after which it works once,
and then stops again.

## What it is not

I instrumented a device build with a heartbeat written from `love.update`.
Through the whole failure the app runs at a steady 60fps with the importer
poll armed and waiting, so the run loop is fine and the Lua side is behaving.

## The cause

`UIDocumentPickerViewController` reports an **interactive** dismissal — the
sheet swiped down rather than the Cancel button — only through
`UIAdaptivePresentationControllerDelegate.presentationControllerDidDismiss`.
`PickerDelegate` implements `didPickDocumentsAt` and
`documentPickerWasCancelled`, so a swipe reaches neither. `onFinish` never
runs, and the delegate is never removed from `liveDelegates`.

The re-present guard then does this on every later attempt:

```swift
guard liveDelegates.isEmpty else {
    NSLog("GRPickerBridge: picker already active; ignoring re-present")
    return true
}
```

It answers `true`, so `RomImporter` believes a sheet is up and arms
`_pollPickedFiles` for a file that will never arrive. Restarting "fixes" it
only because that clears the array.

## The fix

- Implement `presentationControllerDidDismiss` and wire the delegate to
  `picker.presentationController`.
- Self-heal: if UIKit is presenting nothing at all, any delegate still in
  `liveDelegates` belongs to a sheet that is gone. The callback closes the
  known hole; this closes the next one.

31 lines, no behaviour change on any path that already worked.

## Testing

Physical iPhone 17 Pro, iOS 27. Before: open the picker, swipe it away, and
Import ROM is dead until relaunch. After: it reopens every time. Picking and
cancelling behave as they did.

I do not have Android, Windows or Linux to hand — but this file is inside
`#if os(iOS)` territory (`mobile/ios/native/`), so no other platform compiles
it.