### PR TITLE
Handle non-JSON update responses

### DIFF
--- a/src/update/Check.lua
+++ b/src/update/Check.lua
@@ -52,8 +52,13 @@ end
 -- falls back to require.
 function Check.parseRelease(jsonText, Json)
   Json = Json or require("src.link.Json")
-  local doc = Json.decode(jsonText)
-  if type(doc) ~= "table" or not doc.tag_name then
+  local notJson = Json.describeUnexpected(jsonText)
+  if notJson then return nil, notJson end
+  local doc, decodeErr = Json.decode(jsonText)
+  if type(doc) ~= "table" then
+    return nil, decodeErr or "no tag_name in release json"
+  end
+  if not doc.tag_name then
     return nil, "no tag_name in release json"
   end
   local version = stripV(doc.tag_name)

--- a/tests/engine/update_check_tests.lua
+++ b/tests/engine/update_check_tests.lua
@@ -47,6 +47,20 @@ eq(bad, nil, "non-X.Y.Z tag rejected")
 check(badErr ~= nil, "rejection carries an error string")
 eq(Check.parseRelease(Json.encode({ foo = 1 })), nil, "missing tag_name rejected")
 
+-- Network failures can return a plain-text or HTML body instead of JSON. The
+-- launcher must describe that response rather than leaking the decoder's
+-- low-level "unexpected character 'E'" assertion.
+do
+  local release, err = Check.parseRelease("Error: API rate limit exceeded")
+  check(release == nil and tostring(err):find("not JSON", 1, true) ~= nil,
+    "plain-text update failure is reported as non-JSON")
+  release, err = Check.parseRelease("<!DOCTYPE html><html>502 Bad Gateway</html>")
+  check(release == nil and tostring(err):find("HTML", 1, true) ~= nil,
+    "HTML update failure is identified")
+  check(tostring(err):find("unexpected character", 1, true) == nil,
+    "decoder assertion is not exposed")
+end
+
 -- parseSums: shasum -a 256 format, tolerating the '*' binary marker, a './'
 -- prefix and CRLF line endings; unrelated lines are skipped
 local sums =


### PR DESCRIPTION
## Summary\n- classify plain-text and HTML self-update responses before JSON decoding\n- preserve existing release metadata and semver validation\n- add regression coverage for gateway/API error responses\n\n## Tests\n- luajit tests/engine/update_check_tests.lua\n- luajit tests/engine/mod_index_tests.lua\n- luajit tests/engine/mod_update_tests.lua\n- luajit tests/engine/launcher_mods_tests.lua\n- luajit tests/drivers/mod_index_bug597_test.lua\n- git diff --check