### PR TITLE
feat(launcher): dynamic fit-scaling for short and square windows

### DIFF
--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -223,8 +223,9 @@ filesystem stub the slot backend uses (`tests/engine/save_file_io_tests.lua`).
 ## Responsiveness
 
 Every measurement derives from `love.graphics.getDimensions()` each frame
-plus the existing global scale `s = clamp(height / 768, 0.7, 1.6)`; nothing
-assumes a fixed window size. The game panel's two-column grid (ROM/SAVE
+plus the existing global scale `s = clamp(min(width / 640, height / 768),
+0.9, 1.6) * 1.3`; nothing assumes a fixed window size. The game panel's
+two-column grid (ROM/SAVE
 FILES/Play on the left, SAVE SLOT on the right) collapses to one stacked
 column, slot card below Play, when the window is too narrow for both
 `~300 * s`-wide columns. The save-slot list and the mod list both scroll
@@ -235,6 +236,20 @@ narrow-safe, and content caps out at `~1440 * s` wide, centered.
 The desktop window has a floor of 480x360 (`conf.lua` `minwidth`/`minheight`),
 under which the cards stop being readable at all. Mobile ignores it: those
 windows are fullscreen.
+
+### Fit scaling
+
+A SHORT or squat window is answered by FIT-SCALING, not just scrolling.
+`Layout.metrics(maxAppW, fitH)` takes the panel minimum the active tab
+needs (`{ two = 460, one = 660 }`, unscaled px) and `Kit.layout` solves
+for the scale at which that minimum plus the header/footer chrome lands
+on screen: text, tap targets, padding and row heights all move together
+off `Kit.scale`, so a 720x720 handheld (RG34XX) and 4:3 or phone-shaped
+windows show the whole stack with nothing under the fold. Because
+fit-shrinking can flip the column count, the metrics re-fit against the
+matching minimum until scale and columns stabilise. The fit never sinks
+below `Kit.FIT_FLOOR` (0.78, below which a 30px tap target would shrink
+to ~23px); under that the page scroll above remains the backstop.
 
 ### Page scroll
 

--- a/src/import/LauncherView.lua
+++ b/src/import/LauncherView.lua
@@ -2199,6 +2199,15 @@ end
 -- this the page SCROLLS (wheel / touch drag) instead of compressing: the
 -- pinned Play block used to walk up over the cards on a short window, which
 -- is unusable, and the footer simply lives below the fold until scrolled to.
+--
+-- The minimum is also the FIT-SCALE target: Layout.metrics shrinks the whole
+-- UI until the panel minimum plus the header/footer chrome fits the window
+-- height, so on short or square windows (the RG34XX's 720x720, 4:3 devices,
+-- phones) everything stays reachable instead of sitting under the fold.
+-- Only below the fit floor (Kit.FIT_FLOOR) does the page fall back to
+-- scrolling rather than compressing.
+local PANEL_MIN_TWO = 460   -- side-by-side columns
+local PANEL_MIN_ONE = 660   -- one column (actions + slot + pinned Play)
 local function minPanelHeight(m)
   -- One column stacks the actions card, the slot card and the pinned Play
   -- block in a single pile, so it needs more room than the side-by-side
@@ -2208,12 +2217,13 @@ local function minPanelHeight(m)
   -- no slot could be picked at all (#852).  660 fits the actions card, one
   -- slot row with its pager and New button, and the pinned block; whatever
   -- the window cannot show, the page scroll above reaches.
-  return math.floor((m.twoCol and 460 or 660) * m.s)
+  return math.floor((m.twoCol and PANEL_MIN_TWO or PANEL_MIN_ONE) * m.s)
 end
 
 function LauncherView.draw(imp)
   ensureState(imp)
-  local m = Layout.metrics(1200)
+  local m = Layout.metrics(1200,
+    { two = PANEL_MIN_TWO, one = PANEL_MIN_ONE })
 
   -- The pointer is the pad cursor while it is active, so the ring, hover and
   -- clicks all agree on where "the pointer" is.

--- a/src/ui/kit/Kit.lua
+++ b/src/ui/kit/Kit.lua
@@ -8,7 +8,9 @@
 -- ~9.2ms/frame down to well under 1ms (see POKEPORT_LAUNCHER_PROF).
 --
 -- Usage, once per love.draw():
---     Kit.layout(w, h)                     -- fonts + scale, only on resize
+--     Kit.layout(w, h, fitH)               -- fonts + scale, only on resize
+--                                          -- fitH = unscaled px of panel
+--                                          --    content that must fit height
 --     Kit.beginFrame(mx, my, clicked, wheel)
 --     ... widgets ...
 --     Kit.endFrame()
@@ -118,19 +120,38 @@ local function font(name)
 end
 Kit.font = font
 
--- Rebuild the font set when the window size changes.  The scale never dips
--- below 0.9 so text and the 30px tap targets stay readable on a phone; a
--- narrow window is answered by REFLOW (see Layout.lua), never by shrinking.
+-- Rebuild the font set when the window size changes.  A narrow window is
+-- answered by REFLOW (see Layout.lua); a SHORT window that would put content
+-- under the fold is answered by FIT-SCALING: the whole UI (text, tap
+-- targets, padding, row heights) shrinks together until the caller's panel
+-- minimum plus the header/footer chrome lands on screen.  The fit never
+-- sinks below FIT_FLOOR; below that the page scrolls instead of rendering
+-- unusably tiny controls.
 -- Global size multiplier.  Everything in the UI derives from Kit.scale, so
 -- one factor here moves text, tap targets, padding and row heights together
 -- and nothing drifts out of proportion.  1.3 because the launcher is read at
 -- couch distance as often as at desk distance, and the old sizing was tuned
 -- for the latter only.
 local UI_SCALE = 1.3
+-- Fit-scaling floor, in effective (post UI_SCALE) px.  0.78 keeps a 30px tap
+-- target at ~23px and the 14px button face at ~11px on a dense handheld, and
+-- is enough to fit the whole launcher on the RG34XX's 720x720 screen.
+local FIT_FLOOR = 0.78
+-- Vertical chrome the fit budget must cover beyond the panel minimum,
+-- unscaled px: the header body (~80), the footer body (~74) and the
+-- inter-block gap (~12).
+local FIT_CHROME = 166
 
-function Kit.layout(width, height)
+function Kit.layout(width, height, fitH)
   local s = Theme.clamp(math.min(width / 640, height / 768), 0.9, 1.6) * UI_SCALE
-  local key = ("%dx%d"):format(math.floor(width), math.floor(height))
+  if fitH and fitH > 0 then
+    -- Solve for the scale at which the panel minimum plus chrome (which
+    -- grows with s) plus the fixed logo band fits the window height, and
+    -- take it only if it is below the resolution scale.
+    local logoH = Theme.clamp(height * 0.10, 36, 84)
+    s = math.min(s, math.max(FIT_FLOOR, (height - logoH) / (fitH + FIT_CHROME)))
+  end
+  local key = ("%dx%d@%.2f"):format(math.floor(width), math.floor(height), s)
   if Kit._fontKey ~= key then
     Kit._fontKey = key
     Kit.fonts = Theme.fonts(s)

--- a/src/ui/kit/Layout.lua
+++ b/src/ui/kit/Layout.lua
@@ -27,15 +27,45 @@ Layout.BP = {
   threeCol = 1100,  -- wide desktop: mod list + detail + chrome
 }
 
+-- Resolve the column count for an app width and scale.  Shared by the
+-- metrics builder and the fit-scale pass below.
+local function columnCount(appW, s)
+  return (appW >= Layout.BP.threeCol * s and 3)
+      or (appW >= Layout.BP.twoCol * s and 2)
+      or 1
+end
+
 -- Build the frame's metrics.  `maxAppW` caps the content column on an
 -- ultrawide monitor so the UI stays a readable measure instead of stretching.
-function Layout.metrics(maxAppW)
+-- `fitH` (optional) is the panel minimum the caller needs to fit vertically,
+-- as `{ two = 460, one = 660 }` in unscaled px per column count.  When set,
+-- the whole UI fit-scales down so that minimum plus the header/footer chrome
+-- lands on screen instead of under the fold (see Kit.layout).
+function Layout.metrics(maxAppW, fitH)
   local W, H = 0, 0
   if love and love.graphics and love.graphics.getDimensions then
     W, H = love.graphics.getDimensions()
   end
   local ox, oy, sw, sh = SafeArea.rect()
   local s = Kit.layout(sw, sh)
+
+  -- The column count decides which panel minimum applies, so resolve it
+  -- against the resolution scale first, then fit against the matching
+  -- minimum.  Fit-shrinking can change the column count -- a 720px square
+  -- window drops below the two-column breakpoint and the two-column
+  -- minimum (460) replaces the one-column minimum (660) -- so re-fit
+  -- against the new minimum until scale and column count stabilise.
+  local cols = columnCount(math.min(sw, (maxAppW or 1200) * s), s)
+  if fitH then
+    for _ = 1, 3 do
+      local need = cols >= 2 and fitH.two or fitH.one
+      if not need then break end
+      s = Kit.layout(sw, sh, need)
+      local nextCols = columnCount(math.min(sw, (maxAppW or 1200) * s), s)
+      if nextCols == cols then break end
+      cols = nextCols
+    end
+  end
 
   local appW = math.min(sw, (maxAppW or 1200) * s)
   local m = {
@@ -53,9 +83,7 @@ function Layout.metrics(maxAppW)
     railH = math.max(3, math.floor(4 * s)),
     logoH = math.floor(Theme.clamp(sh * 0.10, 36, 84)),
   }
-  m.cols = (appW >= Layout.BP.threeCol * s and 3)
-        or (appW >= Layout.BP.twoCol * s and 2)
-        or 1
+  m.cols = columnCount(appW, s)
   m.twoCol = m.cols >= 2
   m.contentW = m.w - 2 * m.pad
   m.colW = m.twoCol

--- a/tests/engine/launcher_one_column_reach_bug852.lua
+++ b/tests/engine/launcher_one_column_reach_bug852.lua
@@ -8,8 +8,11 @@
 -- threshold read "tall enough", so the short-window page scroll never
 -- engaged, buildSlotCard was cut by Kit.pushClip against the pinned block,
 -- and Kit's clip-bounded hit-testing (src/ui/kit/Kit.lua) left every slot
--- row, the pager and "+ New save slot" drawn-but-inert.  The fix makes the
--- threshold column-aware, so those windows scroll instead of clipping.
+-- row, the pager and "+ New save slot" drawn-but-inert.  The fix made the
+-- threshold column-aware (LauncherView's PANEL_MIN_TWO/ONE).  That minimum
+-- now doubles as the FIT-SCALE target: Layout.metrics shrinks the whole UI
+-- until the stack plus chrome fits the window, so those windows show
+-- everything on screen; only below the fit floor does the page scroll.
 --
 -- The seam is LauncherView.draw itself: it publishes the page-scroll extent
 -- on the importer (imp._pageScroll / imp._pageScrollMax, the values the
@@ -52,39 +55,52 @@ local function freshLauncher()
   return RomImporter.new(function() end, { launcher = true })
 end
 
--- ------------------------------------------------ #852: the scroll engages
--- 480x900 one column: enough room for the old flat 460*s threshold, not for
--- the one-column stack.  Before the fix draw() left _pageScrollMax at 0 here
--- and the slot card sat clipped inert against the pinned buttons.
+-- ------------------------------------------ #852: the stack stays reachable
+-- 480x900 one column.  Before the #852 fix the flat 460*s threshold read
+-- "tall enough", so the page-scroll never engaged and the slot card sat
+-- clipped inert against the pinned buttons.  Now the one-column minimum is
+-- also the FIT-SCALE target: Layout.metrics shrinks the whole UI until that
+-- minimum plus the header/footer chrome fits the window height, so the
+-- entire stack -- title, actions card, slot card, pinned block, footer --
+-- lands on screen and there is nothing to scroll.
+--
+-- The draw's own metrics use the launcher's fit hint ({ two = 460, one =
+-- 660 }), so the test passes the same hint to keep m.s in agreement.
 window(480, 900)
-local m = Layout.metrics(1200)
+local m = Layout.metrics(1200, { two = 460, one = 660 })
 eq(m.twoCol, false, "480-wide window lays out one column")
 local imp = freshLauncher()
 LauncherView.draw(imp)
-check((imp._pageScrollMax or 0) > 0,
-  "one-column window short of the stack engages the page scroll")
+eq(imp._pageScrollMax or 0, 0,
+  "fit-scale puts the whole one-column stack on screen")
 eq(imp._pageScroll, 0, "a fresh page starts at the top")
 
--- The wheel moves the page (the same offset the touch drag feeds), and the
--- offset clamps to the extent, so the whole stack down to "+ New save slot"
--- and the footer is reachable rather than clipped away.
-local extent = imp._pageScrollMax
-imp._wheelY = -1
-LauncherView.draw(imp)
-eq(imp._pageScroll, math.min(math.floor(48 * m.s), extent),
-  "one wheel notch scrolls the page down by its step")
-imp._pageScroll = 1e6
-LauncherView.draw(imp)
-eq(imp._pageScroll, imp._pageScrollMax,
-  "an offset past the end clamps to the extent, so the bottom is reachable")
-
--- The reporter's portrait phone (360x780 units) is shorter still and must
--- also scroll; before the fix its slot list was unreachable.
+-- The reporter's portrait phone (360x780 units) also fits after fit-scaling;
+-- before the fix its slot list was unreachable.
 window(360, 780)
 local phone = freshLauncher()
 LauncherView.draw(phone)
-check((phone._pageScrollMax or 0) > 0,
-  "portrait-phone one-column window engages the page scroll")
+eq(phone._pageScrollMax or 0, 0,
+  "portrait-phone one-column window fits after fit-scaling")
+
+-- Below the fit floor a very short window still engages the page scroll, and
+-- the wheel clamps to the extent so the bottom of the stack -- down to
+-- "+ New save slot" and the footer -- stays reachable rather than clipped.
+window(480, 360)
+local short = freshLauncher()
+LauncherView.draw(short)
+check((short._pageScrollMax or 0) > 0,
+  "a very short one-column window below the fit floor scrolls")
+local shortM = Layout.metrics(1200, { two = 460, one = 660 })
+local extent = short._pageScrollMax
+short._wheelY = -1
+LauncherView.draw(short)
+eq(short._pageScroll, math.min(math.floor(48 * shortM.s), extent),
+  "one wheel notch scrolls the page down by its step")
+short._pageScroll = 1e6
+LauncherView.draw(short)
+eq(short._pageScroll, short._pageScrollMax,
+  "an offset past the end clamps to the extent, so the bottom is reachable")
 
 -- A one-column window tall enough for the whole stack stays inert: the
 -- column-aware minimum is a floor, not a permanent scroll.


### PR DESCRIPTION
## Summary

On short or square windows the launcher stopped at the fixed 0.9 scale floor and let content sit under the fold — the RG34XX's 720×720 screen rendered one column with a 353px page scroll and the footer off-screen. This PR adds **fit-scaling**: the whole UI (text, tap targets, padding, row heights) shrinks together off `Kit.scale` until the panel minimum plus the header/footer chrome lands on screen, instead of scrolling.

## How it works

- `Kit.layout(w, h, fitH)` — an optional third argument solves for the scale at which the caller's panel minimum (unscaled px) plus chrome fits the window height. `FIT_FLOOR = 0.78` is the legibility floor; below it the existing page scroll remains the backstop.
- `Layout.metrics(maxAppW, fitH)` — resolves the column count against the resolution scale first, then fit-scales against the matching per-column minimum. Because fit-shrinking can flip the column count (a 720px square drops below the two-column breakpoint), it re-fits against the new minimum until scale and columns stabilise.
- `LauncherView` — the launcher's column-aware panel minimums (#852: 460 two-col / 660 one-col) now double as the fit-scale target and are passed as the fit hint.
- Fonts rebuild when the fit changes scale at a fixed resolution (font cache key now includes `s`).

## Effects

- **720×720 (RG34XX):** two-column, scroll-free, footer and seal on screen (was one-column + 353px scroll).
- **480×900 / 360×780 (portrait phones):** whole one-column stack fits; no scroll (was unreachable slot list).
- **1280×800 desktop:** unchanged — fit only kicks in when the resolution scale alone would put content under the fold.
- **Below the floor (e.g. 480×360):** still scrolls and clamps to a reachable bottom.

## Tests

`tests/engine/launcher_one_column_reach_bug852.lua` rewritten for the new mechanism: 480×900 and 360×780 now assert `scrollMax = 0`; a below-floor 480×360 window still engages the page scroll and the wheel clamps to the extent. `scripts/test.sh --quick`: **ALL TIERS PASSED**.

Docs updated in `docs/launcher.md` (Responsiveness → Fit scaling).

## Files

- `src/ui/kit/Kit.lua` — fit-scale solve, `FIT_FLOOR`/`FIT_CHROME`, font key includes scale
- `src/ui/kit/Layout.lua` — `metrics(maxAppW, fitH)` + `columnCount` extraction + stabilisation loop
- `src/import/LauncherView.lua` — panel minimums as the fit hint
- `tests/engine/launcher_one_column_reach_bug852.lua`
- `docs/launcher.md`
