### PR TITLE
Mod API: expose a read-only active map overview

### DIFF
--- a/src/world/WorldAPI.lua
+++ b/src/world/WorldAPI.lua
@@ -43,6 +43,26 @@ function WorldAPI:current()
            facing = p and p.facing }
 end
 
+-- A compact, read-only view of the active map for minimaps and companion UIs.
+-- Rows use " " for blocked terrain, "." for walkable land, "~" for water
+-- and "+" for a door or warp.
+function WorldAPI:mapOverview()
+  local ow = self:overworld()
+  if not ow or not ow.map then return nil, NO_OVERWORLD end
+  local map, rows = ow.map, {}
+  for y = 0, map.heightCells - 1 do
+    local row = {}
+    for x = 0, map.widthCells - 1 do
+      row[#row + 1] = map:isWarpTileCell(x, y) and "+"
+        or map:isWaterCell(x, y) and "~"
+        or map:isWalkableCell(x, y) and "." or " "
+    end
+    rows[#rows + 1] = table.concat(row)
+  end
+  return { mapId = map.id, width = map.widthCells,
+           height = map.heightCells, rows = rows }
+end
+
 -- opts.arrive = "fly" | "teleport" picks the arrival FX; anything else
 -- lands the player without one, like a scripted warp.
 function WorldAPI:warpTo(mapId, x, y, facing, opts)

--- a/tests/engine/world_map_overview_test.lua
+++ b/tests/engine/world_map_overview_test.lua
@@ -1,0 +1,26 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.harness")
+local WorldAPI = require("src.world.WorldAPI")
+
+local api = WorldAPI.new({ stack = { states = {} } }, "tester")
+local overview, err = api:mapOverview()
+T.eq(overview, nil, "map overview is unavailable outside the overworld")
+T.eq(err, "no overworld", "map overview reports why it is unavailable")
+
+local map = { id = "TEST_MAP", widthCells = 2, heightCells = 2 }
+function map:isWarpTileCell(x, y) return x == 1 and y == 0 end
+function map:isWaterCell(x, y) return x == 0 and y == 1 end
+function map:isWalkableCell(x, y) return x == 0 and y == 0 end
+
+api = WorldAPI.new({ stack = { states = {
+  { isOverworld = true, map = map },
+} } }, "tester")
+overview = api:mapOverview()
+T.eq(overview.mapId, "TEST_MAP", "map overview identifies the active map")
+T.eq(overview.width, 2, "map overview reports its width")
+T.eq(overview.height, 2, "map overview reports its height")
+T.eq(overview.rows[1], ".+", "walkable land and warps are distinct")
+T.eq(overview.rows[2], "~ ", "water and blocked terrain are distinct")
+
+T.finish("world map overview")


### PR DESCRIPTION
## Summary

- add `mod.world:mapOverview()` as a read-only snapshot of the active map
- return the map ID, dimensions and compact terrain rows
- distinguish blocked terrain, walkable land, water and doors/warps without exposing the live `Map` object
- preserve the existing `nil, "no overworld"` behavior outside gameplay

## Motivation

Mods can already query the player's current map and position, but a minimap, guide or companion UI still has to reach into unsupported world internals to understand the active map's shape. This provides the smallest useful platform-neutral snapshot while keeping map ownership and mutation inside the engine.

Each row uses `" "` for blocked terrain, `"."` for walkable land, `"~"` for water and `"+"` for a door or warp.

## Verification

- `luajit tests/engine/world_map_overview_test.lua` - 7/7 checks passed
- `luajit tests/run_engine.lua` - the new suite passes; 131/134 suites pass overall
- the same three Windows-only failures reproduce unchanged on clean `upstream/dev`: `build_zip_pipe_guard_bug774`, `quit_thread_shutdown` and `title_zone_seams`
