### PR TITLE
Fix custom TTF rendering on Android

### DIFF
--- a/src/render/Font.lua
+++ b/src/render/Font.lua
@@ -137,8 +137,10 @@ function Font.load(data)
   -- typo'd path degrades exactly like a missing page image does above.
   if type(def.ttf) == "table" then
     local file = def.ttf.file or Font.PLAINPIXEL
-    local ok, obj = pcall(love.graphics.newFont, file,
-                          def.ttf.size or Font.PLAINPIXEL_SIZE, "mono")
+    local size = def.ttf.size or Font.PLAINPIXEL_SIZE
+    -- The game renders into a pixel-exact canvas, so keep the TTF rasterizer
+    -- on that same 1x grid instead of inheriting the window DPI on mobile.
+    local ok, obj = pcall(love.graphics.newFont, file, size, "mono", 1)
     if ok and obj then
       -- nearest keeps the pixel font crisp under the integer UI scale
       if obj.setFilter then pcall(obj.setFilter, obj, "nearest", "nearest") end

--- a/tests/engine/ttf_font_mode.lua
+++ b/tests/engine/ttf_font_mode.lua
@@ -40,6 +40,27 @@ T.eq(Font.advanceOf(0x80), 8, "and the pen stays 8px monospace")
 
 -- ------------------------------------------------- the ttf takes over
 
+-- Font rasterizers must use the same 1x pixel grid as PixelCanvas, rather
+-- than inheriting Android's window density.  Keep this local fake so the
+-- contract is testable without requiring a real LÖVE window.
+do
+  local g, oldNewFont = love.graphics, love.graphics.newFont
+  local args
+  g.newFont = function(...)
+    args = { ... }
+    return oldNewFont(Font.PLAINPIXEL, Font.PLAINPIXEL_SIZE)
+  end
+  local loaded, err = pcall(Font.load, {
+    font = { charmap = CHARMAP, ttf = { file = "custom.ttf", size = 13 } },
+  })
+  g.newFont = oldNewFont
+  if not loaded then error(err, 0) end
+  T.eq(args[1], "custom.ttf", "rasterizer uses the configured file")
+  T.eq(args[2], 13, "rasterizer uses the configured size")
+  T.eq(args[3], "mono", "rasterizer keeps the pixel hinting mode")
+  T.eq(args[4], 1, "rasterizer stays on the pixel canvas scale")
+end
+
 Font.load({ font = { charmap = CHARMAP, ttf = {} } })
 T.check(Font.ttfActive(), "an empty ttf table loads the bundled font")
 


### PR DESCRIPTION
## Summary

- Rasterize in-game custom TTF fonts at an explicit 1x DPI scale.
- Preserve the existing load-failure fallback to ROM tiles.
- Add regression coverage for the custom-TTF rasterizer DPI contract.

## Problem

Custom pixel TTF fonts supplied by mods rendered correctly on Windows but
appeared fragmented on Android. ROM tile glyphs remained sharp, while strokes
from the TTF could be dropped, doubled, or interrupted.

The in-game renderer draws into a pixel-exact canvas created with
`dpiscale = 1`. However, TTF fonts were created without an explicit DPI scale,
so LÖVE used the Android window density when rasterizing them. The resulting
high-density glyph texture was sampled back into the lower-resolution 1x game
canvas, which distorted one-pixel strokes.

## Solution

Create the graphics font with an explicit `dpiscale = 1`:

```lua
local ok, font = pcall(
  love.graphics.newFont,
  file,
  size,
  "mono",
  1
)
```

If font construction fails, the engine retains its existing warning and
falls back to ROM tile glyphs.

This change is limited to the optional TTF path used by the pixel-exact in-game
text renderer. Screen-space and launcher fonts retain their normal HiDPI
behavior.

## Validation

- `luajit tests/engine/ttf_font_mode.lua` — 50/50 checks passed.
- `luajit tests/run_engine.lua` — 139/139 suites passed.
- `git diff --check` — clean.
- Android debug APK built successfully for all configured ABIs, including
  `x86_64`.
- Verified with a translation mod on an Android emulator:
  custom TTF glyphs render cleanly after the change.

## Risk

Low. The explicit 1x rasterizer matches the DPI scale of the game's pixel
canvas and only affects its optional TTF path. Existing load failures continue
to degrade gracefully to ROM tile glyphs.

## Screenshots

Screenshots made using Android Studio, with the unfixed and the fixed apk.

<img width="1150" height="198" alt="pr1-text" src="https://github.com/user-attachments/assets/14a65277-ad64-4207-ad1e-55c02f7ec89c" />

<img width="1150" height="197" alt="pr2-text" src="https://github.com/user-attachments/assets/cbbd359d-3814-488c-a334-25f0fd14ba5e" />


