### PR TITLE
tests: return checkout-relative paths from luaFilesUnder on Windows

### DIFF
--- a/tests/fs_io.lua
+++ b/tests/fs_io.lua
@@ -45,7 +45,29 @@ function FsIo.listDir(path)
   return items
 end
 
--- every *.lua under dir, recursively, as forward-slash paths
+-- `dir /b /s` answers with ABSOLUTE paths where `find <dir>` answers with
+-- checkout-relative ones, so the two hosts handed callers different strings.
+-- Every gate that classifies a site by path substring inherited whatever the
+-- checkout happened to be called: a directory named "gen2-recomp" makes
+-- gate_gen2_mod_api's isGen2Site() true for all 321 src files, so the Gen 1
+-- half of each parity pair reports "no Gen 1 site" and 194 checks fail on a
+-- tree that is fine. Strip the root back off so Windows matches POSIX.
+local windowsRoot
+local function stripRoot(path)
+  if windowsRoot == nil then
+    -- cmd's bare `cd` prints the working directory
+    windowsRoot = (shellLines("cd")[1] or ""):gsub("\\", "/"):gsub("/+$", "")
+  end
+  if windowsRoot == "" then return path end
+  local prefix = windowsRoot .. "/"
+  -- Windows paths are case-insensitive; `cd` and `dir` can disagree on case
+  if path:sub(1, #prefix):lower() == prefix:lower() then
+    return path:sub(#prefix + 1)
+  end
+  return path
+end
+
+-- every *.lua under dir, recursively, as checkout-relative forward-slash paths
 function FsIo.luaFilesUnder(dir)
   local cmd
   if FsIo.isWindows then
@@ -58,7 +80,9 @@ function FsIo.luaFilesUnder(dir)
   end
   local files = {}
   for _, line in ipairs(shellLines(cmd)) do
-    files[#files + 1] = (line:gsub("\\", "/"))
+    local path = (line:gsub("\\", "/"))
+    if FsIo.isWindows then path = stripRoot(path) end
+    files[#files + 1] = path
   end
   table.sort(files)
   return files


### PR DESCRIPTION
## The bug

`FsIo.luaFilesUnder` shells out to two different commands and they answer in two different shapes:

- POSIX: `find <dir> -name '*.lua'` → **checkout-relative** paths (`src/core/Game.lua`)
- Windows: `dir /b /s "<dir>\*.lua"` → **absolute** paths (`C:/some/path/src/core/Game.lua`)

Callers get different strings depending on host. `tests/modkit/catalog.lua` feeds those paths straight into the parity gates, and `tests/engine/gate_gen2_mod_api.lua` classifies a call site by testing the path for a substring:

```lua
local function isGen2Site(path)
  return path:match("gen2") ~= nil or path:match("Gen2") ~= nil
    or path:match("Game2") ~= nil
end
```

With an absolute path, that test picks up whatever the checkout is named. A directory containing `gen2` anywhere in its path makes `isGen2Site()` true for **every** file under `src/`, so `assertShared` counts `gen1 == 0` for every pair and each one fails with *"the event X is shared, not a Gen 2 invention (no Gen 1 site)"*.

## Reproducing

Clone into a directory whose path contains `gen2` (mine was `gen2-recomp`, working on a Gen 2 fork) and run on Windows:

```
luajit tests/run_engine.lua
```

```
> 746/940 checks passed, 194 FAILURES  (gate_gen2_mod_api)
engine: 148/154 suites passed
```

All 194 are the same assertion. The tree is fine — only the classification is wrong. Confirmed directly:

```lua
local F = require("tests.fs_io")
local f = F.luaFilesUnder("src")
-- before: 321 of 321 paths match "gen2"
-- after:  121 of 321   (the actual Gen 2 files)
```

## The fix

Strip the working-directory prefix off the Windows listing so both hosts return the same shape. `cmd`'s bare `cd` prints the working directory; the comparison is case-insensitive because `cd` and `dir` don't always agree on case. The root is resolved once and memoized.

No change to the POSIX path.

## Result

`run_engine` 148/154 → 149/154 on Windows; `gate_gen2_mod_api` goes green. No change on Linux/macOS, where the function already returned relative paths.

Worth noting this needs Windows *and* a checkout path containing `gen2` to trigger, which is presumably why it hasn't come up — but the underlying host inconsistency affects any caller of `luaFilesUnder` that cares about path shape, so it seemed better to fix the root cause than to harden `isGen2Site`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)