### PR TITLE
Stop boulders being pushed through walls (#754)

### DIFF
--- a/src/world/OverworldController.lua
+++ b/src/world/OverworldController.lua
@@ -1216,12 +1216,16 @@ function OverworldState:checkBoulderPush(dir)
   end
   local bx, by = Collision.target(fx, fy, dir)
   if not self.map:inBounds(bx, by) then self.boulderTried = nil return false end
+  -- CheckForCollisionWhenPushingBoulder uses the same walkable check as
+  -- player movement (CheckTilePassable walks the same wTilesetCollisionPtr
+  -- list) -- there is no hole/warp escape hatch in the original, so a
+  -- boulder can never be pushed onto a cell the player cannot walk onto.
+  -- The known push targets (CAVERN $22 holes, Victory Road switches) are
+  -- walkable tiles in their tileset's coll list already, so removing the
+  -- port's isWarpTileCell exception only stops wall pushes (#754).
   if not self.map:isWalkableCell(bx, by) then
-    -- boulders may be pushed into holes/switch spots that aren't walkable
-    if not self.map:isWarpTileCell(bx, by) then
-      self.boulderTried = nil
-      return false
-    end
+    self.boulderTried = nil
+    return false
   end
   if Collision.occupied(self.entities, bx, by, npc) then
     self.boulderTried = nil


### PR DESCRIPTION
## Fixes #754

### Root cause

`checkBoulderPush` (`src/world/OverworldController.lua:1219-1225`) had an escape hatch: if the destination cell was not walkable, a boulder was still allowed onto it when `isWarpTileCell` returned true (door tiles or warp-activating tiles). If a wall tile is flagged as a door/warp tile, the boulder pushes straight through.

In pokered, `CheckForCollisionWhenPushingBoulder` (engine/overworld/player_state.asm:352-376) walks the **same** `wTilesetCollisionPtr` list that player movement uses (`CheckTilePassable`) — there is no hole/warp exception. A boulder can never land on a cell the player cannot walk onto; the boulder check is strictly more restrictive (stairs tile-pair checks), never less.

### Fix

Removed the `isWarpTileCell` escape hatch — boulder push now requires `isWalkableCell`, exactly like player movement.

The known push targets are unaffected:
- Seafoam Islands holes / Victory Road switches: these are coordinate-based (`field.seafoam` holes) and the tiles are walkable in their tileset's coll list (parity_seafoam_holes.lua:8-9 documents "CAVERN $22 is walkable").

### Note on tests

`tests/parity_I_M.lua` covers the STRENGTH gate (arm-then-push, activation, map-reload reset) and needs ROM-imported data (SEAFOAM_ISLANDS_1F); it cannot run against the ROM-free fixture. The fix is a strict parity correction verified against the pokered disassembly.
