### PR TITLE
fix ttf text erased after a box, and type names outside battle

### DIFF
--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -41,6 +41,13 @@ function Game:load()
   -- render pipelines dispatch off the merged dataset; point them at the
   -- one the mods just merged into before anything can draw a frame
   require("src.render.Pipelines").install(Data)
+  -- Same reason, same moment: TypeChart caches the merged type records in an
+  -- upvalue, and until now only BattleState loaded it, on entering a battle.
+  -- Every non-battle reader of a type -- the summary screen's TYPE1/TYPE2
+  -- rows, the move-select TYPE/ box -- ran against an unloaded module and got
+  -- the raw id back instead of the display name, so a translation could not
+  -- reach them. Loading here means a type reads the same whoever asks first.
+  require("src.battle.TypeChart").load(Data)
 
   self.input = Input
   Input:init()

--- a/src/render/Font.lua
+++ b/src/render/Font.lua
@@ -405,8 +405,18 @@ for key, code in pairs(Font.DEFAULT_BORDER) do Font.BORDER[key] = code end
 
 -- Draw a Game Boy style bordered box in tile coordinates.
 function Font.drawBox(tx, ty, tw, th)
+  -- The white interior is a fill, so it needs the color; everything after it
+  -- is a glyph and needs the caller's.  Restoring is not cosmetic: the tile
+  -- pages are black glyphs on transparent, so they come out black whatever
+  -- the color is, and leaking white here was invisible for as long as every
+  -- glyph was a tile.  TTF text is not immune -- it draws in the current
+  -- color -- so a leaked white left every label printed after a box white on
+  -- white.  On the summary screen that erased ATTACK/DEFENSE/SPEED/SPECIAL
+  -- and TYPE1/TYPE2 while the numbers beside them, still tiles, stayed put.
+  local r, g, b, a = love.graphics.getColor()
   love.graphics.setColor(1, 1, 1, 1)
   love.graphics.rectangle("fill", tx * 8, ty * 8, tw * 8, th * 8)
+  love.graphics.setColor(r, g, b, a)
   local B = Font.BORDER
   Font.drawCode(B.tl, tx * 8, ty * 8)
   Font.drawCode(B.tr, (tx + tw - 1) * 8, ty * 8)

--- a/tests/engine/ttf_font_mode.lua
+++ b/tests/engine/ttf_font_mode.lua
@@ -75,6 +75,20 @@ T.eq(Font.encode("A")[1], BASE + 65, "and leaves the others on the TTF")
 Font.load({ font = { charmap = CHARMAP, ttf = {} } })
 T.eq(Font.encode("A")[1], BASE + 65, "no tiles list means the TTF takes it back")
 
+-- ------------------------------------------------- drawBox restores color
+
+-- drawBox fills its interior white and used to leave the color that way.
+-- Tile pages are black glyphs on transparent, so they draw black whatever the
+-- color is and the leak stayed invisible for as long as every glyph was a
+-- tile.  TTF text draws in the current color, so every label printed after a
+-- box came out white on white -- the summary screen lost ATTACK/DEFENSE/
+-- SPEED/SPECIAL and TYPE1/TYPE2 while the numbers beside them survived.
+love.graphics.setColor(0, 0, 0, 1)
+Font.drawBox(0, 0, 4, 4)
+local r, g, b, a = love.graphics.getColor()
+T.eq(("%s,%s,%s,%s"):format(r, g, b, a), "0,0,0,1",
+  "drawBox leaves the caller's color alone")
+
 -- metrics come straight from the font object (the stub: half the point
 -- size per codepoint, doubled from U+1000 up, mimicking Plain Pixel's
 -- single/double width split)


### PR DESCRIPTION
two follow-ups to #789.

`Font.drawBox` filled its interior white and never put the colour back. tile pages are black glyphs on transparent so they draw black either way, which hid it for as long as every glyph was a tile. ttf text draws in the current colour, so every label after a box came out white on white - the summary screen lost ATTACK/DEFENSE/SPEED/SPECIAL and TYPE1/TYPE2 while the numbers next to them stayed.

`TypeChart` only got loaded by `BattleState` on entering a battle, so the summary screen and the move-select TYPE/ box read an unloaded module and got the raw id back instead of the display name. nothing outside a battle could be translated.

test added for the colour restore.