### PR TITLE
launcher: pad cursor edge-scroll for stickless handhelds

### DIFF
--- a/src/import/RomImporter.lua
+++ b/src/import/RomImporter.lua
@@ -2345,6 +2345,20 @@ function RomImporter:_updatePadCursor(dt)
     local ny = self._padCursor.y + dy * speed * dt
     self._padCursor.x = math.max(ox, math.min(ox + w, nx))
     self._padCursor.y = math.max(oy, math.min(oy + h, ny))
+    -- Pushing INTO the top/bottom edge scrolls the page instead of stalling.
+    -- The cursor is clamped to the safe area above, so on a short window the
+    -- rows below the fold are unreachable on a stickless handheld: no mouse
+    -- wheel, no touchscreen, and no right stick to feed the existing wheel
+    -- path.  Only the OVERSHOOT scrolls -- parking the cursor at the edge does
+    -- nothing, it has to be actively pushed -- and this block only runs on pad
+    -- input, so a real mouse is unaffected.  /48 matches the pixels-per-notch
+    -- LauncherView.draw multiplies back out.
+    local overY = 0
+    if ny > oy + h then overY = ny - (oy + h)
+    elseif ny < oy then overY = ny - oy end
+    if overY ~= 0 and self._flex then
+      require("src.import.LauncherView").wheelmoved(self, 0, -overY / 48)
+    end
     -- Desktop: FlexLove polls the real mouse, so warp it with the pad pointer.
     -- NX: the getPosition bridge already returns pad coords — skip setPosition.
     if not self.isNX and love.mouse.setPosition then


### PR DESCRIPTION
On a handheld with no mouse, no touchscreen and no analog sticks, nothing in the
launcher can reach content below the fold. This makes the pad cursor scroll the
page when it is pushed into the top or bottom edge.

Refs #1142.

## The problem

`LauncherView.draw`'s **SHORT-WINDOW SCROLL** already does the right thing: on a
480px-tall panel the space between header and footer falls under
`minPanelHeight`, `scrollMax > 0`, and the page is scrollable so that (per the
comment) "the footer simply lives below the fold until scrolled to."

The mechanism is fine — it just has only three inputs:

| Input | Where |
|---|---|
| Mouse wheel | `LauncherView.lua` `wheelmoved` |
| Touch drag | `LauncherView.lua` `touchmoved` |
| Right analog stick | `RomImporter.lua` -> `LauncherView.wheelmoved` |

An RG35XXSP has none of them. `/proc/bus/input/devices` on the device lists a
single input device:

```
N: Name="muOS-Keys"
P: Phys=gpio-keys-polled/input0
H: Handlers=kbd js0 event1
```

A polled GPIO key device that reports the D-pad as a hat — there are no analog
axes on the machine. There is also no scroll-to-focus anywhere (I grepped
`LauncherView`, `Kit` and `PadCursor`), so moving the pad cursor never touches
`_pageScroll`. The result is that below-fold rows are not merely clipped, they
are unreachable by any input the device has.

## The change

The motion is already being computed and thrown away. In the pad cursor update,
`ny` is clamped to the safe area and the excess discarded:

```lua
self._padCursor.y = math.max(oy, math.min(oy + h, ny))
```

This spends that overshoot on the existing wheel path instead — the same one the
right stick feeds a few lines below. 14 lines, one file.

Three properties I tried to preserve:

- **Pad-only by construction.** The enclosing block runs only when d-pad/stick
  input is non-zero, so a real mouse never reaches it and desktop behaviour is
  unchanged. Edge-scroll on a mouse would be actively wrong — you would move
  toward a button near the bottom and the page would slide out from under you.
- **Overshoot, not proximity.** Parking the cursor at the edge does nothing; it
  has to be actively pushed. This avoids the drift that makes naive
  edge-scrolling unpleasant.
- **No new state.** `draw` already clamps `_pageScroll` to `scrollMax`. The sign
  follows from `draw`'s `scroll - _wheelY * 48 * m.s`, so positive overshoot ->
  negative wheel -> scrolls down; `/48` makes scroll track cursor speed.

## Testing

`./scripts/test.sh` passes in full (T1/T2/T4; T3 skipped, no ROM in the tree).

Manually verified on an RG35XXSP (muOS, 640x480, 0.1.83) with `Kit.lua` left at
the **stock 0.9 scale** — i.e. with the layout still overflowing:

- pushing the cursor into the bottom edge scrolls the page; the pager and footer
  become reachable
- pushing up at the top edge scrolls back
- parking the cursor at either edge does nothing
- mouse and desktop behaviour unchanged

Worth noting for #1142: I had been running a local `Kit.lua` clamp-floor
workaround (0.9 -> 0.75) to squeeze the important rows on screen. With this
change that workaround is unnecessary — stock scale plus scrolling beats
shrinking everything, especially since there was only ~7% of scale between
"text still readable" and "footer fits". This needs no tuned constant and helps
any stickless handheld, not just 480px-tall ones.

Happy to adjust the scroll rate, the placement, or anything else you'd prefer
done differently.