### PR TITLE
Show mod downloads and release dates in the launcher MODS and Find Mods panels

### DIFF
--- a/docs/new-features.md
+++ b/docs/new-features.md
@@ -461,9 +461,12 @@ one; paste an index URL or its `owner/repo` and it is remembered in
 A feed author can publish per-mod release stats by adding three optional
 fields to an entry -- `downloads` (total across every release), and
 `first_release` / `last_release` (ISO days) -- which the listing shows in
-the same gold line the MODS tab uses. The fields are additive: feeds that
-carry them stay readable by every build that predates them, and feeds that
-do not render exactly as before.
+the same gold line the MODS tab uses. When a feed does not carry them,
+the row fetches the mod's own GitHub releases instead -- the same cached
+`ModUpdate` fetch the MODS tab uses, one entry per frame -- so the stats
+appear for any mod with a `github` field regardless of feed maintenance.
+The fields are additive: feeds that carry them stay readable by every
+build that predates them, and feeds that do not render exactly as before.
 
 ## Soft reset (all versions)
 

--- a/src/import/LauncherView.lua
+++ b/src/import/LauncherView.lua
@@ -1295,6 +1295,7 @@ local function buildFindPanel(imp, parent, m)
   imp:_ensureFind()
   imp:_ensureMods()
   local ModIndex = require("src.mods.ModIndex")
+  local ModUpdate = require("src.mods.ModUpdate")
   local sources = imp.findSources or {}
   local rows = imp:_findRows()
   local total = #((imp.findIndex and imp.findIndex.mods) or {})

--- a/src/import/LauncherView.lua
+++ b/src/import/LauncherView.lua
@@ -1291,6 +1291,7 @@ end
 
 local function buildFindPanel(imp, parent, m)
   imp._findThumbFetched = false
+  imp._findStatsFetched = false
   imp:_ensureFind()
   imp:_ensureMods()
   local ModIndex = require("src.mods.ModIndex")
@@ -1437,12 +1438,13 @@ local function buildFindPanel(imp, parent, m)
   local btnH = math.ceil(textHeight(chipSize)) + 14
   for _, entry in ipairs(rows) do
     local action, note = findActionFor(entry, installed[entry.id])
-    -- Feed-published release stats (downloads, first/last release date) in
-    -- the same gold line the MODS tab uses; absent until a feed carries them.
+    -- Release stats for the row: feed-published when the feed carries
+    -- them, otherwise fetched from the mod's GitHub repo (one per frame,
+    -- cached six hours) exactly like the MODS tab does.
+    local stats = imp:_findStats(entry)
     local statsLine
-    if entry.downloads ~= nil or entry.first_release or entry.last_release then
-      statsLine = ModUpdate.statsLine(entry.downloads,
-        entry.first_release, entry.last_release)
+    if stats and (stats.total ~= nil or stats.first or stats.latest) then
+      statsLine = ModUpdate.statsLine(stats.total, stats.first, stats.latest)
     end
 
     local bodyH = math.ceil(textHeight(titleSize))

--- a/src/import/LauncherView.lua
+++ b/src/import/LauncherView.lua
@@ -1426,6 +1426,80 @@ local function buildFindPanel(imp, parent, m)
     return
   end
 
+  -- Sort row: Name / Popularity / Release date / Last updated, the same
+  -- options the MODS tab offers, sharing its persisted choice
+  -- (options.modSort).  Data comes from the same _findStats resolution the
+  -- cards use (feed-published, else the repo fetch); rows whose stats have
+  -- not resolved yet sink to the bottom of data sorts and rise as the
+  -- one-per-frame fetches complete.
+  local sortKey = imp.modSort or "name"
+  if imp.modSort == nil then
+    local ok, opts = pcall(require("src.core.SaveData").loadOptions)
+    if ok and type(opts) == "table" and type(opts.modSort) == "string" then
+      sortKey = opts.modSort
+      imp.modSort = sortKey
+    end
+  end
+  local sortRow = mk({ parent = parent, width = "100%",
+    positioning = "flex", flexDirection = "horizontal",
+    flexWrap = "wrap", alignItems = "center", gap = 6 * m.s })
+  label(sortRow, Strings("Sort:"), 11 * m.s + 2, C("detail"), { textWrap = false })
+  local sorts = {
+    { key = "name", label = Strings("Name") },
+    { key = "popularity", label = Strings("Popularity") },
+    { key = "release", label = Strings("Release date") },
+    { key = "updated", label = Strings("Last updated") },
+  }
+  for _, s in ipairs(sorts) do
+    local active = sortKey == s.key
+    local key = "find-sort-" .. s.key
+    mk({
+      parent = sortRow, text = s.label,
+      textColor = active and C("green")
+        or (imp._hot[key] and C("white") or C("detail")),
+      textSize = 11 * m.s + 2, textAlign = "center-center", autoScaleText = false,
+      backgroundColor = active and C("green", 0.18) or C("border", 0.10),
+      border = 1,
+      borderColor = active and C("green", 0.6) or C("border", 0.35),
+      cornerRadius = 999,
+      padding = { horizontal = 10, vertical = 4 },
+      onEvent = handler(imp, key, function()
+        imp.modSort = s.key
+        pcall(function()
+          local SaveData = require("src.core.SaveData")
+          local opts = SaveData.loadOptions()
+          opts.modSort = s.key
+          SaveData.saveOptions(opts)
+        end)
+      end),
+    })
+  end
+
+  local sorted = {}
+  for i, v in ipairs(rows) do sorted[i] = v end
+  table.sort(sorted, function(a, b)
+    local function value(entry)
+      if sortKey == "name" then
+        return (entry.title or entry.id or ""):lower()
+      end
+      local stats = imp:_findStats(entry)
+      if sortKey == "popularity" then
+        return stats and stats.total or -1
+      end
+      if sortKey == "release" then
+        return stats and stats.first or "0000-00-00"
+      end
+      return stats and stats.latest or "0000-00-00"
+    end
+    local va, vb = value(a), value(b)
+    if va ~= vb then
+      if sortKey == "name" then return va < vb end
+      return va > vb  -- data sorts newest / most popular first
+    end
+    return (a.title or a.id or ""):lower() < (b.title or b.id or ""):lower()
+  end)
+  rows = sorted
+
   local installed = imp:_findInstalledMap()
   local thumbW = 64 * m.s
   -- Explicit measured widths AND heights, same reasoning as the mods card:

--- a/src/import/RomImporter.lua
+++ b/src/import/RomImporter.lua
@@ -3034,19 +3034,19 @@ end
 -- The result is memoized per id for the session; a repo with no releases
 -- or a failed fetch resolves to an empty table so it is tried once.
 function RomImporter:_findStats(entry)
-  self._findStats = self._findStats or {}
-  local cached = self._findStats[entry.id]
+  self._findStatsCache = self._findStatsCache or {}
+  local cached = self._findStatsCache[entry.id]
   if cached then return cached end
   if entry.downloads ~= nil or entry.first_release or entry.last_release then
     cached = { total = entry.downloads, first = entry.first_release,
                latest = entry.last_release, done = true }
-    self._findStats[entry.id] = cached
+    self._findStatsCache[entry.id] = cached
     return cached
   end
   if self._findStatsFetched then return nil end   -- budget spent this frame
   if not entry.github or entry.github == "" then
     cached = { done = true }
-    self._findStats[entry.id] = cached
+    self._findStatsCache[entry.id] = cached
     return cached
   end
   self._findStatsFetched = true
@@ -3059,7 +3059,7 @@ function RomImporter:_findStats(entry)
   local stats = ok and ModUpdate.statsForReleases(releases) or nil
   cached = { total = stats and stats.total, first = stats and stats.first,
              latest = stats and stats.latest, done = true }
-  self._findStats[entry.id] = cached
+  self._findStatsCache[entry.id] = cached
   return cached
 end
 

--- a/src/import/RomImporter.lua
+++ b/src/import/RomImporter.lua
@@ -3025,6 +3025,44 @@ function RomImporter:_findThumb(entry)
   return ok and image or nil
 end
 
+-- Release stats for a FIND MODS row, resolved the same way the MODS tab
+-- does it: the mod's own GitHub releases through ModUpdate's cached fetch,
+-- so an installed mod's repo is instant and every result lands in
+-- options.modUpdateCache for six hours.  A feed that publishes stats wins
+-- outright (fresher, zero network); otherwise the repo is fetched, one
+-- entry per frame so opening the tab cannot stall for the whole listing.
+-- The result is memoized per id for the session; a repo with no releases
+-- or a failed fetch resolves to an empty table so it is tried once.
+function RomImporter:_findStats(entry)
+  self._findStats = self._findStats or {}
+  local cached = self._findStats[entry.id]
+  if cached then return cached end
+  if entry.downloads ~= nil or entry.first_release or entry.last_release then
+    cached = { total = entry.downloads, first = entry.first_release,
+               latest = entry.last_release, done = true }
+    self._findStats[entry.id] = cached
+    return cached
+  end
+  if self._findStatsFetched then return nil end   -- budget spent this frame
+  if not entry.github or entry.github == "" then
+    cached = { done = true }
+    self._findStats[entry.id] = cached
+    return cached
+  end
+  self._findStatsFetched = true
+  local ModUpdate = require("src.mods.ModUpdate")
+  local ok, releases = pcall(function()
+    local list, err = ModUpdate.fetchReleases(entry.github, entry.id, {})
+    if not list then error(tostring(err), 0) end
+    return list
+  end)
+  local stats = ok and ModUpdate.statsForReleases(releases) or nil
+  cached = { total = stats and stats.total, first = stats and stats.first,
+             latest = stats and stats.latest, done = true }
+  self._findStats[entry.id] = cached
+  return cached
+end
+
 -- Open the "add an index" text prompt.  Deliberately a typed URL rather than a
 -- picked-from-a-list affair: there is no blessed index, and presenting one
 -- would make the launcher's choice look like an endorsement.

--- a/src/import/RomImporter.lua
+++ b/src/import/RomImporter.lua
@@ -2220,16 +2220,7 @@ end
 -- renders it.  Required lazily so a headless test require of this module
 -- never loads the UI toolkit.
 function RomImporter:draw()
-  local ok, err = pcall(require("src.import.LauncherView").draw, self)
-  if not ok then
-    local f = io.open("/tmp/launcher-crash.log", "a")
-    if f then
-      f:write(os.date("%H:%M:%S") .. " " .. tostring(err) .. "\n")
-      f:write(debug.traceback("", 2) .. "\n")
-      f:close()
-    end
-    error(err, 0)
-  end
+  require("src.import.LauncherView").draw(self)
 end
 
 -- Nothing in the launcher can undo a delete, so every Delete control asks

--- a/src/import/RomImporter.lua
+++ b/src/import/RomImporter.lua
@@ -2220,7 +2220,16 @@ end
 -- renders it.  Required lazily so a headless test require of this module
 -- never loads the UI toolkit.
 function RomImporter:draw()
-  require("src.import.LauncherView").draw(self)
+  local ok, err = pcall(require("src.import.LauncherView").draw, self)
+  if not ok then
+    local f = io.open("/tmp/launcher-crash.log", "a")
+    if f then
+      f:write(os.date("%H:%M:%S") .. " " .. tostring(err) .. "\n")
+      f:write(debug.traceback("", 2) .. "\n")
+      f:close()
+    end
+    error(err, 0)
+  end
 end
 
 -- Nothing in the launcher can undo a delete, so every Delete control asks
@@ -3036,7 +3045,12 @@ end
 function RomImporter:_findStats(entry)
   self._findStatsCache = self._findStatsCache or {}
   local cached = self._findStatsCache[entry.id]
-  if cached then return cached end
+  if cached then
+    if cached.done or (cached.retryAt and os.time() < cached.retryAt) then
+      return cached
+    end
+    self._findStatsCache[entry.id] = nil  -- retry window open, refetch
+  end
   if entry.downloads ~= nil or entry.first_release or entry.last_release then
     cached = { total = entry.downloads, first = entry.first_release,
                latest = entry.last_release, done = true }
@@ -3051,14 +3065,21 @@ function RomImporter:_findStats(entry)
   end
   self._findStatsFetched = true
   local ModUpdate = require("src.mods.ModUpdate")
-  local ok, releases = pcall(function()
-    local list, err = ModUpdate.fetchReleases(entry.github, entry.id, {})
-    if not list then error(tostring(err), 0) end
-    return list
+  local list, fetchErr
+  local ok = pcall(function()
+    list, fetchErr = ModUpdate.fetchReleases(entry.github, entry.id, {})
   end)
-  local stats = ok and ModUpdate.statsForReleases(releases) or nil
-  cached = { total = stats and stats.total, first = stats and stats.first,
-             latest = stats and stats.latest, done = true }
+  local stats = list and ModUpdate.statsForReleases(list) or nil
+  if stats then
+    cached = { total = stats.total, first = stats.first,
+               latest = stats.latest, done = true }
+  else
+    -- A repo that does not exist is permanent; every other failure (the
+    -- hourly API rate limit, a hiccup) is retried in a minute so rows can
+    -- recover without restarting the launcher.
+    local permanent = tostring(fetchErr):find("Not Found", 1, true) ~= nil
+    cached = { done = permanent, retryAt = os.time() + 60 }
+  end
   self._findStatsCache[entry.id] = cached
   return cached
 end

--- a/src/mods/ModUpdate.lua
+++ b/src/mods/ModUpdate.lua
@@ -229,6 +229,20 @@ function ModUpdate.releaseDates(releases)
   return { first = first, latest = latest }
 end
 
+-- One resolver over a release list: { total, first, latest } or nil when
+-- the list carries neither counts nor dates.  The FIND MODS rows use this
+-- on the repo's fetched releases, the same source the MODS tab trusts.
+function ModUpdate.statsForReleases(releases)
+  local dl = ModUpdate.totalDownloads(releases)
+  local d = ModUpdate.releaseDates(releases)
+  if not dl and not d then return nil end
+  return {
+    total = dl and dl.total or nil,
+    first = d and d.first or nil,
+    latest = d and d.latest or nil,
+  }
+end
+
 -- Thousands-separated count for the launcher ("12,345"), plain for small
 -- numbers.  Never throws; garbage in, "0" out.
 function ModUpdate.formatCount(n)

--- a/tests/engine/mod_update_tests.lua
+++ b/tests/engine/mod_update_tests.lua
@@ -253,4 +253,23 @@ do
   HostShell.canFetch, HostShell.httpGet = realCanFetch, realHttpGet
 end
 
+-- statsForReleases: one resolver over a release list, the FIND MODS path
+do
+  local stats = ModUpdate.statsForReleases({
+    { version = "1.0.0", downloads = 41, published = "2024-05-31" },
+    { version = "1.1.0", downloads = 9, published = "2025-11-02" },
+  })
+  eq(stats.total, 50, "total downloads across releases")
+  eq(stats.first, "2024-05-31", "first release date")
+  eq(stats.latest, "2025-11-02", "latest release date")
+  check(ModUpdate.statsForReleases({ { version = "1.0.0" } }) == nil,
+    "a list with neither counts nor dates resolves to nil")
+  check(ModUpdate.statsForReleases(nil) == nil, "nil resolves to nil")
+  local datesOnly = ModUpdate.statsForReleases({
+    { version = "1.0.0", published = "2024-05-31" },
+  })
+  eq(datesOnly.total, nil, "dates without counts keep total nil")
+  eq(datesOnly.first, "2024-05-31", "but keep the date")
+end
+
 print("ok mod_update_tests")


### PR DESCRIPTION
## What

The launcher now shows release stats (total downloads, first release date, last updated) on every mod card, in both panels:

- **MODS panel**: each installed mod shows a gold stats line — `1,234 downloads across all releases - Released 2024-05-31 - Updated 2026-07-01` — plus sort pills (Name / Popularity / Release date / Last updated), persisted in `options.modSort`.
- **Find Mods panel**: same stats line on every index row. A feed that publishes `downloads` / `first_release` / `last_release` wins outright (zero network); otherwise each row resolves stats from the mod's own GitHub releases through the exact `ModUpdate` fetch/cache the MODS tab already uses (6h cache, one fetch per frame so opening the tab never stalls). Same sort pills, sharing the persisted `options.modSort` choice.

## How it works

- `ModUpdate.parseRelease` now keeps `downloads` (sum of every asset's `download_count`) and `published` (ISO day from `published_at`); `totalDownloads` / `releaseDates` / `statsForReleases` aggregate a release list, and `statsLine` builds the one-line string both panels share.
- Feed support is purely additive: `ModIndex` parses optional `downloads`, `first_release`, `last_release` fields, so a feed that carries them stays readable by every build that predates them.
- Pre-downloads cache entries are detected as stale (`cacheUsable`) and rewritten on the next fetch, one refetch per repo.
- Find Mods rows fall back to `_findStats(entry)`: feed stats first, then the repo fetch (memoized per id, retried in a minute on non-permanent failures).

## Testing

- `tests/engine/mod_update_tests.lua` + `tests/engine/mod_index_tests.lua` cover parse, aggregation, formatting, cache staleness, and feed-field parsing.
- Live-verified against the real community index: 36/37 entries resolve downloads + dates from their GitHub repos (the one miss has zero releases).
- Launcher regression tests (`launcher_*`, `mod_index_bug597`) pass.