### PR TITLE
Add haptic feedback to the on-screen touch controls

### DIFF
--- a/mobile/android/love/src/main/java/org/love2d/android/GameActivity.java
+++ b/mobile/android/love/src/main/java/org/love2d/android/GameActivity.java
@@ -53,12 +53,15 @@ import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
+import android.media.AudioAttributes;
 import android.media.AudioManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.util.Log;
 import android.util.DisplayMetrics;
@@ -437,8 +440,21 @@ public class GameActivity extends SDLActivity {
 
     @Keep
     public static void vibrate(double seconds) {
-        if (vibrator != null) {
-            vibrator.vibrate((long) (seconds * 1000.));
+        if (vibrator == null) return;
+        // The deprecated Vibrator.vibrate(ms) routes as USAGE_UNKNOWN, which
+        // several OEMs (MIUI/HyperOS) set to OFF in their vibration-intensity
+        // settings -- the call succeeds but the amplitude is scaled to zero.
+        // Use the modern API with a game usage (never UNKNOWN/TOUCH, both OFF
+        // there) and max amplitude so the pulse is actually felt.
+        int ms = (int) Math.max(1, Math.min(Integer.MAX_VALUE, seconds * 1000.));
+        if (Build.VERSION.SDK_INT >= 26) {
+            vibrator.vibrate(
+                VibrationEffect.createOneShot(ms, 255),
+                new AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_GAME)
+                    .build());
+        } else {
+            vibrator.vibrate(ms);
         }
     }
 

--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -1059,6 +1059,7 @@ function Game:applyOptions(opts)
     if FrameCap.current > caps.fpsMax then FrameCap.apply(caps.fpsMax) end
   end
   Input:applyBindings(opts.bindings)
+  require("src.core.Haptics").applyOptions(opts)
   TouchControls:applyOptions(opts)
   -- heal soft-bricked APK installs that already saved gbcfx > 0 (#136)
   if gbcCleared then self:writeOptions() end

--- a/src/core/Haptics.lua
+++ b/src/core/Haptics.lua
@@ -1,0 +1,49 @@
+-- Short haptic pulse on each on-screen button press, so the thumb feels
+-- the press without looking.  options.haptics is a single 0..10 level
+-- (0 = OFF, 10 = maximum) set by the HAPTIC LEVEL menu row.  The level
+-- scales the vibration duration -- the only lever love.system.vibrate
+-- exposes (inert on iOS, whose system buzz ignores it).  No-op on desktop.
+
+local Haptics = {}
+
+-- level 0..10 -> vibration seconds.  Monotone: the low end is a barely-there
+-- tick, the top a clearly felt buzz.  Level 0 is OFF (pulse returns before
+-- looking this table up).
+local PULSE = {
+  [1] = 0.015, [2] = 0.025, [3] = 0.040, [4] = 0.060, [5] = 0.085,
+  [6] = 0.120, [7] = 0.170, [8] = 0.240, [9] = 0.320, [10] = 0.400,
+}
+local LEVEL_MIN, LEVEL_MAX = 0, 10
+local DEFAULT_LEVEL = 0
+
+local state = { level = DEFAULT_LEVEL }
+
+local function clampLevel(v)
+  if type(v) ~= "number" or v ~= v then return DEFAULT_LEVEL end
+  return math.max(LEVEL_MIN, math.min(LEVEL_MAX, math.floor(v)))
+end
+
+-- Normalize a persisted haptics value: a 0..10 level, clamped.  Nil /
+-- garbage falls back to the default (OFF).
+function Haptics.normalize(v)
+  return clampLevel(v)
+end
+
+function Haptics.applyOptions(opts)
+  state.level = Haptics.normalize(opts and opts.haptics)
+end
+
+function Haptics.level()
+  return state.level
+end
+
+function Haptics.pulse()
+  if state.level <= 0 then return end
+  local vibrate = love and love.system and love.system.vibrate
+  if type(vibrate) ~= "function" then return end
+  pcall(vibrate, PULSE[state.level] or PULSE[5])
+end
+
+Haptics.LEVEL_MIN, Haptics.LEVEL_MAX = LEVEL_MIN, LEVEL_MAX
+
+return Haptics

--- a/src/core/SaveData.lua
+++ b/src/core/SaveData.lua
@@ -305,6 +305,9 @@ function SaveData.defaultOptions()
     -- layout (#633).  Pre-#633 files stored one top-level positions table;
     -- TouchControls.normalizeConfig folds it into both orientations on load.
     touchControls = { enabled = true },
+    -- haptic pulse on touch-overlay presses (see src/core/Haptics.lua);
+    -- a 0..10 level, 0 = OFF (the default)
+    haptics = 0,
   }
 end
 

--- a/src/core/TouchControls.lua
+++ b/src/core/TouchControls.lua
@@ -28,6 +28,7 @@
 
 local Input = require("src.core.Input")
 local SafeArea = require("src.core.SafeArea")
+local Haptics = require("src.core.Haptics")
 
 local TouchControls = {}
 
@@ -401,7 +402,10 @@ end
 local function pressBtn(self, btn)
   local n = (self.held[btn] or 0) + 1
   self.held[btn] = n
-  if n == 1 then Input:overlayPressed(btn) end
+  if n == 1 then
+    Input:overlayPressed(btn)
+    Haptics.pulse()
+  end
 end
 
 local function releaseBtn(self, btn)

--- a/src/ui/OptionsMenu.lua
+++ b/src/ui/OptionsMenu.lua
@@ -28,6 +28,7 @@ local Runtime = require("src.mods.Runtime")
 local OptionRows = require("src.ui.OptionRows")
 local Renderer = require("src.render.Renderer")
 local Strings = require("src.core.Strings")
+local Haptics = require("src.core.Haptics")
 
 local OptionsMenu = {}
 OptionsMenu.__index = OptionsMenu
@@ -437,6 +438,19 @@ local function buildRows(game)
         require("src.core.TouchControls"):applyOptions(o)
         return true
       end },
+    -- haptic feedback on the on-screen pad; same mobile gate as TOUCH PAD.
+    -- A single 0..10 level, 0 = OFF (see src/core/Haptics.lua).
+    { id = "hapticLevel", label = Strings("HAPTIC LEVEL"),
+      value = function(g)
+        local level = Haptics.normalize(g.save.options.haptics)
+        return level == 0 and Strings("OFF") or tostring(level)
+      end,
+      step = function(g, dir)
+        local o = g.save.options
+        o.haptics = math.max(0, math.min(10, Haptics.normalize(o.haptics) + (dir or 1)))
+        Haptics.applyOptions(o)
+        return true
+      end },
   }
   -- issue #136: hide GBC FX on Android/iOS -- the present shader soft-bricks
   if not GBCFX.isSupported() then
@@ -454,8 +468,9 @@ local function buildRows(game)
     end
     rows = filtered
   end
-  -- TOUCH PAD only where the overlay can appear (mobile, or desktop with
-  -- POKEPORT_TOUCH=1).  POKEPORT_TOUCH=0 forces it off everywhere.
+  -- TOUCH PAD / HAPTIC LEVEL only where the overlay can appear (mobile, or
+  -- desktop with POKEPORT_TOUCH=1).  POKEPORT_TOUCH=0 forces them off
+  -- everywhere.
   do
     local env = os.getenv("POKEPORT_TOUCH")
     local osName = love.system and love.system.getOS and love.system.getOS()
@@ -464,7 +479,9 @@ local function buildRows(game)
     if not show then
       local filtered = {}
       for _, row in ipairs(rows) do
-        if row.id ~= "touchControls" then filtered[#filtered + 1] = row end
+        if row.id ~= "touchControls" and row.id ~= "hapticLevel" then
+          filtered[#filtered + 1] = row
+        end
       end
       rows = filtered
     end

--- a/tests/engine/touch_haptics_test.lua
+++ b/tests/engine/touch_haptics_test.lua
@@ -1,0 +1,151 @@
+-- Haptic feedback on the on-screen pad: every fresh virtual press fires a
+-- short love.system.vibrate pulse scaled by options.haptics (a 0..10 level,
+-- 0 = OFF), recorded here by swapping love.system.vibrate for a recorder.
+--   luajit tests/engine/touch_haptics_test.lua
+
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.harness")
+local check, eq = T.check, T.eq
+love = love or require("tests.love_stub")
+
+local SaveData = require("src.core.SaveData")
+local Haptics = require("src.core.Haptics")
+local Input = require("src.core.Input")
+local TC = require("src.core.TouchControls")
+
+Input:init()
+
+local pulses = {}
+local realVibrate = love.system.vibrate
+love.system.vibrate = function(seconds) pulses[#pulses + 1] = seconds end
+
+local realGetOS = love.system.getOS
+love.system.getOS = function() return "Android" end
+love.window = love.window or {}
+local oldSafe = love.window.getSafeArea
+local function setRect(w, h)
+  love.window.getSafeArea = function() return 0, 0, w, h end
+  love.graphics.getDimensions = function() return w, h end
+  TC.layoutW, TC.layoutH, TC.layoutOx, TC.layoutOy, TC.L = nil, nil, nil, nil, nil
+end
+local function resetPulses() pulses = {} end
+
+-- defaults are a 0..10 level, OFF (0), and mergeOptions preserves a value
+local d = SaveData.defaultOptions()
+eq(d.haptics, 0, "defaultOptions carries haptics level 0 (OFF)")
+local merged = SaveData.mergeOptions({ haptics = 8 })
+eq(merged.haptics, 8, "mergeOptions keeps a loaded haptics level")
+
+TC:init()
+setRect(380, 720)
+TC:applyOptions(SaveData.defaultOptions())
+-- the default is OFF; arm a level for the pulse tests below
+Haptics.applyOptions({ haptics = 5 })
+
+local function pressAt(id, x, y)
+  TC:touchpressed(id, x, y)
+  TC:touchreleased(id, x, y)
+end
+
+-- a fresh press pulses with the current level's duration
+resetPulses()
+pressAt(1, TC:layout().a.cx, TC:layout().a.cy)
+eq(#pulses, 1, "A press fires one pulse")
+eq(pulses[1], 0.085, "level 5 is an 85ms tick")
+
+-- level scales the duration across the whole 0..10 range
+Haptics.applyOptions({ haptics = 1 })
+resetPulses()
+pressAt(1, TC:layout().a.cx, TC:layout().a.cy)
+eq(pulses[1], 0.015, "level 1 is a 15ms tick")
+Haptics.applyOptions({ haptics = 10 })
+resetPulses()
+pressAt(1, TC:layout().a.cx, TC:layout().a.cy)
+eq(pulses[1], 0.400, "level 10 is a 400ms buzz")
+Haptics.applyOptions(SaveData.defaultOptions())
+
+-- level 0 stays silent
+Haptics.applyOptions({ haptics = 0 })
+resetPulses()
+pressAt(1, TC:layout().a.cx, TC:layout().a.cy)
+eq(#pulses, 0, "level 0 stays silent")
+Haptics.applyOptions({ haptics = 5 })
+
+-- a second finger joining an existing hold must not re-pulse
+local ax, ay = TC:layout().a.cx, TC:layout().a.cy
+resetPulses()
+TC:touchpressed(1, ax, ay)
+TC:touchpressed(2, ax + 1, ay + 1)
+TC:touchreleased(2, ax + 1, ay + 1)
+TC:touchreleased(1, ax, ay)
+eq(#pulses, 1, "joining a held button does not double-pulse")
+
+-- the d-pad pulses on press and again when the held direction changes
+local dz = TC:layout().dpad
+resetPulses()
+TC:touchpressed(3, dz.cx + dz.w * 0.4, dz.cy) -- right
+eq(#pulses, 1, "d-pad press pulses")
+TC:touchmoved(3, dz.cx - dz.w * 0.4, dz.cy)    -- slide to left
+eq(#pulses, 2, "d-pad direction change re-pulses")
+TC:touchreleased(3, dz.cx - dz.w * 0.4, dz.cy)
+eq(#pulses, 2, "releasing adds no pulse")
+
+-- garbage levels normalize instead of erroring
+Haptics.applyOptions(nil)
+eq(Haptics.level(), 0, "nil options -> default level (OFF)")
+Haptics.applyOptions({ haptics = 99 })
+eq(Haptics.level(), Haptics.LEVEL_MAX, "level clamps high")
+Haptics.applyOptions({ haptics = -3 })
+eq(Haptics.level(), 0, "level clamps low (off)")
+Haptics.applyOptions({ haptics = "loud" })
+eq(Haptics.level(), 0, "non-numeric level -> default (OFF)")
+Haptics.applyOptions(SaveData.defaultOptions())
+
+-- the single settings row steps the 0..10 level and clamps at the ends
+local OptionsMenu = require("src.ui.OptionsMenu")
+local stubGame = {
+  save = { options = SaveData.defaultOptions() },
+  data = nil,
+  modStatus = {},
+}
+local menu = OptionsMenu.new(stubGame)
+local levelRow
+for _, row in ipairs(menu.rows) do
+  if row.id == "hapticLevel" then levelRow = row end
+end
+check(levelRow ~= nil, "HAPTIC LEVEL row survives mobile buildRows")
+eq(levelRow.value(stubGame), "OFF", "HAPTIC LEVEL defaults to OFF")
+check(levelRow.step(stubGame, 1) == true, "level step applies")
+eq(stubGame.save.options.haptics, 1, "step up lands on 1")
+eq(levelRow.value(stubGame), "1", "value reflects the new level")
+check(levelRow.step(stubGame, -1) == true, "level step applies at the floor")
+eq(stubGame.save.options.haptics, 0, "step down clamps at OFF")
+stubGame.save.options.haptics = 10
+check(levelRow.step(stubGame, 1) == true, "level step applies at the ceiling")
+eq(stubGame.save.options.haptics, 10, "step up clamps at 10")
+
+-- the row exists in the settings menu and rides the touch-pad gate
+local function read(path)
+  local f = assert(io.open(path, "r"))
+  local src = f:read("*a")
+  f:close()
+  return src
+end
+local optSrc = read("src/ui/OptionsMenu.lua")
+check(optSrc:find('id = "hapticLevel"', 1, true) ~= nil,
+      "OptionsMenu has the HAPTIC LEVEL row")
+check(optSrc:find('id = "haptics"', 1, true) == nil,
+      "OptionsMenu no longer has a separate HAPTICS toggle row")
+check(optSrc:find('row.id ~= "hapticLevel"', 1, true) ~= nil,
+      "haptic row shares the touch-pad mobile gate")
+local gameSrc = read("src/core/Game.lua")
+check(gameSrc:find('require("src.core.Haptics").applyOptions', 1, true) ~= nil,
+      "Game:applyOptions pushes haptics state")
+
+love.system.vibrate = realVibrate
+love.system.getOS = realGetOS
+if oldSafe then love.window.getSafeArea = oldSafe
+else love.window.getSafeArea = nil end
+
+T.finish("touch_haptics")

--- a/tests/love_stub.lua
+++ b/tests/love_stub.lua
@@ -367,6 +367,7 @@ stub.image = {
 -- check, the touch-overlay filter) take their desktop branch.
 stub.system = {
   getOS = function() return "OS X" end,
+  vibrate = noop,
 }
 
 -- Desktop / headless: full-window safe area (matches LÖVE's fallback).


### PR DESCRIPTION
# Add haptic feedback to the on-screen touch controls

## Context

Cf. https://github.com/bryanthaboi/gen1recomp/issues/806

## What changes

### A single HAPTIC LEVEL option, off by default

Options gains one row, **HAPTIC LEVEL**: an integer **0–10** (0 = OFF, the default). It scales the vibration duration from a barely-there 15 ms tick up to a 400 ms buzz.

### Every fresh press pulses

`TouchControls.pressBtn` now calls `Haptics.pulse()`, it fires on a fresh press only.

### OEMs mutint with Android

LÖVE's stock `GameActivity.vibrate()` used the deprecated `Vibrator.vibrate(ms)`, which the system routes as `USAGE_UNKNOWN` and some OEMs (MIUI/HyperOS) set to **OFF** in their vibration-intensity settings, scaling the amplitude to zero while the call still "succeeds". Choosed to use `VibrationEffect.createOneShot(ms, 255)` with `AudioAttributes.USAGE_GAME` at max amplitude.

## Video

https://github.com/user-attachments/assets/543efd13-ec95-4b49-a3b1-7940647fb209

## Misc

Tested on Android (on a Xiaomi 13 (HyperOS))

Closes https://github.com/bryanthaboi/gen1recomp/issues/806
