### PR TITLE
Pre-add the official mod index to FIND MODS for every install

### DIFF
--- a/docs/new-features.md
+++ b/docs/new-features.md
@@ -453,10 +453,14 @@ printout.
 
 A FIND MODS tab sits beside MODS in the launcher and browses a published
 mod index: a metadata-only feed listing mods that live in their authors'
-own repositories. No index ships with the launcher and none is ever added
-automatically, so the tab opens on an "Add an index" prompt until you name
-one; paste an index URL or its `owner/repo` and it is remembered in
-`options.lua`. More than one index can be added, and the listings merge.
+own repositories. The project's own index
+(`bryanthaboi/gen1recomp-mod-index`) ships pre-added for every install,
+so the tab opens on the official listing right away; paste another index
+URL or its `owner/repo` and it is remembered in `options.lua`. More than
+one index can be added, and the listings merge (the first source wins on
+a duplicate mod id). Removing the official index opts out of it for good
+-- it will not come back on the next launch -- and removing any index
+drops its cached listing with it.
 
 ## Soft reset (all versions)
 

--- a/src/import/RomImporter.lua
+++ b/src/import/RomImporter.lua
@@ -2889,10 +2889,10 @@ end
 --
 -- The index is metadata only (src/mods/ModIndex.lua): it says where a mod's
 -- zip lives, and the install runs through exactly the same path "Import mod
--- .zip" does.  Nothing here is automatic -- no index ships with the launcher,
--- and the tab stays an empty "Add an index" prompt until the player names one,
--- because subscribing to somebody's list of mods is a trust decision and not a
--- default.
+-- .zip" does.  The project's own index (bryanthaboi/gen1recomp-mod-index)
+-- ships pre-added for every install -- it tops ModIndex.sources() until the
+-- player removes it, which opts out permanently -- and any number of other
+-- indexes can be added beside it.
 --
 -- Fetching is the same synchronous curl the update checks already use, cached
 -- in options for a day, so the first open of the tab costs one round trip and

--- a/src/mods/ModIndex.lua
+++ b/src/mods/ModIndex.lua
@@ -421,9 +421,25 @@ local function loadOptions()
   return require("src.core.SaveData").loadOptions()
 end
 
+-- The project's own index, pre-added for every install: it is the default
+-- source behind FIND MODS.  Built through the same resolution players'
+-- pastes go through, so the feed/base/fallback triple cannot drift from
+-- what addSource("bryanthaboi/gen1recomp-mod-index") would store.
+ModIndex.OFFICIAL = ModIndex.resolveSource("bryanthaboi/gen1recomp-mod-index")
+    or {}
+if type(ModIndex.OFFICIAL.feed) == "string" then
+  ModIndex.OFFICIAL.url =
+    "https://github.com/bryanthaboi/gen1recomp-mod-index"
+  ModIndex.OFFICIAL.official = true
+end
+
 -- The player's index list, normalised.  Rows are { url, feed, base, fallback,
 -- label }; `url` is what they typed, kept so the row reads back the way they
 -- entered it.
+--
+-- The official index tops the list for every install unless the player
+-- removed it (a permanent opt-out: it must not come back next launch) or
+-- already added it by hand (no duplicates).
 function ModIndex.sources()
   local ok, opts = pcall(loadOptions)
   if not ok or type(opts) ~= "table" then return {} end
@@ -432,6 +448,14 @@ function ModIndex.sources()
     if type(row) == "table" and type(row.feed) == "string" then
       out[#out + 1] = row
     end
+  end
+  local official = ModIndex.OFFICIAL
+  if type(official.feed) == "string" and opts.modIndexesOfficialRemoved ~= true then
+    local hasOfficial = false
+    for _, row in ipairs(out) do
+      if row.feed == official.feed then hasOfficial = true break end
+    end
+    if not hasOfficial then table.insert(out, 1, official) end
   end
   return out
 end
@@ -471,8 +495,15 @@ function ModIndex.removeSource(feed)
     for _, row in ipairs(opts.modIndexes or {}) do
       if row.feed == feed then found = true else kept[#kept + 1] = row end
     end
-    if not found then return nil end
     opts.modIndexes = kept
+    -- Removing the official index opts out of the pre-added default too:
+    -- it tops the sources list without ever being in modIndexes, so the
+    -- flag (not the list) is what keeps it gone.
+    if ModIndex.OFFICIAL and feed == ModIndex.OFFICIAL.feed then
+      opts.modIndexesOfficialRemoved = true
+      found = true
+    end
+    if not found then return nil end
     if type(opts.modIndexCache) == "table" then opts.modIndexCache[feed] = nil end
     SaveData.saveOptions(opts)
     return true

--- a/tests/engine/mod_index_tests.lua
+++ b/tests/engine/mod_index_tests.lua
@@ -273,4 +273,83 @@ do
   eq(cats[1], "GAMEPLAY", "and they keep the feed's declared order")
 end
 
+-- ------- the pre-added official index (sources)
+
+-- sources()/addSource()/removeSource() persist through SaveData; stub the
+-- module functions so the assertions observe the exact option writes
+-- without touching a real options file.
+do
+  local SaveData = require("src.core.SaveData")
+  local vanillaLoad, vanillaSave = SaveData.loadOptions, SaveData.saveOptions
+  local state = { opts = nil, saved = nil }
+  SaveData.loadOptions = function() return state.opts end
+  SaveData.saveOptions = function(opts) state.saved = opts end
+  local function fresh()
+    state.opts = {}          -- a fresh install: no index ever configured
+    state.saved = nil
+  end
+  local official = ModIndex.OFFICIAL
+  check(official ~= nil and type(official.feed) == "string",
+    "the official index resolves to a feed URL")
+
+  fresh()
+  local list = ModIndex.sources()
+  eq(#list, 1, "a fresh install lists one source")
+  eq(list[1].feed, official.feed, "and it is the official index")
+  check(state.saved == nil, "listing the default does not persist anything")
+
+  fresh()
+  state.opts = {
+    modIndexes = {
+      { url = "https://example.com/ix", feed = "https://example.com/ix/data/index.json",
+        base = "https://example.com/ix/", label = "example/ix" },
+    },
+  }
+  list = ModIndex.sources()
+  eq(#list, 2, "player indexes ride below the official default")
+  eq(list[1].feed, official.feed, "official stays on top")
+  eq(list[2].feed, "https://example.com/ix/data/index.json",
+    "the player's own index follows")
+
+  fresh()
+  state.opts = { modIndexes = { {
+    url = "https://github.com/bryanthaboi/gen1recomp-mod-index",
+    feed = official.feed, base = official.base, label = official.label,
+  } } }
+  list = ModIndex.sources()
+  eq(#list, 1, "a hand-added official index is not duplicated")
+
+  fresh()
+  state.opts = { modIndexes = {}, modIndexesOfficialRemoved = true }
+  eq(#ModIndex.sources(), 0,
+    "removing the official index opts out of the default for good")
+
+  -- Removing the pre-added (never persisted) official row still sticks.
+  fresh()
+  local ok = ModIndex.removeSource(official.feed)
+  check(ok == true, "removing the pre-added official index succeeds")
+  check(state.saved.modIndexesOfficialRemoved == true,
+    "and records the permanent opt-out")
+
+  -- Removing a player index does not touch the official opt-out.
+  fresh()
+  state.opts = { modIndexes = { {
+    url = "https://example.com/ix", feed = "https://example.com/ix/data/index.json",
+    base = "https://example.com/ix/", label = "example/ix",
+  } } }
+  ModIndex.removeSource("https://example.com/ix/data/index.json")
+  check(state.saved.modIndexesOfficialRemoved == nil,
+    "removing a player index leaves the official default alone")
+  eq(#state.saved.modIndexes, 0, "and drops the removed row")
+
+  -- addSource on the official feed stores one row; sources() shows it once.
+  fresh()
+  local added, err = ModIndex.addSource("bryanthaboi/gen1recomp-mod-index")
+  check(added ~= nil, "adding the official index by slug works: " .. tostring(err))
+  eq(added.feed, official.feed, "and resolves to the same feed")
+  eq(#ModIndex.sources(), 1, "one row, no double-listing")
+
+  SaveData.loadOptions, SaveData.saveOptions = vanillaLoad, vanillaSave
+end
+
 print("ok mod_index_tests")


### PR DESCRIPTION
## What

FIND MODS currently ships with no default index: the tab opens on an "Add an index" prompt and stays empty until the player names one. This PR pre-adds the project's own index (`bryanthaboi/gen1recomp-mod-index`) for every install, so the tab opens on the official listing right away.

## How it works

- `ModIndex.OFFICIAL` resolves the official index through the same `resolveSource` path players' pastes go through, so feed/base/fallback cannot drift from what `addSource("bryanthaboi/gen1recomp-mod-index")` would store.
- `ModIndex.sources()` tops the returned list with the official index unless the player removed it or already added it by hand (no duplicates, no re-pinning).
- `ModIndex.removeSource` on the official feed records a permanent opt-out (`options.modIndexesOfficialRemoved`), so a player who removes it does not get it back on the next launch. Removing any other index behaves exactly as before.
- Docs (`docs/new-features.md`) and the `RomImporter` FIND MODS comment updated to match.

## Testing

- New `mod_index_tests` section (SaveData stubbed): fresh install lists exactly the official index without persisting anything; player indexes ride below it; a hand-added official index is not duplicated; removal records the opt-out and empties the list; removing a player index leaves the default alone.
- End-to-end smoke: a fresh importer draws the Find panel, picks up the pinned source, fetches the official feed, and lists its mods.
- Launcher regression tests (`launcher_*`, `mod_index_bug597`) pass.

Note: the trust caveat still applies to third-party indexes; the official listing is the project's own and carries the same "listed, not reviewed" notice.