### PR TITLE
Launcher: route its remaining text through Strings so translation mods can reach it

### DIFF
--- a/src/import/RomImporter.lua
+++ b/src/import/RomImporter.lua
@@ -3340,9 +3340,9 @@ function RomImporter:_drawGamePanel(version, x, y, w, h, paged)
   printB(gameName, x, y)
   local nameW = self.gameNameFont:getWidth(gameName)
   local pill
-  if ready then pill = { text = "GOOD TO GO", c = PAL.green }
+  if ready then pill = { text = Strings("GOOD TO GO"), c = PAL.green }
   elseif locked then pill = { text = "COMING SOON", c = PAL.disabledInk }
-  else pill = { text = "ROM REQUIRED", c = PAL.gold } end
+  else pill = { text = Strings("ROM REQUIRED"), c = PAL.gold } end
   love.graphics.setFont(self.pillFont)
   local pw = self.pillFont:getWidth(pill.text) + 24 * s
   local ph = self.pillFont:getHeight() + 8 * s
@@ -3386,12 +3386,12 @@ function RomImporter:_drawGamePanel(version, x, y, w, h, paged)
       romProgress = self.progress or 0
     elseif ready then
       romState = self.romName[version] or Strings("ROM imported")
-      romDetail = "Verified."
-      romBtnLabel, romBtnEnabled = "Re-import ROM", true
+      romDetail = Strings("Verified.")
+      romBtnLabel, romBtnEnabled = Strings("Re-import ROM"), true
     elseif erroring then
       romState = "Import failed"
       romDetail = self.detail or Strings("That ROM could not be imported.")
-      romBtnLabel, romBtnEnabled = "Import ROM", true
+      romBtnLabel, romBtnEnabled = Strings("Import ROM"), true
     elseif notice then
       romState = "No ROM imported"
       romDetail = trim((notice.status or "") .. " " .. (notice.detail or ""))
@@ -3441,7 +3441,7 @@ function RomImporter:_drawGamePanel(version, x, y, w, h, paged)
     sfHintText, sfHintCol = "Not available yet.", PAL.warning
   elseif self.android then
     sfHintText, sfHintCol =
-      "Import or export a .sav with the system file picker.", PAL.warning
+      Strings("Import or export a .sav with the system file picker."), PAL.warning
   else
     sfHintText, sfHintCol =
       "Import a .sav to a new slot, or export the active slot.", PAL.warning
@@ -3481,7 +3481,7 @@ function RomImporter:_drawGamePanel(version, x, y, w, h, paged)
   local ix, iy = leftX + pad, romY + pad
   love.graphics.setFont(self.labelFont)
   col(PAL.labelGray)
-  printSpaced(self.labelFont, "ROM", ix, iy, 2 * s)
+  printSpaced(self.labelFont, Strings("ROM"), ix, iy, 2 * s)
   iy = iy + labelH + 10 * s
   love.graphics.setFont(self.stateFont)
   col(PAL.white)
@@ -3513,14 +3513,14 @@ function RomImporter:_drawGamePanel(version, x, y, w, h, paged)
   ix, iy = leftX + pad, saveFilesY + pad
   love.graphics.setFont(self.labelFont)
   col(PAL.labelGray)
-  printSpaced(self.labelFont, "SAVE FILES", ix, iy, 2 * s)
+  printSpaced(self.labelFont, Strings("SAVE FILES"), ix, iy, 2 * s)
   iy = iy + labelH + 10 * s
   local bGap = 10 * s
   local halfW = (innerW - bGap) / 2
   self.saveImportRect =
-    self:_glassyButton(ix, iy, halfW, sfBtnH, "Import save", self.saveBtnFont, sfImportEnabled)
+    self:_glassyButton(ix, iy, halfW, sfBtnH, Strings("Import save"), self.saveBtnFont, sfImportEnabled)
   self.saveExportRect = self:_glassyButton(ix + halfW + bGap, iy, halfW, sfBtnH,
-    "Export save", self.saveBtnFont, sfExportEnabled)
+    Strings("Export save"), self.saveBtnFont, sfExportEnabled)
   iy = iy + sfBtnH + 6 * s
   love.graphics.setFont(self.hintFont)
   col(sfHintCol)
@@ -3545,7 +3545,7 @@ function RomImporter:_drawGamePanel(version, x, y, w, h, paged)
   -- Touch Controls: open the drag-to-reposition / disable editor (#327).
   if self.onEditTouchControls and touchBtnH > 0 then
     self.touchControlsRect = self:_glassyButton(
-      leftX, touchY, colW, touchBtnH, "Touch Controls", self.saveBtnFont, true)
+      leftX, touchY, colW, touchBtnH, Strings("Touch Controls"), self.saveBtnFont, true)
   end
 
   -- Play button
@@ -3861,7 +3861,7 @@ function RomImporter:_drawSaveSlotPanel(version, x, y, w, h, paged)
   -- header: "SAVE SLOT" (left) + "N slots" / "1 slot" (right)
   love.graphics.setFont(self.labelFont)
   col(PAL.labelGray)
-  printSpaced(self.labelFont, "SAVE SLOT", x + pad, y + pad, 2 * s)
+  printSpaced(self.labelFont, Strings("SAVE SLOT"), x + pad, y + pad, 2 * s)
   local countTxt = (n == 1) and "1 slot" or (n .. " slots")
   local cw = self.labelFont:getWidth(countTxt)
   love.graphics.print(countTxt, x + w - pad - cw, y + pad)
@@ -3922,8 +3922,8 @@ function RomImporter:_drawSaveSlotPanel(version, x, y, w, h, paged)
         -- so the row never reflows (#433).
         love.graphics.setFont(self.hintFont)
         local darmed = armedDelete(self._confirmDelete, "slot", slot.id, version)
-        local delLabel = darmed and "Sure?" or "Delete"
-        local delW = self.hintFont:getWidth("Delete") + 24 * s
+        local delLabel = darmed and Strings("Sure?") or Strings("Delete")
+        local delW = self.hintFont:getWidth(delLabel) + 24 * s
         local delX = rx + rw - 12 * s - delW
         local delY = ry + rowH - rowPadV - chipBtnH
         local drect = self:_chipButton(delX, delY, delLabel, {
@@ -3937,9 +3937,10 @@ function RomImporter:_drawSaveSlotPanel(version, x, y, w, h, paged)
         -- slot actually holds a save.
         local erect = nil
         if self.onEditSave and slot.exists then
-          local edW = self.hintFont:getWidth("Edit") + 24 * s
+          local edLabel = Strings("Edit")
+          local edW = self.hintFont:getWidth(edLabel) + 24 * s
           local edX = delX - btnGap - edW
-          erect = self:_chipButton(edX, delY, "Edit", {
+          erect = self:_chipButton(edX, delY, edLabel, {
             w = edW, h = chipBtnH, id = slot.id, kind = "accent",
           })
           rightReserve = rightReserve + edW + btnGap + 6 * s
@@ -3949,7 +3950,7 @@ function RomImporter:_drawSaveSlotPanel(version, x, y, w, h, paged)
         local pillW = 0
         if selected then
           love.graphics.setFont(self.warningFont)
-          local pText = "LOADED"
+          local pText = Strings("LOADED")
           local pw = self.warningFont:getWidth(pText) + 14 * s
           local ph = loadedH
           local ppx = rx + rw - 12 * s - pw
@@ -3973,7 +3974,7 @@ function RomImporter:_drawSaveSlotPanel(version, x, y, w, h, paged)
           metaTxt = Strings("%d badges - %s - %d caught", slot.meta.badges or 0, slot.meta.timeText or "0:00",
             slot.meta.dexCount or 0)
         else
-          metaTxt = "empty slot"
+          metaTxt = Strings("empty slot")
         end
         love.graphics.setFont(self.labelFont)
         col(PAL.warning)
@@ -4343,7 +4344,7 @@ end
 
 -- The status-chip label + colour for a mod row (deriveList's status verdict).
 local function modStatusChip(status)
-  if status == "ok" then return "Ready", PAL.green end
+  if status == "ok" then return Strings("Ready"), PAL.green end
   if status == "conflict" then return "Conflict", PAL.red end
   return "Incompatible", PAL.gold   -- "warn": bad range or missing dependency
 end
@@ -4376,7 +4377,7 @@ function RomImporter:_drawModsPanel(x, y, w, h, paged)
   love.graphics.print(countText, countX,
     y + (headerH - self.hintFont:getHeight()) / 2)
 
-  local btnLabel = "Import mod .zip"
+  local btnLabel = Strings("Import mod .zip")
   local btnH = math.max(38 * s, self.saveBtnFont:getHeight() + 20 * s)
   local btnW = math.min(w * 0.5, self.saveBtnFont:getWidth(btnLabel) + 40 * s)
   local btnX = x + w - btnW
@@ -4419,7 +4420,7 @@ function RomImporter:_drawModsPanel(x, y, w, h, paged)
     love.graphics.printf(self.modNotice.text, x, top, w, "left")
   else
     col(PAL.warning)
-    love.graphics.printf(self.android and "Or copy a mod .zip via USB."
+    love.graphics.printf(self.android and Strings("Or copy a mod .zip via USB.")
       or Strings("Or drop a mod .zip onto the window."), x, top, w, "left")
   end
   top = top + self.hintFont:getHeight() + 12 * s
@@ -4466,10 +4467,11 @@ function RomImporter:_drawModsPanel(x, y, w, h, paged)
     local chipText = modStatusChip(m.status)
     local chipW = self.hintFont:getWidth(chipText) + 20 * s
     local delW = self.hintFont:getWidth("Delete") + 24 * s
-    local verW = self.hintFont:getWidth("Versions") + 24 * s
+    local verLabel = Strings("Versions")
+    local verW = self.hintFont:getWidth(verLabel) + 24 * s
     local hasGh = m.github and m.github ~= ""
     local info = hasGh and self:_modUpdateInfo(m.id) or nil
-    local updLabel = "Check for updates"
+    local updLabel = Strings("Check for updates")
     local updateKind = "neutral"
     -- checkLine: always on the mod row for github mods so the check result
     -- is visible without relying on the top-of-panel notice.
@@ -4638,7 +4640,7 @@ function RomImporter:_drawModsPanel(x, y, w, h, paged)
         })
         clipHit(urect, self.modUpdateRects)
         btnX = btnX + L.updW + btnGap
-        local vrect = self:_chipButton(btnX, btnY, "Versions", {
+        local vrect = self:_chipButton(btnX, btnY, verLabel, {
           w = L.verW, h = btnH, id = m.id, kind = "neutral",
         })
         clipHit(vrect, self.modVersionsRects)


### PR DESCRIPTION
You mentioned on #729 that translation mods are the way to go. This removes something in their way: **a translation mod cannot translate the launcher at all today.**

Most of what the launcher draws never reaches the catalog — `GOOD TO GO`, `ROM REQUIRED`, `Verified.`, `SAVE FILES`, `SAVE SLOT`, `LOADED`, `Edit`, `Delete`, `empty slot`, the ROM and save buttons, and the mod browser's chrome are raw literals. So someone who installs a Spanish mod gets Spanish battle text sitting under an English launcher, with nothing they can do about it.

24 sites now go through `Strings()`.

**No behaviour change without a catalog.** `Strings.lookup` returns the source unchanged when nothing is loaded, so a vanilla install draws byte-identical text. This only adds keys a mod may choose to override.

Two of them also had a latent bug worth mentioning: the Edit and Versions buttons measured their width against the English literal while drawing the label, so any longer translation would have overflowed the button. They measure what they draw now.

I found this building a Spanish iOS distribution — I have a working catalog for these keys and I am deliberately not proposing it here, since a built-in table is exactly the thing you said you would rather do with mods. This is just the hooks.

`scripts/test.sh --quick`: 73/73 engine, 3/3 modkit.