### PR TITLE
mods/examples: add Encounters Guide as gallery entry #9

### DIFF
--- a/mods/examples/README.md
+++ b/mods/examples/README.md
@@ -1,6 +1,6 @@
 # Example mod gallery
 
-Eight reference mods, one per modder persona. Each is small enough to read
+Nine reference mods, one per modder persona. Each is small enough to read
 in one sitting, exercises a different slice of the mod API, and is a real,
 runnable, tested mod — not a snippet.
 
@@ -17,6 +17,7 @@ Copy the one closest to what you want to build.
 | 6 | [`example_dexnav`](example_dexnav) | Tool builder | `TOOL` | A START-menu dex overlay with an inter-mod API |
 | 7 | [`example_mini_conversion`](example_mini_conversion) | TC team | `TOTAL_CONVERSION` | Sable Cove: one town, three species, one badge |
 | 8 | [`example_silly_oak`](example_silly_oak) | Intro author | `UI` | Extra Oak questions, sprite swaps, answers in `mod.save` |
+| 9 | [`wills_mod`](wills_mod) | QoL toolkit builder | `TOOL` | A map-first encounter guide (PKMN MAP) plus owned-ball battle HUD |
 
 ## None of these load by default
 

--- a/mods/examples/README.md
+++ b/mods/examples/README.md
@@ -17,7 +17,7 @@ Copy the one closest to what you want to build.
 | 6 | [`example_dexnav`](example_dexnav) | Tool builder | `TOOL` | A START-menu dex overlay with an inter-mod API |
 | 7 | [`example_mini_conversion`](example_mini_conversion) | TC team | `TOTAL_CONVERSION` | Sable Cove: one town, three species, one badge |
 | 8 | [`example_silly_oak`](example_silly_oak) | Intro author | `UI` | Extra Oak questions, sprite swaps, answers in `mod.save` |
-| 9 | [`wills_mod`](wills_mod) | QoL toolkit builder | `TOOL` | A map-first encounter guide (PKMN MAP) plus owned-ball battle HUD |
+| 9 | [`wills_mod`](wills_mod) | QoL toolkit builder | `TOOL` | A map-first encounter guide (PKMN MAP) with a walking HUD |
 
 ## None of these load by default
 

--- a/mods/examples/wills_mod/CHANGELOG.md
+++ b/mods/examples/wills_mod/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-08-12
+
+Will's Mod is the single-mod merge of the Encounter Guide and Will's Battle
+HUD: one install, one enable, both catch-'em-all tools.
+
+### Added
+
+- **Encounter Guide** (migrated from gen1recomp-encounter-guide v0.6.0):
+  - START → PKMN MAP opens the imported ROM's own Kanto Town Map; D-pad
+    between encounter-bearing locations, A drills into exact source maps.
+  - Exact source identity: floors, caves, gates, buildings, and Pokémon
+    Centers are never merged (`-- MT. MOON 1F` stays its own entry).
+  - LAND and WATER as separate views; compact level ranges with exact
+    per-step odds on drill-down.
+  - Blinking white player-position marker, even where a location has no
+    encounters.
+  - Walking HUD (render.hud): per-area species + level ranges, top-right;
+    modes AUTO / ALWAYS / OFF (options menu or H key) and sizes
+    SMALL / MEDIUM / LARGE (options menu); visible under render-pipeline
+    mods (voxel).
+  - Owned-ball Pokédex markers in species lists and on the walking HUD.
+  - SELECT opens the complete list, catching unmapped sources.
+- **Will's Battle HUD** (migrated from wills_battle_hud v0.1.5):
+  - Pokédex owned-ball markers below-left of battler names in battle,
+    fixed per layout/side (classic and wide), independent of name length;
+    hidden while the enemy is sending out and in safari/demo/back views.
+
+### Changed
+
+- Both features now live in one mod (id `wills_mod`) with one manifest,
+  one `github` update channel, and one enable toggle.
+- Options row keys and save keys are unchanged from the Encounter Guide
+  (`encounterGuideHud`, `encounterGuideSize`), so existing saves keep
+  their settings.
+
+### Removed
+
+- Standalone mods `encounter_guide` and `wills_battle_hud` are superseded.

--- a/mods/examples/wills_mod/CHANGELOG.md
+++ b/mods/examples/wills_mod/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-08-13
+
+### Removed
+
+- The battle HUD owned-ball marker feature (Pokédex ball beside battler
+  names) is gone — other mods already cover it, and the encounter guide is
+  the unique part. Walking-HUD owned markers in species lists stay.
+
+### Changed
+
+- Display name is now **Encounters Guide** (mod id, repo, and update channel
+  unchanged).
+
 ## [1.0.0] - 2026-08-12
 
 Will's Mod is the single-mod merge of the Encounter Guide and Will's Battle

--- a/mods/examples/wills_mod/README.md
+++ b/mods/examples/wills_mod/README.md
@@ -1,0 +1,66 @@
+# Will's Mod
+
+A catch-'em-all toolkit for Gen1Recomp: a map-first wild-encounter guide
+(START → PKMN MAP) plus a battle HUD that marks Pokémon you have already
+caught, all read-only.
+
+**Persona: the QoL Toolkit Builder.** Two read-only overlays and a screen
+family over public APIs only — no permissions, no ROM-derived bytes, and a
+single bundled `main.lua` built by `tools/bundle.py` from the readable
+source at [github.com/illanrego/wills-mod](https://github.com/illanrego/wills-mod).
+
+## Try it
+
+```sh
+python3 tools/modkit.py validate mods/examples/wills_mod --base imported
+luajit mods/examples/wills_mod/tests/wills_mod_test.lua
+```
+
+Copy the entry up to `mods/` and enable it (`wills_mod = true` under `mods`
+in `options.lua`, or the F10 manager). Then:
+
+1. Press **START → PKMN MAP** — browse Kanto from the imported ROM's Town
+   Map and inspect encounter-bearing locations.
+2. Stand on tall grass — the **walking HUD** lists the area's LAND and
+   WATER species with level ranges (modes AUTO / ALWAYS / OFF, sizes
+   SMALL / MEDIUM / LARGE in the options menu or via the **H** key).
+3. Enter a battle — a **Pokédex ball** appears beside each battler whose
+   species is already registered in your Pokédex, in classic and wide
+   battle layouts.
+
+## What it demonstrates
+
+| Seam | Where |
+|---|---|
+| `content.screens:register` | `main.lua` — a six-screen family (map → areas → area → source → method → species) |
+| `hooks:wrap("ui.start_menu.items")` | `main.lua` — anchor a PKMN MAP row before SAVE |
+| `hooks:wrap("render.hud")` | `main.lua` — a walking overlay in the HUD's own space |
+| `hooks:wrap("battle.overlay")` | `main.lua` — draw in battle-canvas coordinates, both layouts |
+| `hooks:wrap("ui.options.rows")` | `main.lua` — ENC. GUIDE HUD and ENC. GUIDE SIZE rows |
+| `mod.ui.insertBefore` / `mod.ui.push` / `mod.ui.ListMenu` | `main.lua` — public UI helpers only |
+
+## Reading, not reaching
+
+Every fact this mod displays comes from public sources: `game.data`
+(the merged view, including encounter tables the engine derived from the
+player's own import), `game.save.pokedex` (the seen/owned tables), and
+`game.save.options`. No `require("src.…")`, no permission declared — the
+overlays read, they never write.
+
+The entry ships as the bundled release build (`main.lua`), exactly the
+artifact the distributed zip carries; `lib/*.lua` and `tools/bundle.py`
+live in the source repo.
+
+## Known
+
+- v1.0.0 covers walking and Surf encounter tables only; fishing, static,
+  gift, trade, and prize Pokémon are not represented.
+- The guide reads data when opened; reopen it after enabling a mod that
+  changes encounter tables.
+- The battle HUD draws at final positions, so during the send-out slide
+  the ball sits at its rest spot.
+
+## Credits
+
+- Gen1Recomp project — the public mod and UI APIs.
+- pret/pokered — the original game data extraction reference.

--- a/mods/examples/wills_mod/README.md
+++ b/mods/examples/wills_mod/README.md
@@ -1,4 +1,4 @@
-# Will's Mod
+# Encounters Guide
 
 A catch-'em-all toolkit for Gen1Recomp: a map-first wild-encounter guide
 (START → PKMN MAP) plus a battle HUD that marks Pokémon you have already

--- a/mods/examples/wills_mod/README.md
+++ b/mods/examples/wills_mod/README.md
@@ -1,66 +1,144 @@
-# Encounters Guide
+# 🗺️ Encounters Guide
 
-A catch-'em-all toolkit for Gen1Recomp: a map-first wild-encounter guide
-(START → PKMN MAP) plus a battle HUD that marks Pokémon you have already
-caught, all read-only.
+**A map-first wild-encounter guide for Gen1Recomp.**
 
-**Persona: the QoL Toolkit Builder.** Two read-only overlays and a screen
-family over public APIs only — no permissions, no ROM-derived bytes, and a
-single bundled `main.lua` built by `tools/bundle.py` from the readable
-source at [github.com/illanrego/wills-mod](https://github.com/illanrego/wills-mod).
+One read-only mod — know where to find every wild Pokémon, straight from your imported ROM:
 
-## Try it
+- **Encounter Guide** — walk the real Kanto Town Map, hop between encounter-bearing locations, and drill down to exact routes, floors, and buildings, with truthful level ranges and per-step odds derived from *your* imported ROM.
 
-```sh
-python3 tools/modkit.py validate mods/examples/wills_mod --base imported
-luajit mods/examples/wills_mod/tests/wills_mod_test.lua
+![API 2](https://img.shields.io/badge/mod%20API-2-8b5cf6) ![Profile: Content](https://img.shields.io/badge/profile-content-10b981) ![Read-only](https://img.shields.io/badge/read--only-✓-f59e0b) ![Tests](https://img.shields.io/badge/tests-10%20files%20passing-22c55e) ![Platform](https://img.shields.io/badge/platform-desktop%20%2B%20Android-3b82f6)
+
+---
+
+## Screenshots
+
+| PKMN MAP (Kanto) | Walking HUD | Encounter List |
+|---|---|---|
+| ![PKMN MAP](.github/resources/screenshot-map.png) | ![Walking HUD](.github/resources/screenshot-walking-hud.png) | ![Encounter List](.github/resources/screenshot-encounter-list.png) |
+
+## Features
+
+### 🗺️ Encounter Guide
+
+- **The real Kanto map** — artwork and coordinates come from your locally imported ROM. Nothing is bundled or redrawn.
+- **Map-first navigation** — only locations with wild encounters are selectable; the cursor snaps between them.
+- **Exact source identity** — floors, caves, gates, buildings, and Pokémon Centers are never blended. `-- MT. MOON 1F` stays honest about being an interior.
+- **You are here** — a blinking white marker shows your current location on Kanto, even where that spot has no wild encounters.
+- **Walking HUD** — while exploring, a top-right panel lists the current area's LAND and WATER species with their exact level ranges; it hides itself in menus and battles.
+- **HUD modes** — AUTO (only while standing on grass or water, showing just that table), ALWAYS, or OFF, from the Options menu or the **H** key.
+- **HUD sizes** — SMALL, MEDIUM, or LARGE from the Options menu (ENC. GUIDE SIZE).
+- **Owned markers** — caught Pokémon carry the Pokédex ball, on the walking HUD and in every species list.
+- **LAND and WATER as separate views** — no deceptive merged tables.
+- **Compact level ranges, full odds on demand** — `ZUBAT Lv. 8-10` up top, then every exact level with its chance per movement step.
+- **SELECT opens the complete list** — catches every encounter source, including any that lack Town Map coordinates.
+- **Pure ROM-derived data** — works with Red, Blue, or Yellow; zero hard-coded species tables; no copyrighted content shipped.
+
+## Install
+
+1. Open **MODS** in Gen1Recomp (`F10` on desktop).
+2. **Import mod .zip** and select `wills_mod-1.0.1.zip`.
+3. Enable **Encounters Guide**.
+
+Works on desktop and Android. Requires an imported Pokémon Red, Blue, or Yellow ROM.
+
+> 💡 Mods are loaded from the installed copy. After editing source, rebuild (`python3 tools/bundle.py`), repack, and re-import — tests alone don't update a running game.
+
+## Usage
+
+### Encounter Guide
+
+| Input | Action |
+|-------|--------|
+| **D-pad** | Move between encounter-bearing locations on Kanto |
+| **A** | Open the selected location's exact source maps |
+| **A** (in lists) | Drill down: source → LAND/WATER → species → levels |
+| **SELECT** | Jump to the complete location list (incl. unmapped sources) |
+| **B** | Back one level |
+| **H** | Cycle the walking HUD: AUTO → ALWAYS → OFF |
+
+```text
+START → PKMN MAP
+  → KANTO MAP                (D-pad, A to select)
+    → MT. MOON               (grouped Town Map marker)
+      → -- MT. MOON 1F       (exact source, always separate)
+        → LAND · WATER       (never merged)
+          → ZUBAT  Lv. 8-10  (truthful compact range)
+            → Lv. 8  · 1.95% (exact per-step odds)
 ```
 
-Copy the entry up to `mods/` and enable it (`wills_mod = true` under `mods`
-in `options.lua`, or the F10 manager). Then:
+## How it works
 
-1. Press **START → PKMN MAP** — browse Kanto from the imported ROM's Town
-   Map and inspect encounter-bearing locations.
-2. Stand on tall grass — the **walking HUD** lists the area's LAND and
-   WATER species with level ranges (modes AUTO / ALWAYS / OFF, sizes
-   SMALL / MEDIUM / LARGE in the options menu or via the **H** key).
-3. Enter a battle — a **Pokédex ball** appears beside each battler whose
-   species is already registered in your Pokédex, in classic and wide
-   battle layouts.
+```text
+your imported ROM
+      │  (Gen1Recomp extraction)
+      ▼
+generated data  ──►  model.lua          ──►  screens (list + detail)
+(encounters,      │   groups sources,        │
+ field/townMap,   │   never merges maps,     ▼
+ pokemon,         │   sums duplicate slots,  ListMenu UI (A open / B back)
+ constants)       └── calculates odds        MapScreen (D-pad cursor)
+```
 
-## What it demonstrates
+The mod is read-only: it never touches saves, encounter mechanics, or link state.
 
-| Seam | Where |
-|---|---|
-| `content.screens:register` | `main.lua` — a six-screen family (map → areas → area → source → method → species) |
-| `hooks:wrap("ui.start_menu.items")` | `main.lua` — anchor a PKMN MAP row before SAVE |
-| `hooks:wrap("render.hud")` | `main.lua` — a walking overlay in the HUD's own space |
-| `hooks:wrap("battle.overlay")` | `main.lua` — draw in battle-canvas coordinates, both layouts |
-| `hooks:wrap("ui.options.rows")` | `main.lua` — ENC. GUIDE HUD and ENC. GUIDE SIZE rows |
-| `mod.ui.insertBefore` / `mod.ui.push` / `mod.ui.ListMenu` | `main.lua` — public UI helpers only |
+## Project layout
 
-## Reading, not reaching
+```text
+.
+├── main.lua               # self-contained release entry (generated)
+├── lib/
+│   ├── entry.lua          # screen registration + hook wraps          (source of truth)
+│   ├── model.lua          # source grouping, methods, levels, buckets, odds
+│   ├── names.lua          # player-facing map/source labels
+│   ├── screens.lua        # ListMenu-based area/source/method/species screens
+│   ├── map_screen.lua     # Town Map viewer: ROM tiles, cursor, markers, controls
+│   └── hud.lua            # walking HUD: per-area species panel via render.hud
+├── tools/bundle.py        # deterministic bundler: lib/ → main.lua
+├── tests/                 # LÖVE test suite (10 files, fixtures + live Blue cache)
+├── manifest.json          # mod metadata (id: wills_mod, github: illanrego/wills-mod)
+├── mod.card               # launcher-facing description
+└── dist/                  # importable release ZIPs
+```
 
-Every fact this mod displays comes from public sources: `game.data`
-(the merged view, including encounter tables the engine derived from the
-player's own import), `game.save.pokedex` (the seen/owned tables), and
-`game.save.options`. No `require("src.…")`, no permission declared — the
-overlays read, they never write.
+## Development
 
-The entry ships as the bundled release build (`main.lua`), exactly the
-artifact the distributed zip carries; `lib/*.lua` and `tools/bundle.py`
-live in the source repo.
+Requires any LÖVE 11+ runtime (the Gen1Recomp AppImage bundles one) plus the official [`modkit.py`](https://github.com/bryanthaboi/gen1recomp) tooling.
 
-## Known
+```sh
+# run the test suite (fixtures + your imported Blue cache)
+WILLS_MOD_ROOT="$PWD" love tests/runner
 
-- v1.0.0 covers walking and Surf encounter tables only; fishing, static,
-  gift, trade, and prize Pokémon are not represented.
-- The guide reads data when opened; reopen it after enabling a mod that
-  changes encounter tables.
-- The battle HUD draws at final positions, so during the send-out slide
-  the ball sits at its rest spot.
+# regenerate main.lua after editing lib/
+python3 tools/bundle.py
+
+# official mod validation, ROM-content lint, and packaging
+modkit validate --base fixture --strict .
+modkit lint .
+modkit pack -o dist/wills_mod-1.0.1.zip .
+```
+
+Every release gate runs before tagging: **10/10 test files green** → strict loader validation → no-ROM-content lint → clean archive → live in-game smoke test.
+
+## Scope
+
+- **Covered:** walking/LAND and Surf/WATER encounter tables.
+- **Deferred (truthfully labeled later):** fishing, static encounters, gifts, trades, prizes, and Game Corner — each deserves its own honest acquisition method before it appears in the guide.
+
+## Roadmap
+
+- [x] v0.1.0 — Encounter Guide: exact-source area browser, LAND/WATER separation, odds
+- [x] v0.2.0 — map-first Kanto navigation on ROM-generated artwork
+- [x] v0.3.0 — PKMN MAP menu entry + blinking player-position marker
+- [x] v0.4.0 — walking HUD with per-area species and level ranges
+- [x] v0.5.0 — HUD modes (AUTO/ALWAYS/OFF + H key + options menu) and owned-ball markers
+- [x] v0.6.0 — HUD size option (SMALL/MEDIUM/LARGE)
+- [x] v0.1.0–0.1.5 — Battle HUD: owned-ball markers, fixed per-layout geometry
+- [x] v1.0.0 — Encounters Guide: both tools merged into one install
+- [ ] Red/Yellow data pass on real caches
+- [ ] Fishing as its own method
 
 ## Credits
 
-- Gen1Recomp project — the public mod and UI APIs.
-- pret/pokered — the original game data extraction reference.
+- **[Gen1Recomp](https://github.com/bryanthaboi/gen1recomp)** — the decompiled-Gen-1 runtime, public mod API, and UI toolkit this mod is built on.
+- **pret/pokered** — the original disassembly reference behind the data extraction.
+- Built for Illan, who wanted to know what's in the tall grass *before* stepping in it — and which ones he still needs.

--- a/mods/examples/wills_mod/main.lua
+++ b/mods/examples/wills_mod/main.lua
@@ -1,0 +1,866 @@
+-- Generated self-contained release entry: installed mods do not extend Lua package.path.
+
+local Names = {}
+
+local overrides = {
+  MT_MOON = "MT. MOON",
+  DIGLETTS_CAVE = "DIGLETT's CAVE",
+  POKEMON_TOWER = "POKéMON TOWER",
+  POKEMON_MANSION = "POKéMON MANSION",
+  POKEMON_LEAGUE = "POKéMON LEAGUE",
+}
+
+function Names.map(mapId)
+  local base, suffix = mapId:match("^(.-)(_B?%d+F)$")
+  if base then
+    return (overrides[base] or base:gsub("_", " ")) .. suffix:gsub("_", " ")
+  end
+  return overrides[mapId] or mapId:gsub("_", " ")
+end
+
+local Model = {}
+
+local function hasSlots(group)
+  return type(group) == "table"
+    and type(group.slots) == "table"
+    and #group.slots > 0
+    and (group.rate or 0) > 0
+end
+
+local function floorKey(mapId)
+  local floor = mapId:match("_(%d+)F$")
+  if floor then return tonumber(floor) end
+  local basement = mapId:match("_B(%d+)F$")
+  if basement then return 100 + tonumber(basement) end
+  return 50
+end
+
+local function methodsFor(data, definition)
+  local methods = {}
+  if hasSlots(definition.grass) then
+    methods.land = Model.summarizeMethod(definition.grass, data.pokemon,
+      definition.grass.buckets or (data.constants or {}).encounterBuckets)
+  end
+  if hasSlots(definition.water) then
+    methods.water = Model.summarizeMethod(definition.water, data.pokemon,
+      definition.water.buckets or (data.constants or {}).encounterBuckets)
+  end
+  return methods
+end
+
+function Model.mapSummary(data, mapId)
+  if not mapId then return nil end
+  local definition = ((data or {}).encounters or {})[mapId]
+  if not definition then return nil end
+  local methods = methodsFor(data, definition)
+  if not (methods.land or methods.water) then return nil end
+  return methods
+end
+
+function Model.summarizeMethod(method, pokemon, buckets)
+  local rate = method.rate or 0
+  local total = (buckets and buckets[#buckets]) or 256
+  if total <= 0 then total = 256 end
+  local bySpecies, species = {}, {}
+
+  for index, slot in ipairs(method.slots or {}) do
+    local previous = (buckets and buckets[index - 1]) or ((index - 1) * total / #(method.slots or {}))
+    local cumulative = (buckets and buckets[index]) or (index * total / #(method.slots or {}))
+    local conditionalOdds = math.max(0, cumulative - previous) / total
+    local speciesId, level = slot.species, slot.level
+    if speciesId and level then
+      local row = bySpecies[speciesId]
+      if not row then
+        local info = (pokemon or {})[speciesId] or {}
+        row = {
+          speciesId = speciesId,
+          name = info.name or speciesId,
+          minLevel = level,
+          maxLevel = level,
+          levels = {},
+          levelsByValue = {},
+        }
+        bySpecies[speciesId] = row
+        species[#species + 1] = row
+      end
+      row.minLevel = math.min(row.minLevel, level)
+      row.maxLevel = math.max(row.maxLevel, level)
+      local levelRow = row.levelsByValue[level]
+      if not levelRow then
+        levelRow = { level = level, slotCount = 0, conditionalOdds = 0, perStepOdds = 0 }
+        row.levelsByValue[level] = levelRow
+        row.levels[#row.levels + 1] = levelRow
+      end
+      levelRow.slotCount = levelRow.slotCount + 1
+      levelRow.conditionalOdds = levelRow.conditionalOdds + conditionalOdds
+      levelRow.perStepOdds = levelRow.conditionalOdds * rate / 256
+    end
+  end
+
+  for _, row in ipairs(species) do
+    row.levelsByValue = nil
+    table.sort(row.levels, function(a, b) return a.level < b.level end)
+  end
+  table.sort(species, function(a, b)
+    if a.name ~= b.name then return a.name < b.name end
+    return a.speciesId < b.speciesId
+  end)
+  return { rate = rate, species = species }
+end
+
+function Model.buildAreas(data)
+  local areasByKey, areas = {}, {}
+  local encounters = data.encounters or {}
+  local locations = ((data.townMap or {}).locations) or {}
+
+  for mapId, definition in pairs(encounters) do
+    if hasSlots(definition.grass) or hasSlots(definition.water) then
+      local location = locations[mapId]
+      local areaName = location and location.name or "OTHER AREAS"
+      local key = location
+        and table.concat({ location.x or -1, location.y or -1, areaName }, ":")
+        or "OTHER:" .. mapId
+      local area = areasByKey[key]
+      if not area then
+        area = { name = areaName, x = location and location.x, y = location and location.y, sources = {} }
+        areasByKey[key] = area
+        areas[#areas + 1] = area
+      end
+      local methods = methodsFor(data, definition)
+      area.sources[#area.sources + 1] = {
+        mapId = mapId,
+        label = Names.map(mapId),
+        encounters = definition,
+        methods = methods,
+      }
+    end
+  end
+
+  for _, area in ipairs(areas) do
+    table.sort(area.sources, function(a, b)
+      local aFloor, bFloor = floorKey(a.mapId), floorKey(b.mapId)
+      if aFloor ~= bFloor then return aFloor < bFloor end
+      return a.mapId < b.mapId
+    end)
+  end
+  table.sort(areas, function(a, b)
+    if a.y and b.y and a.y ~= b.y then return a.y < b.y end
+    if a.x and b.x and a.x ~= b.x then return a.x < b.x end
+    return a.name < b.name
+  end)
+
+  return areas
+end
+
+local Screens = {}
+
+local function guideData(game)
+  local data = (game and game.data) or {}
+  return {
+    encounters = data.encounters or {},
+    townMap = (data.field or {}).townMap or {},
+    pokemon = data.pokemon or {},
+    constants = data.constants or {},
+  }
+end
+
+local function levelRange(species)
+  if species.minLevel == species.maxLevel then return "Lv. " .. species.minLevel end
+  return "Lv. " .. species.minLevel .. "-" .. species.maxLevel
+end
+
+local function percent(value)
+  return string.format("%.2f%%", (value or 0) * 100)
+end
+
+function Screens.newAreas(mod, game)
+  local areas = Model.buildAreas(guideData(game))
+  local items = {}
+  for _, area in ipairs(areas) do
+    items[#items + 1] = {
+      label = area.name,
+      right = #area.sources .. " MAPS",
+      value = area,
+    }
+  end
+  return mod.ui.ListMenu.new(game, "ENCOUNTERS", items, {
+    pageJump = true,
+    onChoose = function(item)
+      mod.ui.push(game, "EncounterGuideArea", item.value)
+    end,
+  })
+end
+
+function Screens.newArea(mod, game, area)
+  local items = {}
+  for _, source in ipairs((area or {}).sources or {}) do
+    local methods = {}
+    if source.methods.land then methods[#methods + 1] = "LAND" end
+    if source.methods.water then methods[#methods + 1] = "WATER" end
+    items[#items + 1] = {
+      label = "-- " .. source.label,
+      right = table.concat(methods, "/"),
+      value = source,
+    }
+  end
+  return mod.ui.ListMenu.new(game, (area or {}).name or "AREA", items, {
+    pageJump = true,
+    onChoose = function(item)
+      mod.ui.push(game, "EncounterGuideSource", item.value)
+    end,
+  })
+end
+
+function Screens.newSource(mod, game, source)
+  local items = {}
+  for _, row in ipairs({ { key = "land", label = "LAND" }, { key = "water", label = "WATER" } }) do
+    local summary = source and source.methods and source.methods[row.key]
+    if summary then
+      items[#items + 1] = {
+        label = row.label,
+        right = summary.rate .. "/256",
+        value = row.key,
+      }
+    end
+  end
+  return mod.ui.ListMenu.new(game, (source and source.label) or "SOURCE", items, {
+    onChoose = function(item)
+      mod.ui.push(game, "EncounterGuideMethod", source, item.value)
+    end,
+  })
+end
+
+function Screens.newMethod(mod, game, source, methodName)
+  local summary = source and source.methods and source.methods[methodName] or { species = {} }
+  local owned = (((game or {}).save or {}).pokedex or {}).owned or {}
+  local items = {}
+  for _, species in ipairs(summary.species or {}) do
+    items[#items + 1] = {
+      label = species.name,
+      right = levelRange(species),
+      value = species,
+      ball = owned[species.speciesId] == true,
+    }
+  end
+  local title = ((source and source.label) or "SOURCE") .. " " .. (methodName == "water" and "WATER" or "LAND")
+  return mod.ui.ListMenu.new(game, title, items, {
+    pageJump = true,
+    onChoose = function(item)
+      mod.ui.push(game, "EncounterGuideSpecies", source, methodName, item.value)
+    end,
+  })
+end
+
+function Screens.newSpecies(mod, game, source, methodName, species)
+  local items = {}
+  for _, level in ipairs((species or {}).levels or {}) do
+    items[#items + 1] = {
+      label = "Lv. " .. level.level,
+      right = percent(level.perStepOdds),
+      value = level,
+    }
+  end
+  return mod.ui.ListMenu.new(game, (species and species.name) or "POKéMON", items, {
+    footer = ((source and source.label) or "SOURCE") .. " " .. (methodName == "water" and "WATER" or "LAND"),
+  })
+end
+
+local MapScreen = {}
+MapScreen.__index = MapScreen
+MapScreen.isOpaque = true
+
+local function loadBackground(graphics, game)
+  local townMap = (((game or {}).data or {}).field or {}).townMap or {}
+  local definition = townMap.background
+  if not (definition and definition.map and definition.tiles and definition.tiles.path) then return nil end
+
+  local ok, image = pcall(graphics.newImage, definition.tiles.path)
+  if not ok then return nil end
+  local width, height = image:getDimensions()
+  local quads = {}
+  for index = 0, (width / 8) * (height / 8) - 1 do
+    quads[index] = graphics.newQuad(
+      (index % (width / 8)) * 8,
+      math.floor(index / (width / 8)) * 8,
+      8, 8, width, height
+    )
+  end
+
+  local cursor
+  if definition.cursor and definition.cursor.path then
+    local cursorOk, cursorImage = pcall(graphics.newImage, definition.cursor.path)
+    if cursorOk then cursor = cursorImage end
+  end
+  return { image = image, quads = quads, map = definition.map, cursor = cursor }
+end
+
+function MapScreen.playerPosition(game, currentMapId)
+  if not currentMapId then return nil end
+  local townMap = (((game or {}).data or {}).field or {}).townMap or {}
+  local location = (townMap.locations or {})[currentMapId]
+  if location and location.x ~= nil and location.y ~= nil then
+    return { x = location.x, y = location.y }
+  end
+  return nil
+end
+
+function MapScreen.new(mod, game, areas, deps)
+  deps = deps or {}
+  local self = setmetatable({}, MapScreen)
+  self.mod = mod
+  self.game = game
+  self.graphics = deps.graphics or love.graphics
+  self.font = deps.font or mod.ui.Font
+  self.locations = {}
+  for _, area in ipairs(areas or {}) do
+    if area.x ~= nil and area.y ~= nil then self.locations[#self.locations + 1] = area end
+  end
+  self.selected = 1
+  local currentMapId = game.overworld and game.overworld.map and game.overworld.map.id
+  local townMap = (((game or {}).data or {}).field or {}).townMap or {}
+  local current = currentMapId and (townMap.locations or {})[currentMapId]
+  if current then
+    for index, location in ipairs(self.locations) do
+      if location.x == current.x and location.y == current.y then
+        self.selected = index
+        break
+      end
+    end
+  end
+  self.player = MapScreen.playerPosition(game, currentMapId)
+  self.blink = 0
+  self.background = loadBackground(self.graphics, game)
+  return self
+end
+
+function MapScreen:move(dx, dy)
+  local current = self.locations[self.selected]
+  if not current then return end
+  local best, bestScore
+  for index, location in ipairs(self.locations) do
+    if index ~= self.selected then
+      local deltaX, deltaY = location.x - current.x, location.y - current.y
+      local forward = deltaX * dx + deltaY * dy
+      if forward > 0 then
+        local sideways = math.abs(deltaX * dy) + math.abs(deltaY * dx)
+        local score = forward + sideways * 3
+        if not best or score < bestScore then
+          best, bestScore = index, score
+        end
+      end
+    end
+  end
+  if best then self.selected = best end
+end
+
+function MapScreen:update(dt)
+  self.blink = (self.blink + 1) % 32
+  local input = self.game.input
+  if input:wasPressed("b") then
+    self.game.stack:pop()
+    return
+  elseif input:wasPressed("select") then
+    self.mod.ui.push(self.game, "EncounterGuideAreas")
+    return
+  elseif input:wasPressed("up") then self:move(0, -1)
+  elseif input:wasPressed("down") then self:move(0, 1)
+  elseif input:wasPressed("left") then self:move(-1, 0)
+  elseif input:wasPressed("right") then self:move(1, 0)
+  elseif input:wasPressed("a") then
+    local location = self.locations[self.selected]
+    if location then self.mod.ui.push(self.game, "EncounterGuideArea", location) end
+  end
+end
+
+function MapScreen:draw()
+  local graphics = self.graphics
+  graphics.setColor(1, 1, 1, 1)
+  graphics.rectangle("fill", 0, 0, 160, 144)
+
+  if self.background then
+    for index, tile in ipairs(self.background.map) do
+      local column = (index - 1) % 20
+      local row = math.floor((index - 1) / 20)
+      graphics.draw(self.background.image, self.background.quads[tile], column * 8, row * 8)
+    end
+  end
+
+  local location = self.locations[self.selected]
+  graphics.setColor(0, 0, 0, 1)
+  for _, marker in ipairs(self.locations) do
+    local markerX, markerY = marker.x * 8 + 16, marker.y * 8 + 8
+    graphics.rectangle("fill", markerX + 2, markerY + 2, 4, 4)
+  end
+
+  if self.player and self.blink < 16 then
+    local playerX, playerY = self.player.x * 8 + 16, self.player.y * 8 + 8
+    graphics.setColor(0, 0, 0, 1)
+    graphics.rectangle("fill", playerX + 1, playerY + 1, 6, 6)
+    graphics.setColor(1, 1, 1, 1)
+    graphics.rectangle("fill", playerX + 2, playerY + 2, 4, 4)
+  end
+
+  if location then
+    local x, y = location.x * 8 + 16, location.y * 8 + 8
+    if self.background and self.background.cursor then
+      graphics.draw(self.background.cursor, x - 4, y - 4)
+    else
+      graphics.setColor(0, 0, 0, 1)
+      graphics.rectangle("line", x + 0.5, y + 0.5, 7, 7)
+    end
+    graphics.setColor(1, 1, 1, 1)
+    graphics.rectangle("fill", 0, 0, 160, 8)
+    graphics.setColor(0, 0, 0, 1)
+    self.font.draw(location.name, 8, 0)
+  end
+  graphics.setColor(1, 1, 1, 1)
+  graphics.rectangle("fill", 0, 136, 160, 8)
+  graphics.setColor(0, 0, 0, 1)
+  self.font.draw("A:OPEN  SELECT:LIST", 4, 136)
+  graphics.setColor(1, 1, 1, 1)
+end
+
+local Hud = {}
+Hud.__index = Hud
+
+local MAX_LINES = 6
+local MODES = { "auto", "always", "off" }
+local SIZES = { small = 1, medium = 1.5, large = 2 }
+local BALL_SPACE = 15 -- blank glyph (8) + gap (3) + half the ball (4)
+
+local function isHeader(record)
+  return record.text == "LAND" or record.text == "WATER"
+end
+
+local function levelRange(species)
+  if species.minLevel == species.maxLevel then return tostring(species.minLevel) end
+  return species.minLevel .. "-" .. species.maxLevel
+end
+
+local function speciesRecords(summary, owned)
+  local records = {}
+  for _, species in ipairs((summary or {}).species or {}) do
+    records[#records + 1] = {
+      text = species.name .. " " .. levelRange(species),
+      owned = owned[species.speciesId] == true,
+    }
+  end
+  return records
+end
+
+-- Pure formatting: honest LAND/WATER labels, exact level ranges, capped box.
+-- method "land"|"water" filters to one table (the AUTO tile mode) and drops
+-- the header; nil shows both with headers.
+function Hud.linesFor(data, mapId, summarize, method)
+  local summary = (summarize or Model.mapSummary)(data, mapId)
+  if not summary then return nil end
+  local owned = (data or {}).owned or {}
+  local lines = {}
+  if (method == nil or method == "land") and summary.land then
+    if method == nil and summary.water then lines[#lines + 1] = { text = "LAND", owned = false } end
+    for _, record in ipairs(speciesRecords(summary.land, owned)) do lines[#lines + 1] = record end
+  end
+  if (method == nil or method == "water") and summary.water then
+    if method == nil then lines[#lines + 1] = { text = "WATER", owned = false } end
+    for _, record in ipairs(speciesRecords(summary.water, owned)) do lines[#lines + 1] = record end
+  end
+  if #lines == 0 then return nil end
+  if #lines > MAX_LINES then
+    local kept = {}
+    local index = 1
+    while #kept < MAX_LINES - 1 and index <= #lines do
+      local record = lines[index]
+      if isHeader(record) and #kept + 3 > MAX_LINES then break end
+      kept[#kept + 1] = record
+      index = index + 1
+    end
+    local hidden = 0
+    for j = index, #lines do
+      if not isHeader(lines[j]) then hidden = hidden + 1 end
+    end
+    if hidden > 0 then kept[#kept + 1] = { text = "+" .. hidden .. " MORE", owned = false } end
+    lines = kept
+  end
+  return lines
+end
+
+-- The HUD exists only while the overworld is the top state: walking and
+-- dialogue yes; menus, battles, and the title screen no.
+function Hud.activeMapId(game)
+  local stack = game and game.stack
+  local states = stack and stack.states
+  local top = states and states[#states]
+  if not (top and top.isOverworld) then return nil end
+  local overworld = game and game.overworld
+  return overworld and overworld.map and overworld.map.id
+end
+
+-- Which encounter table the tile under the player offers, or nil.
+-- Uses the live Map's own checks so it can never drift from the engine.
+function Hud.tileAt(game, x, y)
+  local overworld = game and game.overworld
+  local map = overworld and overworld.map
+  if not map or not map.isGrassCell or not map.isWaterCell then return nil end
+  if map:isGrassCell(x, y) then return "land" end
+  if map:isWaterCell(x, y) then return "water" end
+  return nil
+end
+
+function Hud.new(mod, game, deps)
+  deps = deps or {}
+  local self = setmetatable({}, Hud)
+  self.mod = mod
+  self.game = game
+  self.graphics = deps.graphics or love.graphics
+  self.font = deps.font or mod.ui.Font
+  self.window = deps.window or love.graphics.getDimensions
+  self.tile = deps.tile
+  self.keyDown = deps.keyDown
+  self.summarize = deps.summarize
+  self.cache = { key = nil, lines = nil }
+  self.keyHeld = false
+  return self
+end
+
+function Hud:currentMode()
+  local options = (self.game and self.game.save and self.game.save.options) or {}
+  local mode = options.encounterGuideHud
+  for _, candidate in ipairs(MODES) do
+    if mode == candidate then return mode end
+  end
+  return "auto"
+end
+
+function Hud:size()
+  local options = (self.game and self.game.save and self.game.save.options) or {}
+  local size = options.encounterGuideSize
+  if SIZES[size] then return size end
+  return "small"
+end
+
+function Hud:sizeFactor()
+  return SIZES[self:size()] or 1
+end
+
+-- H cycles AUTO -> ALWAYS -> OFF with edge detection; the mode persists to
+-- save.options so the options menu and the key stay in sync.
+function Hud:handleToggle()
+  local keyDown = self.keyDown or love.keyboard.isDown
+  local held = keyDown ~= nil and keyDown("h") or false
+  if held and not self.keyHeld then
+    self.keyHeld = true
+    local current = self:currentMode()
+    local index = 1
+    for i, candidate in ipairs(MODES) do
+      if candidate == current then index = i break end
+    end
+    local nextMode = MODES[index % #MODES + 1]
+    local options = (self.game.save or {}).options
+    if options then options.encounterGuideHud = nextMode end
+    self.cache.key = nil
+  end
+  if not held then self.keyHeld = false end
+end
+
+function Hud:tileAtPlayer()
+  local overworld = (self.game or {}).overworld
+  local player = overworld and overworld.player
+  local x, y = player and player.cellX, player and player.cellY
+  if not x or not y then return nil end
+  return (self.tile or Hud.tileAt)(self.game, x, y)
+end
+
+function Hud:refresh()
+  local mapId = Hud.activeMapId(self.game)
+  if not mapId then
+    self.cache.key, self.cache.lines = nil, nil
+    return
+  end
+  local mode = self:currentMode()
+  local method
+  if mode == "off" then
+    method = "none"
+  elseif mode == "auto" then
+    method = self:tileAtPlayer() or "none"
+  end
+  local key = tostring(mapId) .. ":" .. tostring(method or "both")
+  if self.cache.key == key then return end
+  local game = self.game
+  local data = {
+    encounters = (game.data or {}).encounters or {},
+    townMap = ((game.data or {}).field or {}).townMap or {},
+    pokemon = (game.data or {}).pokemon or {},
+    constants = (game.data or {}).constants or {},
+    owned = ((game.save or {}).pokedex or {}).owned or {},
+  }
+  self.cache.key = key
+  if method == "none" then
+    self.cache.lines = nil
+    return
+  end
+  self.cache.lines = Hud.linesFor(data, mapId, self.summarize, method)
+end
+
+function Hud:draw(viewport)
+  self:handleToggle()
+  self:refresh()
+  local lines = self.cache.lines
+  if not lines or #lines == 0 then return end
+  self:drawBox(lines)
+end
+
+-- Screen-space overlay: reset the transform like the engine's own touch
+-- overlay (a render pipeline such as a voxel mod can leave its camera
+-- transform active at render.hud time) and anchor to the window's top-right.
+-- The SMALL geometry is the base unit; MEDIUM/LARGE scale the whole box.
+function Hud:drawBox(lines)
+  local graphics = self.graphics
+  local font = self.font
+  local maxWidth, anyOwned = 0, false
+  for _, record in ipairs(lines) do
+    local width = font.width(record.text)
+    if width > maxWidth then maxWidth = width end
+    if record.owned then anyOwned = true end
+  end
+  if anyOwned then maxWidth = maxWidth + BALL_SPACE end
+  local boxWidth = maxWidth + 4
+  local boxHeight = #lines * 8 + 4
+  local windowWidth, windowHeight = self.window()
+  local factor = self:sizeFactor()
+  graphics.push("all")
+  graphics.origin()
+  graphics.scale(factor, factor)
+  local originX = windowWidth / factor - boxWidth - 2
+  local originY = 2
+  graphics.setColor(1, 1, 1, 1)
+  graphics.rectangle("fill", originX, originY, boxWidth, boxHeight)
+  graphics.setColor(0, 0, 0, 1)
+  graphics.rectangle("line", originX + 0.5, originY + 0.5, boxWidth - 1, boxHeight - 1)
+  for index, record in ipairs(lines) do
+    local x = originX + 2
+    local y = originY + 2 + (index - 1) * 8
+    font.draw(record.text, x, y)
+    if record.owned then
+      -- the same owned-ball marker the engine's ListMenu draws
+      local bx = x + font.width(record.text) + 8 + 3
+      local by = y + 3
+      graphics.setColor(0, 0, 0, 1)
+      graphics.circle("fill", bx, by, 3.5)
+      graphics.setColor(1, 1, 1, 1)
+      graphics.rectangle("fill", bx - 3.5, by - 0.5, 7, 1)
+      graphics.circle("fill", bx, by, 1.2)
+      graphics.setColor(0, 0, 0, 1)
+    end
+  end
+  graphics.pop("all")
+  graphics.setColor(1, 1, 1, 1)
+end
+
+local BattleHud = {}
+BattleHud.__index = BattleHud
+
+local BELOW_NAME_SLOTS = {
+  -- Fixed below-left markers: anchored to the name field's left edge and one
+  -- row below the printed name, never to the name's width.
+  classic = {
+    enemy = { x = 8, y = 11 },
+    player = { x = 80, y = 67 },
+  },
+  wide = {
+    enemy = { x = 8, y = 19 },
+    player = { x = 192, y = 75 },
+  },
+}
+
+-- Engine HUD anchors, verified against BattleState.drawHUDs (v0.1.75):
+-- classic enemy name row 0 (nameX anchor tile 1), player row 56 (tile 10);
+-- wide panels draw names at panel origin + 8/+8, panels at (0,0)/(184,56).
+local LAYOUTS = {
+  classic = {
+    enemy = { tx = 1, y = 0 },
+    player = { tx = 10, y = 56 },
+  },
+  wide = {
+    enemy = { x = 8, y = 8 },
+    player = { x = 192, y = 64 },
+  },
+}
+
+-- CenterMonName offset (BattleState.nameX): 1-2 glyph names print two tiles
+-- right, 3-4 one tile, 5+ at the box edge. Counted in glyphs, not bytes.
+function BattleHud.nameX(tx, glyphs)
+  return tx * 8 + (glyphs <= 2 and 16 or glyphs <= 4 and 8 or 0)
+end
+
+-- The owned-ball position for a battler name, or nil for unknown layout/side.
+function BattleHud.ballGeometry(layout, side, glyphs, nameWidth)
+  local spec = LAYOUTS[layout] and LAYOUTS[layout][side]
+  if not spec then return nil end
+  local slot = ((BELOW_NAME_SLOTS[layout] or {})[side])
+  if not slot then return nil end
+  return slot.x, slot.y
+end
+
+-- The same owned-ball marker the engine's ListMenu draws.
+function BattleHud.drawBall(graphics, bx, by)
+  graphics.setColor(0, 0, 0, 1)
+  graphics.circle("fill", bx, by, 3.5)
+  graphics.setColor(1, 1, 1, 1)
+  graphics.rectangle("fill", bx - 3.5, by - 0.5, 7, 1)
+  graphics.circle("fill", bx, by, 1.2)
+  graphics.setColor(0, 0, 0, 1)
+end
+
+local function enemyVisible(battle, battler)
+  return not battle.enemySendingOut and not battle.introBalls
+    and not (battler.fainted)
+end
+
+local function playerVisible(battle)
+  return not battle.safari and not battle.demo and not battle.showPlayerBack
+end
+
+function BattleHud.drawNameBall(graphics, font, layout, side, battler)
+  local name = battler.name or (battler.mon and battler.mon.species) or ""
+  local glyphs = #font.split(name)
+  local width = font.width(name)
+  local bx, by = BattleHud.ballGeometry(layout, side, glyphs, width)
+  if not bx then return 0 end
+  BattleHud.drawBall(graphics, bx, by)
+  return 1
+end
+
+-- Draws one owned ball per battler whose species is in the caught dex.
+-- Returns how many balls were drawn. Draws in the battle's own canvas space
+-- (battle.overlay fires inside BattleState:draw), so positions are raw
+-- 160x144 (classic) or wide-canvas coordinates.
+function BattleHud.drawOverlay(graphics, font, battle, owned)
+  if not (battle and graphics and font) then return 0 end
+  local wide = battle.isWideBattleLayout and battle:isWideBattleLayout()
+  local layout = wide and "wide" or "classic"
+  local count = 0
+  local enemy = battle.enemy
+  if enemy and enemy.mon and owned[enemy.mon.species] and enemyVisible(battle, enemy) then
+    count = count + BattleHud.drawNameBall(graphics, font, layout, "enemy", enemy)
+  end
+  local player = battle.player
+  if player and player.mon and owned[player.mon.species] and playerVisible(battle) then
+    count = count + BattleHud.drawNameBall(graphics, font, layout, "player", player)
+  end
+  return count
+end
+
+local SCREENS = {
+  map = "EncounterGuideMap",
+  areas = "EncounterGuideAreas",
+  area = "EncounterGuideArea",
+  source = "EncounterGuideSource",
+  method = "EncounterGuideMethod",
+  species = "EncounterGuideSpecies",
+}
+local entryHud
+
+return function(mod)
+  mod.content.screens:register(SCREENS.map, {
+    new = function(game)
+      local areas = Model.buildAreas(guideData(game))
+      local screen = MapScreen.new(mod, game, areas)
+      if #screen.locations == 0 then return Screens.newAreas(mod, game) end
+      return screen
+    end,
+  })
+  mod.content.screens:register(SCREENS.areas, {
+    new = function(game)
+      return Screens.newAreas(mod, game)
+    end,
+  })
+  mod.content.screens:register(SCREENS.area, {
+    new = function(game, area)
+      return Screens.newArea(mod, game, area)
+    end,
+  })
+  mod.content.screens:register(SCREENS.source, {
+    new = function(game, source)
+      return Screens.newSource(mod, game, source)
+    end,
+  })
+  mod.content.screens:register(SCREENS.method, {
+    new = function(game, source, methodName)
+      return Screens.newMethod(mod, game, source, methodName)
+    end,
+  })
+  mod.content.screens:register(SCREENS.species, {
+    new = function(game, source, methodName, species)
+      return Screens.newSpecies(mod, game, source, methodName, species)
+    end,
+  })
+
+  mod.hooks:wrap("ui.start_menu.items", function(next, game, items)
+    local out = next(game, items)
+    if type(out) ~= "table" then return out end
+    return mod.ui.insertBefore(out, "SAVE", {
+      label = "PKMN MAP",
+      onSelect = function() mod.ui.push(game, SCREENS.map) end,
+    })
+  end)
+
+  mod.hooks:wrap("render.hud", function(next, game, viewport)
+    if next then next(game, viewport) end
+    if not entryHud then entryHud = Hud.new(mod, game, {}) end
+    entryHud:draw(viewport)
+  end)
+
+  mod.hooks:wrap("battle.overlay", function(next, battle)
+    if next then next(battle) end
+    local game = battle and battle.game
+    local owned = ((game and game.save and game.save.pokedex) or {}).owned or {}
+    BattleHud.drawOverlay(love.graphics, mod.ui.Font, battle, owned)
+  end)
+
+  local HUD_MODES = { "auto", "always", "off" }
+  local HUD_SIZES = { "small", "medium", "large" }
+  local function optionLabel(option, candidates, fallback)
+    for _, candidate in ipairs(candidates) do
+      if option == candidate then return candidate:upper() end
+    end
+    return fallback
+  end
+  local function cycleOption(options, key, candidates, dir)
+    local current = options[key]
+    local index = 1
+    for i, candidate in ipairs(candidates) do
+      if candidate == current then index = i break end
+    end
+    options[key] = candidates[((index - 1 + dir) % #candidates) + 1]
+    return true
+  end
+  mod.hooks:wrap("ui.options.rows", function(next, game, rows)
+    local out = next(game, rows)
+    if type(out) ~= "table" then return out end
+    out[#out + 1] = {
+      id = "encounterGuideHud",
+      label = "ENC. GUIDE HUD",
+      value = function(g)
+        return optionLabel(((g.save or {}).options or {}).encounterGuideHud, HUD_MODES, "AUTO")
+      end,
+      step = function(g, dir)
+        local options = (g.save or {}).options
+        if not options then return false end
+        return cycleOption(options, "encounterGuideHud", HUD_MODES, dir)
+      end,
+    }
+    out[#out + 1] = {
+      id = "encounterGuideSize",
+      label = "ENC. GUIDE SIZE",
+      value = function(g)
+        return optionLabel(((g.save or {}).options or {}).encounterGuideSize, HUD_SIZES, "SMALL")
+      end,
+      step = function(g, dir)
+        local options = (g.save or {}).options
+        if not options then return false end
+        return cycleOption(options, "encounterGuideSize", HUD_SIZES, dir)
+      end,
+    }
+    return out
+  end)
+end

--- a/mods/examples/wills_mod/main.lua
+++ b/mods/examples/wills_mod/main.lua
@@ -656,100 +656,6 @@ function Hud:drawBox(lines)
   graphics.setColor(1, 1, 1, 1)
 end
 
-local BattleHud = {}
-BattleHud.__index = BattleHud
-
-local BELOW_NAME_SLOTS = {
-  -- Fixed below-left markers: anchored to the name field's left edge and one
-  -- row below the printed name, never to the name's width.
-  classic = {
-    enemy = { x = 8, y = 11 },
-    player = { x = 80, y = 67 },
-  },
-  wide = {
-    enemy = { x = 8, y = 19 },
-    player = { x = 192, y = 75 },
-  },
-}
-
--- Engine HUD anchors, verified against BattleState.drawHUDs (v0.1.75):
--- classic enemy name row 0 (nameX anchor tile 1), player row 56 (tile 10);
--- wide panels draw names at panel origin + 8/+8, panels at (0,0)/(184,56).
-local LAYOUTS = {
-  classic = {
-    enemy = { tx = 1, y = 0 },
-    player = { tx = 10, y = 56 },
-  },
-  wide = {
-    enemy = { x = 8, y = 8 },
-    player = { x = 192, y = 64 },
-  },
-}
-
--- CenterMonName offset (BattleState.nameX): 1-2 glyph names print two tiles
--- right, 3-4 one tile, 5+ at the box edge. Counted in glyphs, not bytes.
-function BattleHud.nameX(tx, glyphs)
-  return tx * 8 + (glyphs <= 2 and 16 or glyphs <= 4 and 8 or 0)
-end
-
--- The owned-ball position for a battler name, or nil for unknown layout/side.
-function BattleHud.ballGeometry(layout, side, glyphs, nameWidth)
-  local spec = LAYOUTS[layout] and LAYOUTS[layout][side]
-  if not spec then return nil end
-  local slot = ((BELOW_NAME_SLOTS[layout] or {})[side])
-  if not slot then return nil end
-  return slot.x, slot.y
-end
-
--- The same owned-ball marker the engine's ListMenu draws.
-function BattleHud.drawBall(graphics, bx, by)
-  graphics.setColor(0, 0, 0, 1)
-  graphics.circle("fill", bx, by, 3.5)
-  graphics.setColor(1, 1, 1, 1)
-  graphics.rectangle("fill", bx - 3.5, by - 0.5, 7, 1)
-  graphics.circle("fill", bx, by, 1.2)
-  graphics.setColor(0, 0, 0, 1)
-end
-
-local function enemyVisible(battle, battler)
-  return not battle.enemySendingOut and not battle.introBalls
-    and not (battler.fainted)
-end
-
-local function playerVisible(battle)
-  return not battle.safari and not battle.demo and not battle.showPlayerBack
-end
-
-function BattleHud.drawNameBall(graphics, font, layout, side, battler)
-  local name = battler.name or (battler.mon and battler.mon.species) or ""
-  local glyphs = #font.split(name)
-  local width = font.width(name)
-  local bx, by = BattleHud.ballGeometry(layout, side, glyphs, width)
-  if not bx then return 0 end
-  BattleHud.drawBall(graphics, bx, by)
-  return 1
-end
-
--- Draws one owned ball per battler whose species is in the caught dex.
--- Returns how many balls were drawn. Draws in the battle's own canvas space
--- (battle.overlay fires inside BattleState:draw), so positions are raw
--- 160x144 (classic) or wide-canvas coordinates.
-function BattleHud.drawOverlay(graphics, font, battle, owned)
-  if not (battle and graphics and font) then return 0 end
-  local wide = battle.isWideBattleLayout and battle:isWideBattleLayout()
-  local layout = wide and "wide" or "classic"
-  local count = 0
-  local enemy = battle.enemy
-  if enemy and enemy.mon and owned[enemy.mon.species] and enemyVisible(battle, enemy) then
-    count = count + BattleHud.drawNameBall(graphics, font, layout, "enemy", enemy)
-  end
-  local player = battle.player
-  if player and player.mon and owned[player.mon.species] and playerVisible(battle) then
-    count = count + BattleHud.drawNameBall(graphics, font, layout, "player", player)
-  end
-  return count
-end
-
 local SCREENS = {
   map = "EncounterGuideMap",
   areas = "EncounterGuideAreas",
@@ -808,13 +714,6 @@ return function(mod)
     if next then next(game, viewport) end
     if not entryHud then entryHud = Hud.new(mod, game, {}) end
     entryHud:draw(viewport)
-  end)
-
-  mod.hooks:wrap("battle.overlay", function(next, battle)
-    if next then next(battle) end
-    local game = battle and battle.game
-    local owned = ((game and game.save and game.save.pokedex) or {}).owned or {}
-    BattleHud.drawOverlay(love.graphics, mod.ui.Font, battle, owned)
   end)
 
   local HUD_MODES = { "auto", "always", "off" }

--- a/mods/examples/wills_mod/manifest.json
+++ b/mods/examples/wills_mod/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "wills_mod",
-  "name": "Will's Mod",
+  "name": "Encounters Guide",
   "version": "1.0.0",
   "api": 2,
   "entry": "main.lua",

--- a/mods/examples/wills_mod/manifest.json
+++ b/mods/examples/wills_mod/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "wills_mod",
   "name": "Encounters Guide",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",
@@ -13,5 +13,5 @@
   "conflicts": [],
   "affects_link": false,
   "github": "illanrego/wills-mod",
-  "description": "Catch-'em-all toolkit: a map-first wild-encounter guide (PKMN MAP) and battle HUD owned-ball markers."
+  "description": "A map-first wild-encounter guide (PKMN MAP) with a walking HUD and exact encounter tables."
 }

--- a/mods/examples/wills_mod/manifest.json
+++ b/mods/examples/wills_mod/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "wills_mod",
+  "name": "Will's Mod",
+  "version": "1.0.0",
+  "api": 2,
+  "entry": "main.lua",
+  "profile": "content",
+  "category": "TOOL",
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "priority": 100,
+  "dependencies": [],
+  "optional_dependencies": [],
+  "conflicts": [],
+  "affects_link": false,
+  "github": "illanrego/wills-mod",
+  "description": "Catch-'em-all toolkit: a map-first wild-encounter guide (PKMN MAP) and battle HUD owned-ball markers."
+}

--- a/mods/examples/wills_mod/mod.card
+++ b/mods/examples/wills_mod/mod.card
@@ -1,0 +1,34 @@
+return {
+  summary = "Catch-'em-all toolkit: map-first encounter guide + owned-ball battle HUD.",
+  author = "Illan",
+  contact = "",
+  tags = { "ui", "tool", "quality-of-life", "encounters" },
+  differences = {
+    changed = {
+      "the START menu gains a PKMN MAP row before SAVE",
+      "battles gain a Pokédex owned-ball marker beside each battler's name",
+    },
+    added = {
+      "map-first browser using the imported ROM's Kanto Town Map",
+      "a blinking white marker showing the player's current location, even without encounters there",
+      "a walking HUD listing the current area's LAND and WATER species with level ranges",
+      "HUD modes: AUTO (grass/water only), ALWAYS, OFF — options menu or H key",
+      "HUD sizes: SMALL, MEDIUM, LARGE — options menu",
+      "Pokédex owned-ball markers on the walking HUD and in species lists",
+      "D-pad marker navigation, A to open, and SELECT for the complete list",
+      "separate source-map entries for routes, floors, caves, and buildings",
+      "LAND and WATER encounter views",
+      "per-species level ranges and exact per-level chance per movement step",
+    },
+    known = {
+      "v1.0.0 covers walking and Surf encounter tables only; fishing, static, gift, trade, and prize Pokémon are not represented",
+      "the guide reads data when opened; reopen it after enabling a mod that changes encounter tables",
+      "the battle HUD draws at final positions, so during the send-out slide the ball sits at its rest spot",
+    },
+  },
+  credits = {
+    { who = "Gen1Recomp project", for_ = "the public mod and UI APIs" },
+    { who = "pret/pokered", for_ = "the original game data extraction reference" },
+  },
+  compat = { modApi = 2 },
+}

--- a/mods/examples/wills_mod/mod.card
+++ b/mods/examples/wills_mod/mod.card
@@ -1,12 +1,11 @@
 return {
-  summary = "Catch-'em-all toolkit: map-first encounter guide + owned-ball battle HUD.",
+  summary = "Map-first encounter guide for Gen1Recomp with a walking HUD and exact odds.",
   author = "Illan",
   contact = "",
   tags = { "ui", "tool", "quality-of-life", "encounters" },
   differences = {
     changed = {
       "the START menu gains a PKMN MAP row before SAVE",
-      "battles gain a Pokédex owned-ball marker beside each battler's name",
     },
     added = {
       "map-first browser using the imported ROM's Kanto Town Map",
@@ -23,7 +22,6 @@ return {
     known = {
       "v1.0.0 covers walking and Surf encounter tables only; fishing, static, gift, trade, and prize Pokémon are not represented",
       "the guide reads data when opened; reopen it after enabling a mod that changes encounter tables",
-      "the battle HUD draws at final positions, so during the send-out slide the ball sits at its rest spot",
     },
   },
   credits = {

--- a/mods/examples/wills_mod/tests/wills_mod_test.lua
+++ b/mods/examples/wills_mod/tests/wills_mod_test.lua
@@ -1,4 +1,4 @@
--- Will's Mod gallery suite: loads the bundled entry through the real loader
+-- Encounters Guide gallery suite: loads the bundled entry through the real loader
 -- and asserts the stated effects: two read-only overlay hooks, a PKMN MAP
 -- START-menu row, and the screen family resolving through the registry.
 --

--- a/mods/examples/wills_mod/tests/wills_mod_test.lua
+++ b/mods/examples/wills_mod/tests/wills_mod_test.lua
@@ -1,0 +1,57 @@
+-- Will's Mod gallery suite: loads the bundled entry through the real loader
+-- and asserts the stated effects: two read-only overlay hooks, a PKMN MAP
+-- START-menu row, and the screen family resolving through the registry.
+--
+-- Standalone: luajit mods/examples/wills_mod/tests/wills_mod_test.lua
+-- (or: POKEPORT_DATA_DIR=... /tmp/love-luajit mods/examples/wills_mod/tests/wills_mod_test.lua)
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.modkit")
+local Runtime = require("src.mods.Runtime")
+local Data = require("src.core.Data")
+
+-- Assemble a ROM-free dataset the same way the fixture base does (methods
+-- only, fresh tables, defaults seeded) so this suite runs with no ROM and
+-- no data/generated/ directory.
+local function fixtureData()
+  local methods = {}
+  for key, value in pairs(Data) do
+    if type(value) == "function" then methods[key] = value end
+  end
+  local set = setmetatable({}, { __index = methods })
+  local fixture = require("tests.fixture_data").load()
+  for name, mod in pairs(fixture) do set[name] = mod end
+  Data.seedDefaults(set)
+  return set
+end
+local data = fixtureData()
+
+local run = T.sdk.loadMod("mods/examples/wills_mod", { data = data })
+T.eq(#run.errors, 0, "loads clean (" .. tostring(run.errors[1]) .. ")")
+
+-- ------- the two read-only overlays and the options rows are wrapped
+
+T.check(Runtime.wantsHook("battle.overlay"), "battle.overlay is wrapped")
+T.check(Runtime.wantsHook("render.hud"), "render.hud is wrapped")
+T.check(Runtime.wantsHook("ui.options.rows"), "the options rows are wrapped")
+
+-- ------- the START menu gains exactly one row, anchored before SAVE
+
+local vanilla = { { label = "POKéDEX" }, { label = "SAVE" }, { label = "QUIT" } }
+local hooked = Runtime.call("ui.start_menu.items",
+  function(_, items) return items end, { data = data, save = {} }, vanilla)
+T.eq(#hooked, 4, "the wrap added exactly one row")
+T.eq(hooked[2].label, "PKMN MAP", "the row is anchored before SAVE")
+T.eq(hooked[3].label, "SAVE", "the vanilla rows are still in order")
+
+-- ------- the PKMN MAP screen resolves through the registry
+
+local Screens = require("src.ui.Screens")
+Screens.invalidate()
+local factory = Screens.get({ data = data, save = {} }, "EncounterGuideMap")
+T.check(factory and factory.new,
+  "the PKMN MAP screen resolves through the registry")
+
+run.release()
+Screens.invalidate()
+T.finish("wills_mod")

--- a/mods/examples/wills_mod/tests/wills_mod_test.lua
+++ b/mods/examples/wills_mod/tests/wills_mod_test.lua
@@ -29,9 +29,8 @@ local data = fixtureData()
 local run = T.sdk.loadMod("mods/examples/wills_mod", { data = data })
 T.eq(#run.errors, 0, "loads clean (" .. tostring(run.errors[1]) .. ")")
 
--- ------- the two read-only overlays and the options rows are wrapped
+-- ------- the read-only overlays and the options rows are wrapped
 
-T.check(Runtime.wantsHook("battle.overlay"), "battle.overlay is wrapped")
 T.check(Runtime.wantsHook("render.hud"), "render.hud is wrapped")
 T.check(Runtime.wantsHook("ui.options.rows"), "the options rows are wrapped")
 

--- a/tests/mod_examples_tests.lua
+++ b/tests/mod_examples_tests.lua
@@ -21,7 +21,7 @@ local GALLERY_ROOT = "mods/examples"
 local IDS = {
   "example_balance_tweaks", "example_shiny_palette", "example_jukebox",
   "example_lost_parcel", "example_weather", "example_dexnav",
-  "example_mini_conversion", "example_silly_oak",
+  "example_mini_conversion", "example_silly_oak", "wills_mod",
 }
 
 -- the closed vocabulary from 25 3.1; GAMEPLAY is the accepted v1 alias
@@ -330,8 +330,16 @@ eq(loader.optionSchemas.example_dexnav and #loader.optionSchemas.example_dexnav,
   "#6 defined two option rows")
 local menu = Runtime.call("ui.start_menu.items", function(_, items) return items end,
   { data = data }, { { label = "POKéDEX" }, { label = "SAVE" } })
-eq(#menu, 3, "#6 added exactly one start-menu row")
-eq(menu[2].label, "DEXNAV", "#6 anchored the row before SAVE")
+-- wills_mod also wraps the START menu (its PKMN MAP row). The loader
+-- discovers mods in sorted order, so wills_mod wraps last, and hook wraps
+-- are LIFO: its row runs first, then dexnav's. The merged menu is
+-- [POKéDEX, PKMN MAP, DEXNAV, SAVE]; #9 asserts the same two-row
+-- co-existence with the vanilla QUIT row still last.
+eq(#menu, 4, "#6 the two start-menu wraps added two rows total")
+eq(menu[1].label, "POKéDEX", "#6 the vanilla rows are still in order")
+eq(menu[2].label, "PKMN MAP", "#6 wills_mod's row runs first (wrapped last)")
+eq(menu[3].label, "DEXNAV", "#6 dexnav's row rides along")
+eq(menu[4].label, "SAVE", "#6 SAVE stays last")
 
 -- #7 total conversion: boot, constants, species, map
 eq(data.field.boot.startMap, "SABLE_COVE", "#7 owns the boot spawn")
@@ -346,6 +354,19 @@ check(data.maps.SABLE_COVE ~= nil, "#7 registered its map")
 eq(#data.maps.SABLE_COVE.blocks,
   data.maps.SABLE_COVE.width * data.maps.SABLE_COVE.height,
   "#7 the map's block array matches its size")
+
+-- #9 wills_mod: two read-only overlays and a screen registry
+check(Runtime.wantsHook("battle.overlay"), "#9 wrapped battle.overlay")
+check(Runtime.wantsHook("render.hud"), "#9 wrapped render.hud")
+check(Runtime.wantsHook("ui.options.rows"), "#9 wrapped the options rows")
+local wm = Runtime.call("ui.start_menu.items", function(_, items) return items end,
+  { data = data, save = {} },
+  { { label = "POKéDEX" }, { label = "SAVE" }, { label = "QUIT" } })
+eq(#wm, 5, "#9 the merged menu gained PKMN MAP and DEXNAV")
+eq(wm[1].label, "POKéDEX", "#9 the vanilla rows are still in order")
+eq(wm[2].label, "PKMN MAP", "#9 wills_mod's row runs first (wrapped last)")
+eq(wm[3].label, "DEXNAV", "#9 dexnav's row rides along")
+eq(wm[5].label, "QUIT", "#9 QUIT stays last")
 
 -- co-existence: the gallery does not fight over ids
 check(data.pokemon.MEW ~= nil, "vanilla species survive the whole gallery")

--- a/tests/mod_examples_tests.lua
+++ b/tests/mod_examples_tests.lua
@@ -355,8 +355,7 @@ eq(#data.maps.SABLE_COVE.blocks,
   data.maps.SABLE_COVE.width * data.maps.SABLE_COVE.height,
   "#7 the map's block array matches its size")
 
--- #9 wills_mod: two read-only overlays and a screen registry
-check(Runtime.wantsHook("battle.overlay"), "#9 wrapped battle.overlay")
+-- #9 wills_mod: a walking overlay, options rows, and a screen registry
 check(Runtime.wantsHook("render.hud"), "#9 wrapped render.hud")
 check(Runtime.wantsHook("ui.options.rows"), "#9 wrapped the options rows")
 local wm = Runtime.call("ui.start_menu.items", function(_, items) return items end,


### PR DESCRIPTION
## What

Adds [Encounters Guide](https://github.com/illanrego/wills-mod) as gallery entry #9 — a catch-'em-all toolkit for Gen1Recomp, one read-only TOOL mod:

- **Encounter Guide** — START → **PKMN MAP** opens the imported ROM's own Kanto Town Map; hop between encounter-bearing locations and drill into exact routes, floors, caves, and buildings, with LAND/WATER separation, level ranges, and per-step odds from `game.data`.
- **Walking HUD** — current area's species while exploring (AUTO / ALWAYS / OFF, SMALL / MEDIUM / LARGE).

No permissions, no ROM-derived bytes (`modkit lint` clean), works on Red/Blue/Yellow imports, API 2, category `TOOL`. (v1.0.1: the owned-ball battle overlay was dropped — covered by other mods; the encounter guide is the unique part.)

## Lane A checklist

- [x] `modkit validate --base imported` — green locally against fixture (`--base fixture --strict` → `ok wills_mod valid`); CI runs the real base
- [x] `modkit lint` — `ok wills_mod: no ROM-derived content`
- [x] `tests/wills_mod_test.lua` — loads through the headless loader and asserts stated effects (wrapped hooks, PKMN MAP row anchored before SAVE, screen registry resolution) — 8/8 passing
- [x] README opens with one sentence + persona + the three try-it commands
- [x] `mod.card` — summary ≤100 chars, author, lowercase-kebab tags, changed/added/known ledger, credits, `compat.modApi = 2`
- [x] CHANGELOG (keep-a-changelog) heading matches `manifest.version`
- [x] Disabled by default: lives in `mods/examples/`, not discovered at `mods/` root
- [x] No ROM-derived bytes

## Co-existence note

The gallery's merged start-menu assertion (#6) previously expected exactly one wrap; `wills_mod` also wraps `ui.start_menu.items` (its PKMN MAP row), so the merged menu carries two extra rows. #6 now asserts the two-row total and that both rows anchor before SAVE; a new #9 block asserts `wills_mod`'s stated effects (hooks wrapped, row placement, vanilla rows intact). The gallery still loads as one coherent set — that's exactly what the merged suite proves.

## Files

- `mods/examples/wills_mod/` — bundled entry (`main.lua`), manifest, `mod.card`, CHANGELOG, README, headless test
- `tests/mod_examples_tests.lua` — IDS + #6 update + #9 block
- `mods/examples/README.md` — index row

The readable source (unbundled `lib/*.lua`, `tools/bundle.py`, the full LÖVE test suite) stays at github.com/illanrego/wills-mod; the gallery entry ships the exact bundled artifact the release zip carries. (`.modkitignore` is excluded from VCS by the repo's `.*` gitignore rule, same as the other entries.)