### PR TITLE
Mod API: allow alternate battle grids to own navigation

### DIFF
--- a/src/battle/BattleState.lua
+++ b/src/battle/BattleState.lua
@@ -145,6 +145,13 @@ function BattleState:statusHUDVisible()
                       self) ~= false
 end
 
+function BattleState:moveGridNavigation()
+  if self:wideLayout() then return true end
+  if not Runtime.wantsHook("battle.move_grid_navigation") then return false end
+  return Runtime.call("battle.move_grid_navigation", function() return false end,
+                      self) == true
+end
+
 local Rulesets = {
   gen1_faithful = require("src.battle.rulesets.gen1_faithful"),
   modern_clean = require("src.battle.rulesets.modern_clean"),
@@ -1994,7 +2001,7 @@ function BattleState:update(dt)
     -- The widescreen layout lays the four slots out as a 2x2 grid, so all
     -- four directions navigate it; nil means no direction was pressed and
     -- A / B / SELECT below behave the same in either layout.
-    local grid = self:wideLayout()
+    local grid = self:moveGridNavigation()
                  and WideBattle.navigate(self.moveIndex, #moves, input)
     if grid then
       self.moveIndex = grid
@@ -2044,7 +2051,7 @@ function BattleState:update(dt)
     local moves = self.mimicMoves
     -- the copy menu shares the widescreen move grid, so it navigates the
     -- same way there (the classic layout keeps the vertical list)
-    local grid = self:wideLayout()
+    local grid = self:moveGridNavigation()
                  and WideBattle.navigate(self.mimicIndex, #moves, input)
     if grid then
       self.mimicIndex = grid

--- a/src/ui/PartyMenu.lua
+++ b/src/ui/PartyMenu.lua
@@ -107,6 +107,23 @@ PartyMenu.iconFrames = {
   PIKACHU   = { rest = 0, alt = 3 }, -- Yellow: PikachuSprite tile 0 <-> 12
 }
 
+local function gridIndex(index, count, direction)
+  if count < 1 then return nil end
+  local row, col = math.floor((index - 1) / 2), (index - 1) % 2
+  if direction == "left" or direction == "right" then
+    local other = row * 2 + (1 - col) + 1
+    return other <= count and other or index
+  end
+  local step = direction == "up" and -1 or direction == "down" and 1
+  if not step then return nil end
+  local rows = math.ceil(count / 2)
+  for offset = 1, rows do
+    local other = ((row + step * offset) % rows) * 2 + col + 1
+    if other <= count then return other end
+  end
+  return index
+end
+
 -- Which 16x16 frame of `name`'s sheet to draw; `ih` (sheet pixel
 -- height) only matters for the fallback, which keeps the old uniform
 -- behavior for icons outside the table (BALL/HELIX y-bob instead).
@@ -305,6 +322,13 @@ end
 -- underneath. #252
 function PartyMenu:close()
   if self.game.stack:top() == self then self.game.stack:pop() end
+end
+
+function PartyMenu:gridNavigation()
+  if not self.battle
+      or not Runtime.wantsHook("ui.party.grid_navigation") then return false end
+  return Runtime.call("ui.party.grid_navigation", function() return false end,
+                      self) == true
 end
 
 function PartyMenu:update(dt)
@@ -531,7 +555,18 @@ function PartyMenu:update(dt)
     return
   end
 
-  if input:wasPressed("up") then
+  local grid
+  if self:gridNavigation() then
+    local direction = input:wasPressed("left") and "left"
+      or input:wasPressed("right") and "right"
+      or input:wasPressed("up") and "up"
+      or input:wasPressed("down") and "down"
+    grid = gridIndex(self.index, #party, direction)
+  end
+  if grid then
+    self.index = grid
+    self.game.partyMenuSavedIndex = self.index
+  elseif input:wasPressed("up") then
     self.index = self.index > 1 and self.index - 1 or math.max(1, #party)
     self.game.partyMenuSavedIndex = self.index -- HandlePartyMenuInput #768
   elseif input:wasPressed("down") then

--- a/tests/mod_qol_hooks_tests.lua
+++ b/tests/mod_qol_hooks_tests.lua
@@ -12,6 +12,7 @@ local Zoom = require("src.render.Zoom")
 local ListMenu = require("src.ui.ListMenu")
 local NamingScreen = require("src.ui.NamingScreen")
 local TextBox = require("src.render.TextBox")
+local PartyMenu = require("src.ui.PartyMenu")
 local Player = require("src.world.Player")
 local Music = require("src.core.Music")
 
@@ -190,6 +191,41 @@ do
   unsub()
   check(BattleState.statusHUDVisible({}),
     "battle status HUD returns when the hook is removed")
+end
+
+-- ------- grid navigation ownership (alternate menu renderers)
+
+do
+  local BattleState = require("src.battle.BattleState")
+  local battle = { wideLayout = function() return false end }
+  check(not BattleState.moveGridNavigation(battle),
+    "classic move navigation stays a list without a mod")
+  local unsub = wrap("battle.move_grid_navigation", function() return true end)
+  check(BattleState.moveGridNavigation(battle),
+    "a mod can opt the classic move menu into grid navigation")
+  unsub()
+  battle.wideLayout = function() return true end
+  check(BattleState.moveGridNavigation(battle),
+    "the native wide move grid remains enabled without a mod")
+
+  local game = {
+    save = { party = { {}, {}, {}, {}, {}, {} } },
+    input = { wasPressed = function(_, key) return key == "down" end },
+  }
+  local field = PartyMenu.new(game)
+  unsub = wrap("ui.party.grid_navigation", function() return true end)
+  field:update(0)
+  check(field.index == 2,
+    "field party navigation remains a native list when the hook is active")
+  game.partyMenuSavedIndex = nil
+  local menu = PartyMenu.new(game, { battle = {} })
+  menu:update(0)
+  check(menu.index == 3 and game.partyMenuSavedIndex == 3,
+    "a battle party can follow and remember a companion grid")
+  unsub()
+  menu:update(0)
+  check(menu.index == 4,
+    "removing the hook restores native list navigation immediately")
 end
 
 -- ------- music.volume (distance / indoor muffling)


### PR DESCRIPTION
## Summary

- add an opt-in `battle.move_grid_navigation` hook for move and Mimic selectors
- add an opt-in `ui.party.grid_navigation` hook for battle party selectors
- keep the selected party slot persisted when an alternate grid owns navigation

## Why

Alternate and companion-screen renderers can present these choices as two-column grids while the native screen still owns controller input. Without a matching navigation contract, the visible focus and the engine selection can disagree. These hooks let the renderer opt the native selector into the layout it is actually showing.

## Compatibility

This is additive and fail-closed:

- both hooks default to `false`
- with no subscriber, classic move and party menus use their existing vertical-list paths
- the party hook is ignored outside battles, even if a mod subscribes globally
- the existing wide battle layout keeps its native grid navigation without requiring a hook
- removing a hook restores native list navigation immediately
- no save, content, rendering, or existing hook contract changes

## Tests

- `luajit tests/mod_qol_hooks_tests.lua` — 54/54
- `luajit tests/engine/wide_battle_layout.lua` — 22/22
- `luajit tests/engine/party_fieldmove_order_bug792.lua` — 6/6
- `luajit tests/engine/gate_hooks.lua` — 395/395
- `luajit tests/engine/gate_meta_coverage.lua` — 185/185
- `luajit tests/run_modkit.lua` — 9/9 suites