### PR TITLE
fix(mods): allow checkpoint restore across engine versions

### DIFF
--- a/src/core/Checkpoint.lua
+++ b/src/core/Checkpoint.lua
@@ -313,6 +313,16 @@ local function equalData(a, b)
   return okA and okB and encodedA == encodedB
 end
 
+local function normalizeVerificationMetadata(actual, expected)
+  if type(actual) == "table" and type(actual.identity) == "table"
+      and type(expected) == "table" and type(expected.identity) == "table" then
+    -- RFC 0004 treats engineVersion as compatibility metadata, not runtime
+    -- state. A fresh recapture stamps the running engine, so normalize only
+    -- that metadata before differential verification.
+    actual.identity.engineVersion = expected.identity.engineVersion
+  end
+end
+
 local function firstDifference(a, b, path)
   path = path or "$"
   if type(a) ~= type(b) then return path .. " (type)" end
@@ -394,6 +404,7 @@ function Checkpoint.restore(game, checkpoint)
   if ok then
     local restored, verifyCode = Checkpoint.capture(game)
     if restored and validated.rng == nil then restored.rng = nil end
+    normalizeVerificationMetadata(restored, validated)
     if restored and equalData(restored, validated) then
       emitRestored(game, validated)
       return true
@@ -474,6 +485,7 @@ function Checkpoint.resume(game, checkpoint)
   if ok then
     local restored, verifyCode = Checkpoint.capture(game)
     if restored and validated.rng == nil then restored.rng = nil end
+    normalizeVerificationMetadata(restored, validated)
     if restored and equalData(restored, validated) then
       emitRestored(game, validated)
       return true

--- a/tests/modkit/cases/title_playthrough_context.lua
+++ b/tests/modkit/cases/title_playthrough_context.lua
@@ -207,6 +207,11 @@ if type(storage) == "table" then
   T.check(type(normalBytes) == "string" and normalBytes ~= "",
     "first checkpoint anchor is durably represented before restart")
   local anchoredAt = SaveSerializer.decode(normalBytes).meta.savedAt
+
+  -- Model a durable checkpoint captured by the previous shipped engine.
+  -- RFC 0004 treats engineVersion as compatibility metadata, not runtime state.
+  checkpoint.identity.engineVersion = "0.1.79"
+
   SaveData.resetSlotState()
   local titleRuntime = makeRuntime(SaveData.newGame({ version = "red" }), true)
   titleRuntime.save.options = { volume = 9, bindings = {} }
@@ -224,7 +229,14 @@ if type(storage) == "table" then
       version = "red", meta = { playthroughId = originalId },
     }, fs).savedAt, anchoredAt,
       "title bootstrap never rewrites the first normal save")
-    T.same(checkpoints:capture(titleRuntime), checkpoint,
+    local recaptured = checkpoints:capture(titleRuntime)
+    T.eq(recaptured and recaptured.identity
+        and recaptured.identity.engineVersion, Version.engine,
+      "cross-version resume recaptures the running engine version")
+    if recaptured and recaptured.identity then
+      recaptured.identity.engineVersion = checkpoint.identity.engineVersion
+    end
+    T.same(recaptured, checkpoint,
       "bootstrapped overworld differentially recaptures the selected checkpoint")
     T.eq(_G.MOD_TITLE_RESTORE_COUNT, 1,
       "a successfully verified title resume emits checkpoint.restored exactly once")


### PR DESCRIPTION
## What changed

- normalizes `identity.engineVersion` only on detached post-restore verification captures;
- applies the same rule to live `Checkpoint.restore()` and title-session `Checkpoint.resume()`;
- keeps checkpoint format, game version, playthrough identity, save/content, position, RNG, and battle runtime verification strict;
- extends the public mod-API title-resume regression with a checkpoint carrying older engine-version metadata.

## Why

RFC 0004 already defines `identity.engineVersion` as caller-facing compatibility metadata and explicitly says the engine does not reject patch/minor mismatches on restore.

Validation follows that contract: it requires a valid engine-version string but compares the active runtime against `gameVersion` and `playthroughId`, not against `Version.engine`.

Differential verification did not. After reconstruction, `Checkpoint.capture()` stamps the running `Version.engine`, then `equalData(restored, validated)` compares the complete checkpoint. A checkpoint created by a previous compatible engine can therefore reconstruct correctly and still return `restore_failed` / `resume_failed` solely because its metadata differs from the new recapture.

This change normalizes only that metadata on the detached verification capture before the byte comparison. Fresh captures still record the actual running engine version.

## Compatibility

- No public API, checkpoint format, or serialized field changes.
- Existing checkpoints require no migration.
- Existing mods require no migration.
- `gameVersion` and `playthroughId` remain strictly validated.
- Save/content validation, map/position, RNG, and supported battle runtime remain strictly verified.
- `ensureNormalSave()` remains strict about the supplied checkpoint matching the current live runtime.
- No-mod behavior is unchanged.

This is an implementation fix for the existing RFC 0004 contract rather than a new compatibility-surface decision, so no new RFC or generated schema/reference change is introduced.

## Verification

- extends `tests/modkit/cases/title_playthrough_context.lua` through the public mod API;
- models a durable checkpoint with `engineVersion = "0.1.79"` and verifies title resume succeeds on the running engine;
- verifies a fresh recapture still reports `Version.engine` before normalizing the test copy for full checkpoint equality;
- existing no-mod, checkpoint, battle-checkpoint, and modkit suites remain covered by repository CI.

ROM-derived Tier 3 was not run locally; no imported/generated game data is included in this change.