### PR TITLE
Show the exhibited species' Pokédex entries in Fuchsia City (#646)

### DIFF
--- a/data/scripts/flavor/fuchsia_city.lua
+++ b/data/scripts/flavor/fuchsia_city.lua
@@ -1,0 +1,80 @@
+-- Fuchsia City (pokered/scripts/FuchsiaCity.asm)
+--
+-- The exhibit signs are text_asm bodies: PrintText of a single text_far,
+-- then DisplayPokedex for the exhibited species.  The preview marks the
+-- species seen but not owned, same as the S.S. Anne passenger's Snorlax.
+--
+-- The fossil sign branches on the Mt. Moon fossil events.  The exhibit
+-- holds the fossil the player did NOT take: taking the Dome Fossil puts
+-- Omanyte on display, taking the Helix Fossil puts Kabuto.  With neither
+-- event set the sign only prints its undetermined line and no dex entry
+-- opens.
+--
+-- The other text pointers (city sign, Safari Game signs, mart/center/gym
+-- and warden signs, the four NPCs, the exhibited-mon FuchsiaCityPokemonText
+-- rows) are plain text_far wrappers that resolve through Data:resolveText,
+-- so they are not ported here.
+return {
+  FUCHSIA_CITY = {
+    talk = {
+      -- FuchsiaCityChanseySignText: PrintText(_FuchsiaCityChanseySignText),
+      -- then DisplayPokedex CHANSEY.
+      TEXT_FUCHSIACITY_CHANSEY_SIGN = {
+        { "show_text", "_FuchsiaCityChanseySignText" },
+        { "mark_seen", "CHANSEY" },
+        { "push_screen", "DexEntryMenu", "CHANSEY" },
+      },
+
+      -- FuchsiaCityVoltorbSignText: PrintText(_FuchsiaCityVoltorbSignText),
+      -- then DisplayPokedex VOLTORB.
+      TEXT_FUCHSIACITY_VOLTORB_SIGN = {
+        { "show_text", "_FuchsiaCityVoltorbSignText" },
+        { "mark_seen", "VOLTORB" },
+        { "push_screen", "DexEntryMenu", "VOLTORB" },
+      },
+
+      -- FuchsiaCityKangaskhanSignText: PrintText(_FuchsiaCityKangaskhanSignText),
+      -- then DisplayPokedex KANGASKHAN.
+      TEXT_FUCHSIACITY_KANGASKHAN_SIGN = {
+        { "show_text", "_FuchsiaCityKangaskhanSignText" },
+        { "mark_seen", "KANGASKHAN" },
+        { "push_screen", "DexEntryMenu", "KANGASKHAN" },
+      },
+
+      -- FuchsiaCitySlowpokeSignText: PrintText(_FuchsiaCitySlowpokeSignText),
+      -- then DisplayPokedex SLOWPOKE.
+      TEXT_FUCHSIACITY_SLOWPOKE_SIGN = {
+        { "show_text", "_FuchsiaCitySlowpokeSignText" },
+        { "mark_seen", "SLOWPOKE" },
+        { "push_screen", "DexEntryMenu", "SLOWPOKE" },
+      },
+
+      -- FuchsiaCityLaprasSignText: PrintText(_FuchsiaCityLaprasSignText),
+      -- then DisplayPokedex LAPRAS.
+      TEXT_FUCHSIACITY_LAPRAS_SIGN = {
+        { "show_text", "_FuchsiaCityLaprasSignText" },
+        { "mark_seen", "LAPRAS" },
+        { "push_screen", "DexEntryMenu", "LAPRAS" },
+      },
+
+      -- FuchsiaCityFossilSignText: CheckEvent EVENT_GOT_DOME_FOSSIL /
+      -- CheckEventReuseA EVENT_GOT_HELIX_FOSSIL pick the text and the
+      -- displayed entry; with neither set only the undetermined line prints.
+      TEXT_FUCHSIACITY_FOSSIL_SIGN = {
+        { "check_flag", "EVENT_GOT_DOME_FOSSIL" },                 -- 1
+        { "jump_if_true", 7 },                                     -- 2
+        { "check_flag", "EVENT_GOT_HELIX_FOSSIL" },                -- 3
+        { "jump_if_true", 11 },                                    -- 4
+        { "show_text", "_FuchsiaCityFossilSignUndeterminedText" }, -- 5
+        { "jump", "end" },                                         -- 6
+        { "show_text", "_FuchsiaCityFossilSignOmanyteText" },      -- 7
+        { "mark_seen", "OMANYTE" },                                -- 8
+        { "push_screen", "DexEntryMenu", "OMANYTE" },              -- 9
+        { "jump", "end" },                                         -- 10
+        { "show_text", "_FuchsiaCityFossilSignKabutoText" },       -- 11
+        { "mark_seen", "KABUTO" },                                 -- 12
+        { "push_screen", "DexEntryMenu", "KABUTO" },               -- 13
+      },
+    },
+  },
+}

--- a/data/scripts/flavor_all.lua
+++ b/data/scripts/flavor_all.lua
@@ -15,6 +15,7 @@ local files = {
   "data.scripts.flavor.cerulean_trashed_house",
   "data.scripts.flavor.copycats_house_1f",
   "data.scripts.flavor.copycats_house_2f",
+  "data.scripts.flavor.fuchsia_city",
   "data.scripts.flavor.game_corner",
   "data.scripts.flavor.lavender_cubone_house",
   "data.scripts.flavor.lavender_mart",

--- a/tests/parity_fuchsia_exhibit_signs.lua
+++ b/tests/parity_fuchsia_exhibit_signs.lua
@@ -1,0 +1,70 @@
+-- Parity: the Fuchsia City exhibit signs open the exhibited species' Pokédex
+-- entry and mark it seen (pokered/scripts/FuchsiaCity.asm).  The fossil sign
+-- shows the fossil the player did NOT take at Mt. Moon, and opens no entry
+-- at all before either fossil is picked up.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+local S = require("tests.harness").suite("parity fuchsia exhibit signs")
+local check, eq = S.check, S.eq
+
+local scripts = require("data.scripts.init")
+
+local exhibits = {
+  TEXT_FUCHSIACITY_CHANSEY_SIGN = { "_FuchsiaCityChanseySignText", "CHANSEY" },
+  TEXT_FUCHSIACITY_VOLTORB_SIGN = { "_FuchsiaCityVoltorbSignText", "VOLTORB" },
+  TEXT_FUCHSIACITY_KANGASKHAN_SIGN = { "_FuchsiaCityKangaskhanSignText", "KANGASKHAN" },
+  TEXT_FUCHSIACITY_SLOWPOKE_SIGN = { "_FuchsiaCitySlowpokeSignText", "SLOWPOKE" },
+  TEXT_FUCHSIACITY_LAPRAS_SIGN = { "_FuchsiaCityLaprasSignText", "LAPRAS" },
+}
+
+for textConst, exhibit in pairs(exhibits) do
+  local script = scripts.talkScript("FUCHSIA_CITY", textConst)
+  check(script ~= nil, textConst .. " has a talk script")
+  if script then
+    eq(script[1][1], "show_text", textConst .. " prints its line first")
+    eq(script[1][2], exhibit[1], textConst .. " prints its own sign text")
+    eq(script[2][1], "mark_seen", textConst .. " marks the species seen")
+    eq(script[2][2], exhibit[2], textConst .. " marks " .. exhibit[2] .. " seen")
+    eq(script[3][1], "push_screen", textConst .. " opens the Pokédex entry")
+    eq(script[3][2], "DexEntryMenu", textConst .. " uses DexEntryMenu")
+    eq(script[3][3], exhibit[2], textConst .. " shows " .. exhibit[2])
+  end
+end
+
+local fossil = scripts.talkScript("FUCHSIA_CITY", "TEXT_FUCHSIACITY_FOSSIL_SIGN")
+check(fossil ~= nil, "the fossil sign has a talk script")
+if fossil then
+  eq(fossil[1][1], "check_flag", "the fossil sign checks the Dome Fossil event")
+  eq(fossil[1][2], "EVENT_GOT_DOME_FOSSIL", "Dome Fossil event first")
+  eq(fossil[3][1], "check_flag", "the fossil sign checks the Helix Fossil event")
+  eq(fossil[3][2], "EVENT_GOT_HELIX_FOSSIL", "Helix Fossil event second")
+
+  -- neither fossil taken: only the undetermined line, no dex entry
+  eq(fossil[5][1], "show_text", "the undetermined branch prints its line")
+  eq(fossil[5][2], "_FuchsiaCityFossilSignUndeterminedText",
+    "the undetermined branch uses the undetermined text")
+  eq(fossil[6][1], "jump", "the undetermined branch stops there")
+  check(fossil[6][2] == "end", "the undetermined branch never reaches a dex entry")
+
+  -- Dome Fossil taken: the exhibit holds Omanyte
+  eq(fossil[2][1], "jump_if_true", "the Dome branch jumps when the event is set")
+  eq(fossil[2][2], 7, "the Dome branch lands on the Omanyte rows")
+  eq(fossil[7][2], "_FuchsiaCityFossilSignOmanyteText", "Dome taken: Omanyte text")
+  eq(fossil[8][1], "mark_seen", "Dome taken: marks the exhibited species seen")
+  eq(fossil[8][2], "OMANYTE", "Dome taken: marks Omanyte seen")
+  eq(fossil[9][1], "push_screen", "Dome taken: opens the Pokédex entry")
+  eq(fossil[9][3], "OMANYTE", "Dome taken: shows Omanyte")
+
+  -- Helix Fossil taken: the exhibit holds Kabuto
+  eq(fossil[4][1], "jump_if_true", "the Helix branch jumps when the event is set")
+  eq(fossil[4][2], 11, "the Helix branch lands on the Kabuto rows")
+  eq(fossil[11][2], "_FuchsiaCityFossilSignKabutoText", "Helix taken: Kabuto text")
+  eq(fossil[12][2], "KABUTO", "Helix taken: marks Kabuto seen")
+  eq(fossil[13][3], "KABUTO", "Helix taken: shows Kabuto")
+end
+
+local save = { pokedex = { seen = {}, owned = {} } }
+require("src.script.Commands").mark_seen({ save = save }, "OMANYTE")
+check(save.pokedex.seen.OMANYTE, "the preview records the species as seen")
+check(not save.pokedex.owned.OMANYTE, "the preview does not mark it owned")
+
+S.finish()


### PR DESCRIPTION
Fixes #646.

The Fuchsia exhibit signs are text_asm entries that print their line and then call DisplayPokedex (scripts/FuchsiaCity.asm). With no script file for Fuchsia City on our side, the signs fell through to plain extracted text, so the Pokédex never opened and the exhibited species never got marked seen.

This adds data/scripts/flavor/fuchsia_city.lua with talk scripts for the Chansey, Voltorb, Kangaskhan, Slowpoke and Lapras signs: print the sign's line, mark_seen, then push DexEntryMenu, the same shape as the S.S. Anne passenger's Snorlax preview. The fossil sign checks EVENT_GOT_DOME_FOSSIL / EVENT_GOT_HELIX_FOSSIL and shows the fossil the player left behind at Mt. Moon (Dome taken shows Omanyte, Helix taken shows Kabuto). Before either fossil is picked up it only prints the undetermined line and opens nothing, matching the original.

Test: tests/parity_fuchsia_exhibit_signs.lua walks all six sign scripts and the fossil sign's three branches.