### PR TITLE
Mod API: expose battle UI visibility hooks

### DIFF
--- a/docs/modding.md
+++ b/docs/modding.md
@@ -290,5 +290,12 @@ update and input ownership, so a mod can mirror a native menu on another
 display without reimplementing it. The default is `true`. Treat the wrapper as
 a pure predicate: the renderer may ask it more than once per frame.
 
+`battle.bottom_ui_visible` and `battle.status_hud_visible` independently
+control the battle text/menu layer and the HP/status panels. Both receive
+`(next, state)` and default to `true`, so vanilla rendering is unchanged.
+Pushed text boxes also pass through `battle.bottom_ui_visible`; a wrapper that
+only owns battle presentation should return `false` only for its active battle
+or text-box state.
+
 Developer mode also arms the mod loader's dev tripwire, which flags mods
 that reach outside their permission set.

--- a/src/battle/BattleState.lua
+++ b/src/battle/BattleState.lua
@@ -127,6 +127,18 @@ function BattleState:sgbPalettes()
   return nil
 end
 
+function BattleState:bottomUIVisible()
+  if not Runtime.wantsHook("battle.bottom_ui_visible") then return true end
+  return Runtime.call("battle.bottom_ui_visible", function() return true end,
+                      self) ~= false
+end
+
+function BattleState:statusHUDVisible()
+  if not Runtime.wantsHook("battle.status_hud_visible") then return true end
+  return Runtime.call("battle.status_hud_visible", function() return true end,
+                      self) ~= false
+end
+
 local Rulesets = {
   gen1_faithful = require("src.battle.rulesets.gen1_faithful"),
   modern_clean = require("src.battle.rulesets.modern_clean"),
@@ -5347,7 +5359,7 @@ function BattleState:drawPicsLayer(slide, sx, sy, onlySide, skipMenuClip)
   -- .mimicmenu) wipes rows 7+.  The port draws pics above the menu
   -- layer in the colorized pipeline, so clip them to the visible rows.
   local g = love.graphics
-  local clipY = not skipMenuClip
+  local clipY = not skipMenuClip and self:bottomUIVisible()
                 and (self.phase == "mimicSelect" and 56
                      or self.phase == "moveSelect" and 64)
                 or nil
@@ -5459,6 +5471,7 @@ function BattleState:drawHUDs(slide)
   -- per-pixel tint (grayFill) -- otherwise GREENBAR's red-channel-0 fill
   -- double-applies and the zone shade shader maps the whole bar to black (#229).
   local grayFill = self:colorMode()
+  local showStatus = self:statusHUDVisible()
   local barData = self.data
   local fx = self.fx
   local hudShake = (fx and fx.hudShakeX) or 0
@@ -5468,7 +5481,8 @@ function BattleState:drawHUDs(slide)
   -- DrawEnemyHUDAndHPBar is called from _InitBattleCommon (core.asm:6763)
   -- AFTER PrintBeginningBattleText returns, so "Wild X appeared!" shows the
   -- player's ball row with no enemy HUD beside it (#317)
-  if self.enemy and not self.showEnemyTrainer and not self.enemySendingOut
+  if showStatus and self.enemy and not self.showEnemyTrainer
+     and not self.enemySendingOut
      and not self:growInScale(self.enemy) and slide == 0
      and not self.introBalls and not self.enemy.fainted then
     -- enemy HUD (DrawEnemyHUDAndHPBar): name row 0, <LV>+level (4,1),
@@ -5555,7 +5569,7 @@ function BattleState:drawHUDs(slide)
     self:drawBallRow(self.playerParty or self.game.save.party, 88, 80, 8)
   end
   local hidePlayer = self.safari or self.demo
-  if self.player and not hidePlayer and not self.showPlayerBack
+  if showStatus and self.player and not hidePlayer and not self.showPlayerBack
      and slide == 0 then
     -- player HUD (DrawPlayerHUDAndHPBar): name (10,7), <LV>+level
     -- (14,8), HP bar (10,9), HP numbers row 10, underline row 11 with
@@ -5580,6 +5594,7 @@ function BattleState:drawHUDs(slide)
 end
 
 function BattleState:drawTextArea()
+  if not self:bottomUIVisible() then return end
   Font.drawBox(0, 12, 20, 6)
   love.graphics.setColor(0, 0, 0, 1)
   if self.phase == "messages"

--- a/src/battle/WideBattle.lua
+++ b/src/battle/WideBattle.lua
@@ -128,7 +128,8 @@ local function drawIntroBalls(battle)
 end
 
 local function drawHUDs(battle, slide)
-  if battle.enemy and not battle.showEnemyTrainer
+  local showStatus = battle:statusHUDVisible()
+  if showStatus and battle.enemy and not battle.showEnemyTrainer
       and not battle.enemySendingOut and not battle:growInScale(battle.enemy)
       and slide == 0 and not battle.introBalls and not battle.enemy.fainted then
     drawStatusPanel(battle, battle.enemy, 0, 0, false)
@@ -139,7 +140,7 @@ local function drawHUDs(battle, slide)
   -- item, not a HUD element (DisplayBattleMenu prints wNumSafariBalls inside
   -- the battle menu box, engine/battle/core.asm:2074-2079), so it rides in
   -- drawCommandMenu below like the classic layout's (#540).
-  if not battle.safari and battle.player and not battle.demo
+  if showStatus and not battle.safari and battle.player and not battle.demo
       and not battle.showPlayerBack and slide == 0 then
     drawStatusPanel(battle, battle.player, 184, 56, true)
   end
@@ -255,6 +256,7 @@ local function drawMoveMenu(battle)
 end
 
 local function drawTextArea(battle)
+  if not battle:bottomUIVisible() then return end
   if battle.phase == "messages" and (battle.current or battle.animPlaying) then
     drawMessageBox(battle)
   elseif battle.phase == "menu" then

--- a/src/render/TextBox.lua
+++ b/src/render/TextBox.lua
@@ -7,11 +7,13 @@
 -- the text is exhausted and A is pressed, then calls onDone.
 
 local Font = require("src.render.Font")
+local Runtime = require("src.mods.Runtime")
 local Theme = require("src.ui.Theme")
 local Timing = require("src.core.Timing")
 
 local TextBox = {}
 TextBox.__index = TextBox
+TextBox.isTextBox = true
 
 -- theme-free fallbacks; geometry resolves against Theme.textBox at
 -- construction time, so an unthemed boot stays byte-identical
@@ -344,6 +346,11 @@ function TextBox:update(dt)
 end
 
 function TextBox:draw()
+  if Runtime.wantsHook("battle.bottom_ui_visible")
+      and Runtime.call("battle.bottom_ui_visible", function() return true end,
+                       self) == false then
+    return
+  end
   -- The dialogue box belongs against the bottom of the screen, not floating
   -- in the middle of a zoomed-out letterbox.  Declared per frame; the
   -- renderer blits this region to the screen edge and the rest of the UI

--- a/tests/engine/wide_battle_shake_bug562.lua
+++ b/tests/engine/wide_battle_shake_bug562.lua
@@ -74,6 +74,9 @@ local function battleWith(fx, sprites)
     growInScale = function() return nil end,
     drawBallRow = function() end,
     statusLabel = function() return "" end,
+    statusHUDVisible = function() return true end,
+    bottomUIVisible = function() return true end,
+    caughtMarkerVisible = function() return false end,
   }
 end
 

--- a/tests/mod_qol_hooks_tests.lua
+++ b/tests/mod_qol_hooks_tests.lua
@@ -11,6 +11,7 @@ local Stats = require("src.pokemon.Stats")
 local Zoom = require("src.render.Zoom")
 local ListMenu = require("src.ui.ListMenu")
 local NamingScreen = require("src.ui.NamingScreen")
+local TextBox = require("src.render.TextBox")
 local Player = require("src.world.Player")
 local Music = require("src.core.Music")
 
@@ -159,6 +160,36 @@ do
   Runtime.call("battle.overlay", function() end, { kind = "wild" })
   check(drew, "battle.overlay runs after the vanilla no-op")
   unsub()
+end
+
+-- ------- battle UI visibility (companion / alternate renderers)
+
+do
+  local BattleState = require("src.battle.BattleState")
+  check(BattleState.bottomUIVisible({ phase = "menu" }),
+    "battle bottom UI is visible without a mod")
+  local seen
+  local unsub = wrap("battle.bottom_ui_visible", function(_, state)
+    seen = state
+    return false
+  end)
+  check(not BattleState.bottomUIVisible({ phase = "messages" }),
+    "a mod can hide the battle text and menu layer")
+  local text = setmetatable({}, TextBox)
+  text:draw()
+  check(seen == text, "pushed text boxes use the same visibility hook")
+  unsub()
+  check(BattleState.bottomUIVisible({ phase = "moveSelect" }),
+    "battle bottom UI returns when the hook is removed")
+
+  check(BattleState.statusHUDVisible({}),
+    "battle status HUD is visible without a mod")
+  unsub = wrap("battle.status_hud_visible", function() return false end)
+  check(not BattleState.statusHUDVisible({}),
+    "a mod can hide the battle status HUD")
+  unsub()
+  check(BattleState.statusHUDVisible({}),
+    "battle status HUD returns when the hook is removed")
 end
 
 -- ------- music.volume (distance / indoor muffling)


### PR DESCRIPTION
## Summary
- add opt-in predicates for the battle text/menu layer and the HP/status HUD
- apply them to classic and wide battle layouts; pushed text boxes share the bottom-layer hook
- document the hooks and keep both vanilla defaults enabled

## Why
Companion and alternate renderers can move duplicated battle layers without replacing battle state or input. The two controls stay independent so a mod can relocate the command layer while keeping the status HUD, or vice versa.

## Tests
- `luajit tests/engine/wide_battle_layout.lua`
- `luajit tests/engine/wide_battle_shake_bug562.lua`
- `luajit tests/engine/battle_fit_option.lua`
- `luajit tests/engine/battle_fixed_menu_scale.lua`
- `luajit tests/engine/render_compose_seam.lua`
- `luajit tests/mod_qol_hooks_tests.lua`
- `luajit tests/run_modkit.lua`