### PR TITLE
Fix Yellow Oak speech showing Nidorino instead of Pikachu (#915)

### DIFF
--- a/src/core/Data.lua
+++ b/src/core/Data.lua
@@ -84,6 +84,15 @@ function Data:applyVersionedFieldData()
     -- Yellow caches carry the wrong demo species too.  The fixed import
     -- manifest below stamps RATTATA for fresh imports.
     self.field.oldManBattle = { species = "RATTATA", level = 5 }
+    -- The Oak-speech show-off mon is the player's Pikachu in Yellow
+    -- (engine/battle/core.asm BATTLE_TYPE_PIKACHU / the ProfOak demo)
+    -- but caches imported before the manifest carried demoSpecies fell
+    -- back to Red's NIDORINO (#915).  The fixed import manifest below
+    -- stamps PIKACHU for fresh imports; fill it here for stale caches.
+    local oakSpeech = self.field.oakSpeech
+    if type(oakSpeech) == "table" and not oakSpeech.demoSpecies then
+      oakSpeech.demoSpecies = "PIKACHU"
+    end
   end
 end
 

--- a/tests/parity_yellow_oak_speech.lua
+++ b/tests/parity_yellow_oak_speech.lua
@@ -1,0 +1,51 @@
+-- Pokemon Yellow's Oak-speech show-off mon is the player's Pikachu, not
+-- Red/Blue's NIDORINO (engine/battle/core.asm BATTLE_TYPE_PIKACHU, the
+-- ProfOak demo; engine/movie/oak_speech/oak_speech.asm).  The import
+-- manifest must carry field.oakSpeech.demoSpecies, and
+-- Data:applyVersionedFieldData repairs Yellow caches made before the
+-- manifest carried it (#915).
+package.path = "./?.lua;./?/init.lua;" .. package.path
+if not _G.love then _G.love = require("tests.love_stub") end
+
+local Data = require("src.core.Data")
+if not (Data.field and Data.field.oakSpeech) then Data:load() end
+local GameVersion = require("src.core.GameVersion")
+local S = require("tests.harness").suite("parity Yellow Oak speech")
+local check, eq = S.check, S.eq
+
+local oldVersion = GameVersion.get()
+local oldTrades = Data.field.trades
+local oldOldManBattle = Data.field.oldManBattle
+
+local manifestFile = assert(io.open("tools/rom_manifest_yellow.json", "r"))
+local manifest = manifestFile:read("*a")
+manifestFile:close()
+
+check(manifest:find('"demoSpecies": "PIKACHU"') ~= nil,
+      "Yellow manifest stamps field.oakSpeech.demoSpecies as PIKACHU")
+
+-- a stale Yellow cache carries shrink frames but no demoSpecies
+local stale = { shrink1 = "assets/generated/intro/shrink1.png",
+                shrink2 = "assets/generated/intro/shrink2.png" }
+local oldOakSpeech = Data.field.oakSpeech
+Data.field.oakSpeech = stale
+
+GameVersion.set("yellow")
+Data:applyVersionedFieldData()
+eq(Data.field.oakSpeech.demoSpecies, "PIKACHU",
+   "applyVersionedFieldData fills a stale Yellow cache with PIKACHU")
+
+-- fill-if-absent: an importer that learns to stamp the key wins
+local preStamped = { demoSpecies = "RAICHU",
+                     shrink1 = "assets/generated/intro/shrink1.png" }
+Data.field.oakSpeech = preStamped
+Data:applyVersionedFieldData()
+eq(Data.field.oakSpeech.demoSpecies, "RAICHU",
+   "applyVersionedFieldData leaves an already-stamped demoSpecies alone")
+
+Data.field.oakSpeech = oldOakSpeech
+Data.field.trades = oldTrades
+Data.field.oldManBattle = oldOldManBattle
+GameVersion.set(oldVersion)
+
+return S:finish()

--- a/tools/make_yellow_manifest.py
+++ b/tools/make_yellow_manifest.py
@@ -481,6 +481,12 @@ def derive(red, pokeyellow, symbols_path):
                     for i, name in enumerate(yellow_bubbles)],
     }
 
+    # The Oak-speech show-off mon is the player's Pikachu in Yellow
+    # (engine/battle/core.asm BATTLE_TYPE_PIKACHU / the ProfOak demo);
+    # the deep-copied Red field.oakSpeech has no demoSpecies, so stamp
+    # it or the import falls back to NIDORINO (#915).
+    yellow["field"]["oakSpeech"]["demoSpecies"] = "PIKACHU"
+
     # Ensure Melanie / Summer Beach town-map entries exist after rebuild.
     locations = yellow["field"]["townMap"]["locations"]
     if "CERULEAN_MELANIES_HOUSE" not in locations \

--- a/tools/rom_manifest_yellow.json
+++ b/tools/rom_manifest_yellow.json
@@ -6566,6 +6566,7 @@
       }
     ],
     "oakSpeech": {
+      "demoSpecies": "PIKACHU",
       "shrink1": "assets/generated/intro/shrink1.png",
       "shrink2": "assets/generated/intro/shrink2.png"
     },


### PR DESCRIPTION
## Summary

Fixes #915 — Pokemon Yellow's Oak opening speech showed **Nidorino** instead of **Pikachu**.

`src/ui/OakSpeech.lua:249` reads `oakGfx.demoSpecies` (from `data.field.oakSpeech`) and falls back to `"NIDORINO"` when absent. Yellow's manifest `field.oakSpeech` carried only `shrink1`/`shrink2`, so the fallback fired for both the show-off sprite and the cry. In vanilla Yellow, the Oak-speech demo mon is the player's Pikachu (`engine/battle/core.asm` `BATTLE_TYPE_PIKACHU` / ProfOak demo).

## Changes

- **`tools/rom_manifest_yellow.json`** — added `"demoSpecies": "PIKACHU"` to `field.oakSpeech` (source of truth for fresh ROM imports via `RomExtractor.lua` and developer builds via `tools/build_rom_data.py`).
- **`tools/make_yellow_manifest.py`** — stamps `field.oakSpeech.demoSpecies` so regenerating against `pret/pokeyellow` keeps the value instead of reverting to the deep-copied Red `oakSpeech`.
- **`src/core/Data.lua`** — `applyVersionedFieldData()` now fills `oakSpeech.demoSpecies = "PIKACHU"` for stale Yellow caches imported before the manifest fix (fill-if-absent, so a future importer that stamps the key wins). Mirrors the #617 `oldManBattle` RATTATA repair pattern and runs before the mod loader so mods can still override.
- **`tests/parity_yellow_oak_speech.lua`** (new) — parity test: manifest carries PIKACHU; a stale cache is repaired; a pre-stamped value is left alone.

Red/Blue manifests are intentionally untouched (NIDORINO fallback remains correct for them); `OakSpeech.lua` is unchanged.

## Validation

- `scripts/test.sh` — ALL TIERS PASSED (T3 skipped without a ROM-imported `data/generated/`, as designed in this checkout).
- New parity test: 3/3 checks pass against `tests/fixture_data`.
- `tools/rom_manifest_yellow.json` parses as JSON; `py_compile` on the generator OK; `luajit -bl` syntax OK on all touched Lua.