### PR TITLE
Keep CacheFs.read from crashing when modkit runs headless

### DIFF
--- a/src/import/CacheFs.lua
+++ b/src/import/CacheFs.lua
@@ -294,6 +294,9 @@ function CacheFs.read(rel)
     f:close()
     return data
   end
+  -- headless (plain luajit, e.g. the modkit validate/pack driver): there is
+  -- no save directory to read from, so a cache miss is nil, not a crash
+  if not (love and love.filesystem) then return nil end
   return love.filesystem.read(rel)
 end
 

--- a/tests/engine/cache_fs_headless_test.lua
+++ b/tests/engine/cache_fs_headless_test.lua
@@ -1,0 +1,20 @@
+-- CacheFs stays headless-safe: plain luajit has no love global, and the
+-- modkit validate/pack driver reaches CacheFs.read through Data:load when
+-- an optional generated module (audio) is missing from the checkout
+-- (issue #850).  With no portable root and no love there is no save
+-- directory to read from, so the read is a nil miss, not a crash.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.harness")
+local check = T.check
+
+check(_G.love == nil, "suite runs with no love global")
+
+local CacheFs = require("src.import.CacheFs")
+
+check(CacheFs.read("data/generated/audio.lua") == nil,
+  "read is a nil miss headless, not a crash")
+check(CacheFs.readActive("data/generated/audio.lua") == nil,
+  "readActive is a nil miss headless, not a crash")
+
+T.finish()


### PR DESCRIPTION
Refs #850

Running `python3 tools/modkit.py validate <mod> --strict` or `pack` headless died with `MK100 ERROR loader driver crashed: CacheFs.lua:297: attempt to index global 'love' (a nil value)` whenever `--base auto` resolved to the imported dataset. The driver runs the real loader under plain luajit, where there is no love global. When `Data:load` hits a generated module require cannot find (an optional one like `data/generated/audio.lua`, which Data.lua marks optional for developer and stale caches), it falls back to reading the bytes through `CacheFs.readActive`, and `CacheFs.read` went straight to `love.filesystem.read` once there was no portable root. In-game this never comes up because love is always there.

Fix: with no portable root and no love, `CacheFs.read` returns nil, the same cache miss it already reports for a file that is not there. The optional module stays absent, `Data:load` logs its usual warning, and the driver gets on with validating the mod. The other love-backed CacheFs calls (write, exists, remove) are unchanged; they are not on the headless driver path.

Tests: `validate example_mew_starter --strict` and `pack mods/example_mew_starter` both crashed before and pass now, with `--base imported` and `--base fixture`. New suite `tests/engine/cache_fs_headless_test.lua` covers read and readActive with no love global; it crashes at the old CacheFs.lua:297 without the fix and passes with it. `luajit tests/run_modkit.lua` passes, and the four validate-related failures in `tests/run_tests.lua` (scaffolded mod validates clean, template validates against the imported dataset, orphan patch target reported as MK103, MK103 names the missing target) are gone. The remaining `run_tests.lua` and `run_engine.lua` failures (cries count, the absent audio module, quit thread shutdown, title zone seams) fail identically on upstream/dev.