### PR TITLE
Fix: tools/modkit.py crashes on Windows when dumped text isn't representable in the system codepage

### DIFF
--- a/tools/modkit.py
+++ b/tools/modkit.py
@@ -716,7 +716,7 @@ def run_loader(repo, mod_dir, findings, base="fixture", notes=None):
         driver_path = handle.name
     try:
         proc = subprocess.run([LUAJIT, driver_path], cwd=repo,
-                              capture_output=True, text=True, timeout=120)
+                              capture_output=True, text=True, encoding="utf-8", timeout=120)
     except FileNotFoundError:
         findings.append(Finding("MK100", "error",
                                 f"cannot run {LUAJIT} (install luajit or "
@@ -1056,7 +1056,7 @@ def check_data_dump(repo, path, base, rel):
     driver = DUMP_DRIVER % (lua_quote(path), lua_quote(vanilla))
     try:
         proc = subprocess.run([LUAJIT, "-e", driver], cwd=repo,
-                              capture_output=True, text=True, timeout=60)
+                              capture_output=True, text=True, encoding="utf-8", timeout=60)
     except FileNotFoundError:
         # the gate must fail closed: a missing interpreter is a broken
         # environment, not a clean mod
@@ -1416,7 +1416,7 @@ def dump_dataset(repo, base):
     handle.close()
     try:
         proc = subprocess.run([os.environ.get("LUA", "luajit"), handle.name],
-                              cwd=repo, capture_output=True, text=True)
+                              cwd=repo, capture_output=True, text=True, encoding="utf-8")
     finally:
         os.unlink(handle.name)
     if proc.returncode != 0:


### PR DESCRIPTION
# Fix: `tools/modkit.py` crashes on Windows when dumped text isn't representable in the system codepage

## Bug

`dump_dataset()` (and two similar call sites: `run_loader()`'s loader driver
and `check_data_dump()`'s dump check) invoke `subprocess.run(...,
capture_output=True, text=True)` without an explicit `encoding=`. In text
mode without an explicit encoding, `subprocess` falls back to the OS
locale's default codepage (`locale.getencoding()` on Python 3.11+,
`locale.getpreferredencoding(False)` on older versions — same underlying
value).

On Windows, that default is a legacy single-byte codepage (e.g. `cp1252`),
never UTF-8. If the LuaJIT dump contains a byte that has no mapping in that
codepage, the internal `_readerthread` used by `subprocess.communicate()` on
Windows crashes with an uncaught `UnicodeDecodeError` in a background
thread. That thread dies silently (Python only prints "Exception in thread
Thread-1" and moves on), so `Popen.communicate()` never finishes populating
`self.stdout`, and the caller gets back a `CompletedProcess` whose `.stdout`
is `None` instead of a string — crashing one line later with:

```
AttributeError: 'NoneType' object has no attribute 'splitlines'
```

### Reproduction

Any translation mod scaffold/refresh (`modkit.py translation ...`) that
dumps text containing a byte outside the machine's default codepage. It
does not depend on the target `--language` (that argument only affects mod
naming, never `dump_dataset()`'s content).

Concretely, on the current `dev` tip, the Yellow-side "imported" dataset
contains this dialogue row:

```
dialogue    "_ColosseumHeightText"    "{RAM:wNameBuffer} is over\n6’8” tall!"
```

`”` is U+201D (RIGHT DOUBLE QUOTATION MARK), encoded in UTF-8 as `E2 80 9D`.
The trailing byte `0x9D` has no defined character in Windows-1252 (the five
undefined cp1252 byte values are `0x81`, `0x8D`, `0x8F`, `0x90`, `0x9D`), so
decoding as cp1252 fails outright on that byte.

Verified directly against the real Yellow-imported dataset (real ROM data,
current `dev` HEAD): the Red/Blue-only dump (275,609 bytes) contains zero
occurrences of any of the five undefined cp1252 bytes; the Yellow dump
(287,796 bytes) contains exactly one, at the `_ColosseumHeightText` row
above. That's why this specific crash is easy to hit when scaffolding a
Yellow-aware translation on Windows and doesn't show up on the Red/Blue-only
path.

## Fix

Pass `encoding="utf-8"` explicitly at the three `subprocess.run(...,
capture_output=True, text=True)` call sites (`run_loader`,
`check_data_dump`, `dump_dataset`). UTF-8 is the encoding these dumps are
actually produced in — `run_loader` and `dump_dataset` write their driver
Lua source to a tempfile with `encoding="utf-8"` (matching how this file
reads other Lua sources), and LuaJIT writes the byte sequences from those
source strings back out verbatim. This isn't a behavior change on any
platform where the default codepage already happens to be UTF-8
(Linux/macOS today); it only changes what happens on Windows, from
"silently corrupt/opaque crash" to "correct decode."

All three call sites get the same explicit encoding for consistency,
though only `run_loader` and `dump_dataset` can actually hit this crash
today with real content: `dump_dataset` dumps game/engine text directly,
and `run_loader`'s failure path echoes up to 400 chars of raw driver
stderr/stdout (`"loader driver crashed: " + (proc.stderr or
proc.stdout).strip()[-400:]`), which can include quoted mod content.
`check_data_dump`'s inline `-e` driver only ever prints one of three fixed
ASCII words (`SKIP`/`DUMP`/`OK`), so it can't reproduce this specific crash
with today's driver script — fixed anyway in case that driver ever grows
more diagnostic output.

### Why not `errors="replace"`

`errors="replace"` would silently substitute undecodable bytes with `�`
instead of raising, closing the whole class of decode-error crashes
regardless of cause. I didn't take that route: these three call sites feed
the translation scaffold and the mod-validation output, so their whole job
is surfacing problems accurately. If this project's own data ever produced
genuinely malformed output (not just UTF-8-that-isn't-cp1252, but actually
invalid UTF-8), I'd rather that still crash loudly than get silently
replaced with `�` in a generated translation catalog or a validation
report. `encoding="utf-8"` targets the specific, verified cause;
`errors="replace"` would paper over a broader class of problems this PR
hasn't found any evidence of.

## Verification

- Re-ran `dump_dataset()` (patched) directly against the real Yellow
  "imported" dataset (real ROM import, current `dev` HEAD): succeeds,
  3528 rows, including the `_ColosseumHeightText` row with `”` decoded
  correctly.
- `python3 -m py_compile tools/modkit.py` passes.
- No explicit encoding is overridden elsewhere by this change; the file's
  other two `subprocess.run` calls (`cmd_bounce`, `cmd_docs`) don't use
  `capture_output` at all, so they aren't affected.

Happy to add a regression test if there's a preferred place/pattern for
Python-level tests of `tools/modkit.py` in this repo — I didn't see one
alongside the Lua test suite under `tests/modkit/` and didn't want to
invent a new test layout unprompted.
