### PR TITLE
Frame the coin clerk's offer with the MONEY/COIN box (#624)

### DIFF
--- a/data/scripts/story3.lua
+++ b/data/scripts/story3.lua
@@ -546,24 +546,53 @@ M.GAME_CORNER = {
     -- object const and from every one of his text labels
     -- (GameCornerClerkText, pokeyellow/scripts/GameCorner.asm) with an
     -- identical body, so each line resolves under both spellings and the
-    -- handler is bound to both text ids just below (#552).
+    -- handler is bound to both text ids just below (#552).  The original
+    -- frames the exchange with GameCornerDrawCoinBox -- the MONEY/COIN
+    -- box top-right, drawn before the offer and redrawn after the sale --
+    -- and the question stays up while the YES/NO box sits over it (#624).
     TEXT_GAMECORNER_CLERK1 = function(game, ow, npc, done)
       local TextBox = require("src.render.TextBox")
-      local ChoiceBox = require("src.ui.ChoiceBox")
+      local Font = require("src.render.Font")
       local t = game.data.text
       local function line(suffix, fallback)
         return t["_GameCornerClerk1" .. suffix]
                or t["_GameCornerClerk" .. suffix]
                or fallback
       end
+      -- The coin box is a draw-only stack state: it reads the save every
+      -- frame, so the post-sale redraw the asm does by hand happens on
+      -- its own.  hlcoord 11,0 with a 7x5 interior (TextBoxBorder b=5,
+      -- c=7), MONEY/¥ on rows 2-3 and COIN/coins on rows 4-5, both
+      -- amounts leading-zeroed like PrintBCDNumber's LEADING_ZEROES.
+      local coinBox = { game = game }
+      function coinBox:draw()
+        Font.drawBox(11, 0, 9, 7)
+        love.graphics.setColor(0, 0, 0, 1)
+        Font.draw("MONEY", 96, 16)
+        Font.draw(("¥%06d"):format(game.save.money), 96, 24)
+        Font.draw("COIN", 96, 32)
+        Font.draw(("%04d"):format(game.save.coins or 0), 120, 40)
+        love.graphics.setColor(1, 1, 1, 1)
+      end
+      game.stack:push(coinBox)
+      local function finish()
+        -- remove in place: the box sits under whichever text is closing
+        local states = game.stack.states
+        for i = #states, 1, -1 do
+          if states[i] == coinBox then table.remove(states, i) break end
+        end
+        done()
+      end
       game.stack:push(TextBox.new(game,
         line("DoYouNeedSomeGameCoinsText",
-             "Do you need some\ngame coins?\f¥1000 for 50."), function()
-        game.stack:push(ChoiceBox.new(game, function(yes)
+             "Do you need some\ngame coins?\f¥1000 for 50."), nil, {
+        -- opts.choice pops the YES/NO up over the still-visible question,
+        -- PrintText + YesNoChoice style, instead of after it (#624)
+        choice = function(yes)
           if not yes then
             game.stack:push(TextBox.new(game,
               line("PleaseComePlaySometimeText",
-                   "No? Please come\nplay sometime!"), done))
+                   "No? Please come\nplay sometime!"), finish))
             return
           end
           -- scripts/GameCorner.asm GameCornerClerk1Text: coins need
@@ -571,29 +600,28 @@ M.GAME_CORNER = {
           if not game.save.inventory.COIN_CASE then
             game.stack:push(TextBox.new(game,
               line("DontHaveCoinCaseText",
-                   "You don't have a\nCOIN CASE!"), done))
+                   "You don't have a\nCOIN CASE!"), finish))
             return
           end
           if (game.save.coins or 0) >= 9990 then
             game.stack:push(TextBox.new(game,
               line("CoinCaseIsFullText",
-                   "Oops! Your COIN\nCASE is full."), done))
+                   "Oops! Your COIN\nCASE is full."), finish))
             return
           end
           if game.save.money < 1000 then
             game.stack:push(TextBox.new(game,
               line("CantAffordTheCoinsText",
-                   "You can't afford\nthe coins!"), done))
+                   "You can't afford\nthe coins!"), finish))
             return
           end
           game.save.money = game.save.money - 1000
           game.save.coins = math.min(9999, (game.save.coins or 0) + 50)
           game.stack:push(TextBox.new(game,
             line("ThanksHereAre50CoinsText",
-                 "Thanks! Here are\nyour 50 coins!")
-            .. ("\fCOINS: %d"):format(game.save.coins), done))
-        end))
-      end))
+                 "Thanks! Here are\nyour 50 coins!"), finish))
+        end,
+      }))
     end,
   },
 }

--- a/tests/parity_game_corner_clerk_bug552.lua
+++ b/tests/parity_game_corner_clerk_bug552.lua
@@ -53,11 +53,14 @@ local sawChoice = false
 
 -- One conversation, start to finish.  `answer` is which row of the YES/NO
 -- box to take; the loop mashes A the way a player does and nudges the
--- cursor down once when the choice box comes up.
+-- cursor down once when the choice box comes up.  The MONEY/COIN box is a
+-- plain draw-only table under the text boxes (#624), so it is the one
+-- stack entry with a draw and no metatable.
 local function talk(save, answer)
   Game.save = save
   StateStack:init()
   shown, sawChoice = {}, false
+  local sawCoinBox = false
   local done = false
   local ow = { map = { id = "GAME_CORNER", def = Data.maps.GAME_CORNER },
                npcs = {}, entities = {} }
@@ -67,6 +70,11 @@ local function talk(save, answer)
   for _ = 1, 2000 do
     local top = StateStack:top()
     if not top then break end
+    for _, state in ipairs(StateStack.states) do
+      if type(state.draw) == "function" and getmetatable(state) == nil then
+        sawCoinBox = true
+      end
+    end
     if getmetatable(top) == ChoiceBox then
       sawChoice = true
       if answer == "no" and not moved then
@@ -81,7 +89,7 @@ local function talk(save, answer)
     StateStack:update(1 / 60)
   end
   Input.pressed = {}
-  return done
+  return done, sawCoinBox
 end
 
 local function newSave(money, coins, caseToo)
@@ -102,13 +110,16 @@ end
 -- ------------------------------------------------------- the sale itself
 do
   local save = newSave(1000, 0)
-  check(talk(save, "yes"), "the buy conversation runs to the end")
+  local finished, sawCoinBox = talk(save, "yes")
+  check(finished, "the buy conversation runs to the end")
   check(sawChoice, "the clerk opens a real YES/NO box, not just a line (#552)")
+  check(sawCoinBox, "the MONEY/COIN box rides the exchange (#624)")
   eq(#shown, 2, "two boxes: the offer and the receipt")
   check(said("¥1000 for 50"), "the offer quotes ¥1000 for 50 coins")
   eq(save.money, 0, "¥1000 leaves the wallet")
   eq(save.coins, 50, "50 coins land in the case")
-  check(said("COINS: 50"), "the receipt prints the new coin total")
+  check(not said("COINS: 50"),
+    "the receipt skips the coin tally; the coin box already shows it")
 end
 
 -- ---------------------------------------------------------------- saying no


### PR DESCRIPTION
Fixes #624.

The coin clerk's exchange was missing its frame. In the original (GameCornerClerk1Text, scripts/GameCorner.asm) the whole thing runs under GameCornerDrawCoinBox: a MONEY/COIN box sits top-right, drawn before the question and redrawn after the sale, and the question text stays on screen while the YES/NO box rides over it. The port showed the question, closed it, and only then popped a bare YES/NO.

Two changes in the clerk's handler (data/scripts/story3.lua):

- the MONEY/COIN box is a draw-only stack state pushed before the offer. It reads the save every frame, so the post-sale redraw the asm does by hand happens on its own. Same geometry as the original: hlcoord 11,0 with a 7x5 interior, both amounts leading-zeroed like PrintBCDNumber.
- the YES/NO now uses the text box's own choice option, which pops the prompt up over the still-visible question instead of after it.

With the coin box live, the receipt no longer needs its tacked-on "COINS: %d" page, so that suffix is gone.

Test: tests/parity_game_corner_clerk_bug552.lua drives the real conversation and now also asserts the coin box is on the stack during the exchange and the receipt carries no coin tally. Yellow's clerk alias picks all of this up too, since it resolves to the same handler.