### PR TITLE
Hide the touch overlay when a controller is connected

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -413,6 +413,14 @@ function love.visible(v)
   Game:visible(v)
 end
 
+-- A controller appearing is a statement of intent: the on-screen pad steps
+-- aside for it (TouchControls:joystickadded), and comes back when the last
+-- one is unplugged.
+function love.joystickadded(joystick)
+  if editorMode or TouchEditor or Importer then return end
+  if Game and Game.joystickadded then Game:joystickadded(joystick) end
+end
+
 function love.touchpressed(id, x, y, dx, dy, pressure)
   if editorMode then return end
   if TouchEditor then

--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -754,6 +754,10 @@ end
 -- A disconnected/dropped controller can't send the button-up for whatever
 -- it was holding, so drop all input state rather than try to guess which
 -- flags it owned.
+function Game:joystickadded(joystick)
+  TouchControls:joystickadded()
+end
+
 function Game:joystickremoved(joystick)
   Input:reset()
   TouchControls:joystickremoved()

--- a/src/core/TouchControls.lua
+++ b/src/core/TouchControls.lua
@@ -210,6 +210,10 @@ end
 function TouchControls:applyOptions(opts)
   local cfg = TouchControls.normalizeConfig(opts and opts.touchControls)
   self.enabled = cfg.enabled
+  -- Default ON: plugging a controller in already says which input the player
+  -- wants, so the overlay steps aside for it.  == false so a missing option
+  -- keeps the new behaviour rather than needing a migration.
+  self.autoHide = not (opts and opts.touchAutoHide == false)
   self.layouts = cfg.layouts
   self.layoutW, self.layoutH = nil, nil
   self.layoutOx, self.layoutOy = nil, nil
@@ -501,11 +505,29 @@ end
 
 -- last controller unplugged: show the overlay again immediately instead
 -- of requiring a blind first tap
+-- A controller has been connected.  noteGamepad already hides the overlay on
+-- the first button or stick USE, but until then the pad sits over the screen
+-- next to a controller the player has clearly chosen -- and on a fresh boot
+-- with a pad already paired, it sits there until something is pressed.
+-- Connecting is itself the statement of intent.
+--
+-- Never resurrects an overlay the player disabled outright, and never fires
+-- where there is no overlay to hide.
+function TouchControls:joystickadded()
+  if self.autoHide == false then return end
+  if not self.active or self.enabled == false then return end
+  self.controllerHidden = true
+  self:reset()
+end
+
 function TouchControls:joystickremoved()
   self:reset()
   if love.joystick and love.joystick.getJoystickCount
      and love.joystick.getJoystickCount() == 0 then
-    self.controllerHidden = false
+    -- With auto-hide off the player is driving this by hand and a disconnect
+    -- must not override them.  With it on, a controller going flat has to
+    -- give the pad back -- there is nothing else to play with.
+    if self.autoHide ~= false then self.controllerHidden = false end
   end
 end
 

--- a/src/ui/OptionsMenu.lua
+++ b/src/ui/OptionsMenu.lua
@@ -423,6 +423,18 @@ local function buildRows(game)
         require("src.core.TouchControls"):applyOptions(o)
         return true
       end },
+    -- Sits next to the pad it governs.
+    { id = "touchAutoHide", label = Strings("AUTO HIDE PAD"),
+      value = function(g)
+        return (g.save.options.touchAutoHide == false)
+          and Strings("OFF") or Strings("ON")
+      end,
+      step = function(g)
+        local o = g.save.options
+        o.touchAutoHide = (o.touchAutoHide == false)
+        require("src.core.TouchControls"):applyOptions(o)
+        return true
+      end },
   }
   -- issue #136: hide GBC FX on Android/iOS -- the present shader soft-bricks
   if not GBCFX.isSupported() then

--- a/src/update/Boot.lua
+++ b/src/update/Boot.lua
@@ -52,7 +52,7 @@ local CALLBACK_NAMES = {
   "touchpressed", "touchmoved", "touchreleased",
   "gamepadpressed", "gamepadreleased", "gamepadaxis",
   "joystickpressed", "joystickreleased", "joystickaxis", "joystickhat",
-  "joystickremoved",
+  "joystickadded", "joystickremoved",
   "focus", "visible", "resize", "filedropped", "directorydropped",
   "errorhandler", "threaderror", "lowmemory",
 }


### PR DESCRIPTION
`noteGamepad` already hides the pad on the first button or stick **use**. But until that press the overlay sits over the screen next to a controller the player has obviously chosen — and on a fresh boot with a pad already paired, it sits there for the whole session until something is pressed.

Connecting a controller is itself the statement of intent, so this hides on connect.

`love.joystickadded` turned out not to be wired anywhere: `main.lua` never defined it, `Boot` did not forward it, and `Game` had no handler. All three are added, plus `TouchControls:joystickadded`.

`joystickremoved` already gave the overlay back. It now respects the same preference, so a player who turned auto-hide off is not overridden by a disconnect — while a controller going flat still returns the pad, since there is nothing else to play with.

**`AUTO HIDE PAD`** in OPTIONS turns it off. Defaults on, and tested with `== false` so an existing `options.lua` without the key keeps the new behaviour rather than needing a migration.

48 lines across 5 files. Never resurrects an overlay the player disabled outright, and never fires where there is no overlay to hide.

Tested on a physical iPhone with a Bluetooth controller: pairing hides the pad mid-game, unplugging brings it back. `scripts/test.sh --quick` passes 73/73 engine and 3/3 modkit on this branch.