### PR TITLE
TrainerCard: honour trueColor flag from player.sprite hook

### DIFF
--- a/src/ui/TrainerCard.lua
+++ b/src/ui/TrainerCard.lua
@@ -67,8 +67,15 @@ function TrainerCard.new(game, opts)
     end
   end
   self.circle = tryImage("assets/generated/trainer_card/circle_tile.png")
-  self.pic = tryImage(require("src.pokemon.Sprites").playerPath(
-    game.data, "front", { kind = "trainer_card" }))
+
+  -- Capture both return values from playerPath: path and trueColor flag.
+  -- The trueColor flag is set by the player.sprite hook when a mod injects
+  -- a custom portrait that should bypass the MEWMON palette pipeline.
+  local picPath, picTrueColor = require("src.pokemon.Sprites").playerPath(
+    game.data, "front", { kind = "trainer_card" })
+  self.pic          = tryImage(picPath)
+  self.picTrueColor = self.pic and picTrueColor or false
+
   return self
 end
 
@@ -117,7 +124,18 @@ function TrainerCard:draw()
   -- top card (rows 0-7): NAME / MONEY / TIME, pic upper-right
   self:frameBox(0, 0, 20, 8)
   if self.pic then
+    love.graphics.setColor(1, 1, 1, 1)
     love.graphics.draw(self.pic, 104, 4)
+    -- True-colour portraits (e.g. mod-injected custom characters) carry their
+    -- own colours and must not be re-mapped by the MEWMON zone shader.
+    -- markTrueColor appends a colors=false zone that the Renderer splices at
+    -- the end of the zone list, causing it to re-blit just this rect without
+    -- the palette shader on top of the already-colourised frame.
+    -- This matches the pattern used by OakSpeech, HallOfFame and SummaryMenu.
+    if self.picTrueColor then
+      local w, h = self.pic:getDimensions()
+      require("src.render.PaletteFX").markTrueColor(104, 4, w, h)
+    end
   end
   love.graphics.setColor(0, 0, 0, 1)
   Font.draw(Strings("NAME/%s", save.player.name or "RED"), 16, 16)


### PR DESCRIPTION
**Summary**

`TrainerCard.new` calls `Sprites.playerPath` but discards its second return value (`trueColor`). Mods that inject a custom front portrait via the `player.sprite` hook and set `ctx.trueColor = true` still have the MEWMON palette shader applied over their sprite, washing out the original colours.

**Root cause**

```lua
-- before: second return value silently dropped
self.pic = tryImage(require("src.pokemon.Sprites").playerPath(
  game.data, "front", { kind = "trainer_card" }))
```

`playerPath` returns `(path, trueColor)`. Passing the call directly into `tryImage` discards `trueColor`, and there is no path to skip the MEWMON zone for just the portrait rect.

**Fix**

Two minimal changes — both following patterns already established elsewhere in the codebase:

**1. Capture `trueColor` in `new`** (same pattern as `OakSpeech.new` with `playerTrueColor`):

```lua
local picPath, picTrueColor = require("src.pokemon.Sprites").playerPath(
  game.data, "front", { kind = "trainer_card" })
self.pic          = tryImage(picPath)
self.picTrueColor = self.pic and picTrueColor or false
```

**2. Call `markTrueColor` in `draw` when the flag is set** (same pattern as `OakSpeech:draw`, `HallOfFame:draw`, `SummaryMenu:draw`):

```lua
if self.pic then
  love.graphics.setColor(1, 1, 1, 1)
  love.graphics.draw(self.pic, 104, 4)
  if self.picTrueColor then
    local w, h = self.pic:getDimensions()
    require("src.render.PaletteFX").markTrueColor(104, 4, w, h)
  end
end
```

`markTrueColor` appends a `colors = false` zone that `Renderer:blitCanvas` splices at the end of the zone list, causing it to re-blit just that rect without the palette shader — on top of the already-colourised frame.

**Behaviour**

| Portrait type | Result |
|---|---|
| Vanilla RED (built-in DMG art) | `trueColor` is always `false` → MEWMON palette applied as before. Zero behaviour change. |
| Built-in character (e.g. Giovanni, Jessie) | DMG 4-shade art → MEWMON remap works correctly as before. |
| Custom character, `trueColor = false` | No change — portrait rendered through the MEWMON zone as before. PNG must use the 4-shade DMG ramp for colours to map correctly. |
| Custom character, `trueColor = true` | Portrait re-blitted unshaded over the colourised frame. Original PNG colours preserved. Badges, borders and text remain correctly colourised. |

**Prior art in this codebase**

The same `markTrueColor` pattern is already used by:
- `OakSpeech:draw` (line ~629) — intro speech portrait
- `HallOfFame:draw` (lines ~334, ~354) — Hall of Fame player and back pics
- `SummaryMenu:draw` (line ~121) — Pokémon summary sprite
- `DexEntryMenu:draw` (line ~84) — Pokédex entry sprite

`TrainerCard` was the only UI screen that captured the portrait via `playerPath` but did not honour the `trueColor` flag it returns.

**Discovered while building** the [Who's That Trainer?](https://github.com/MyFriendPKMN/whos-that-trainer) mod, which uses the `player.sprite` hook to swap the trainer card portrait for custom characters, a mod user report it here https://discord.com/channels/1019387038820216882/1533275976291848212/1534718923440918650 and i check it here https://discord.com/channels/1019387038820216882/1533275976291848212/1534759384683516086 .

after
<img width="345" height="768" alt="image" src="https://github.com/user-attachments/assets/f10f2717-cd27-4d25-b6f9-7357cebb5c84" />
before
<img width="825" height="731" alt="image" src="https://github.com/user-attachments/assets/73c0a74d-7b8a-4351-9b5a-b73de8eb93a0" />
those sprites can be found at the mod repo here ([front.png](https://github.com/MyFriendPKMN/whos-that-trainer/blob/main/custom_characters/kawfy_true_colors/front.png)) https://github.com/MyFriendPKMN/whos-that-trainer/tree/main/custom_characters/kawfy_true_colors