### PR TITLE
launcher: route the last raw literals through strings

### DIFF
--- a/src/import/LauncherView.lua
+++ b/src/import/LauncherView.lua
@@ -807,7 +807,7 @@ local function buildRomCard(imp, parent, m, version, info, ready, locked)
 
   local accent = version == "yellow" and "gold" or version
   local c = card(parent, { padding = m.cardPad, gap = 8 * m.s })
-  label(c, "ROM", 12 * m.s + 1, C("gray"))
+  label(c, Strings("ROM"), 12 * m.s + 1, C("gray"))
   label(c, romState, 15 * m.s + 2, C("white"))
   label(c, romDetail, 12 * m.s + 2, C("detail"))
   if romProgress ~= nil then
@@ -847,7 +847,7 @@ local function buildSaveFilesCard(imp, parent, m, version, ready, locked)
   local savImportLabel = imp.isNX and Strings("Scan again") or Strings("Import save")
 
   local c = card(parent, { padding = m.cardPad, gap = 8 * m.s })
-  label(c, "SAVE FILES", 12 * m.s + 1, C("gray"))
+  label(c, Strings("SAVE FILES"), 12 * m.s + 1, C("gray"))
   local row = mk({ parent = c, width = "100%",
     positioning = "flex", flexDirection = "horizontal", gap = 10 * m.s })
   -- explicit halves rather than flex growth, which mis-distributed inside
@@ -889,7 +889,7 @@ local function buildSlotCard(imp, parent, m, version)
   local head = mk({ parent = c, width = "100%",
     positioning = "flex", flexDirection = "horizontal",
     justifyContent = "space-between", alignItems = "center" })
-  label(head, "SAVE SLOT", 12 * m.s + 1, C("gray"), { textWrap = false })
+  label(head, Strings("SAVE SLOT"), 12 * m.s + 1, C("gray"), { textWrap = false })
   label(head, n == 1 and Strings("1 slot") or Strings("%d slots", n),
     12 * m.s + 1, C("gray"), { textWrap = false })
 
@@ -983,10 +983,14 @@ local function buildSlotCard(imp, parent, m, version)
       })
     end
     local armed = deleteArmed(imp, "slot", slot.id, version)
-    -- width pinned to the unarmed label so arming to "Sure?" never reflows
-    -- the row under the pointer (#433)
+    -- width pinned so arming to "Sure?" never reflows the row under the
+    -- pointer (#433).  Pinned to the wider of the two captions, not to the
+    -- unarmed one: English "Delete" is the longer of the pair, but a
+    -- translation need not keep that order (Japanese さくじょ is shorter than
+    -- よろしい？), and pinning to the shorter one clips the other.
     button(imp, btnRow, rowKey .. "-del", DELETE_LABEL(armed), {
-      w = math.ceil(textWidth(chipSize, DELETE_LABEL(false))) + 26,
+      w = math.ceil(math.max(textWidth(chipSize, DELETE_LABEL(false)),
+                             textWidth(chipSize, DELETE_LABEL(true)))) + 26,
       size = chipSize, kind = armed and "dangerArmed" or "danger",
       keepArm = true,
       action = function()

--- a/src/import/RomImporter.lua
+++ b/src/import/RomImporter.lua
@@ -2888,7 +2888,7 @@ end
 -- NX / desktop / Android labels and inbox hints for the FlexLove view.
 function RomImporter:_modsImportButtonLabel()
   if self.isNX then return Strings("Scan again") end
-  return "Import mod .zip"
+  return Strings("Import mod .zip")
 end
 
 function RomImporter:_modsDefaultHint()
@@ -2899,7 +2899,7 @@ function RomImporter:_modsDefaultHint()
     return Strings("Copy a .zip via MTP into %s/imports/mods/\n"
       .. "DBI MTP → 1: SD Card/%simports/mods/", saveDir, rel)
   end
-  if self.android then return "Or copy a mod .zip via USB." end
+  if self.android then return Strings("Or copy a mod .zip via USB.") end
   return Strings("Or drop a mod .zip onto the window.")
 end
 
@@ -2915,7 +2915,7 @@ function RomImporter:_savesDefaultHint(version)
       .. "DBI MTP → 1: SD Card/%s%s/", game, saveDir, inbox, rel, inbox)
   end
   if self.android then
-    return "Import or export a .sav with the system file picker."
+    return Strings("Import or export a .sav with the system file picker.")
   end
   return Strings("Import a .sav to a new slot, or export the active slot.")
 end


### PR DESCRIPTION
finishes #767 by @hernan0078.

most of that pr already landed on its own when the launcher panels moved from RomImporter into LauncherView, which is also why it went conflicting. of the 22 keys it wrapped, 11 are already routed on dev and 5 more only matched in comments. these are the six that were actually left:

- `ROM`, `SAVE FILES`, `SAVE SLOT` in LauncherView
- `Import mod .zip`, `Or copy a mod .zip via USB.`, `Import or export a .sav with the system file picker.` in RomImporter

each sits next to a sibling branch that already calls Strings.

the width bug that pr mentioned is gone already - chip buttons measure the text they draw. but the delete chip pins its width to the unarmed caption, and english is the only reason that is safe: `Delete` is longer than `Sure?`, while japanese さくじょ is shorter than よろしい？. pinned to the wider of the two now, so it still never reflows.

no behaviour change without a catalog. 107/107 engine, 3/3 modkit.