### PR TITLE
Fix dependent mod option visibility

### DIFF
--- a/src/import/LauncherSettings.lua
+++ b/src/import/LauncherSettings.lua
@@ -20,6 +20,7 @@
 
 local Strings = require("src.core.Strings")
 local SaveData = require("src.core.SaveData")
+local OptionVisibility = require("src.mods.OptionVisibility")
 
 local LauncherSettings = {}
 
@@ -327,6 +328,22 @@ end
 
 local OPTION_TYPES = { toggle = true, choice = true, number = true, text = true }
 
+-- The Android launcher uses this model directly rather than the in-game mod
+-- manager. Evaluate the schema dependency rules here too so child settings
+-- disappear immediately when a parent is switched off.
+local function modOptionValue(opts, modId, row)
+  local stored = opts.modOptions and opts.modOptions[modId]
+  local value = stored and stored[row.key]
+  if value == nil then value = row.default end
+  return value
+end
+
+local function modOptionVisible(opts, modId, row, defaults)
+  return OptionVisibility.isVisible(row, function(key, default)
+    return modOptionValue(opts, modId, { key = key, default = default })
+  end, defaults)
+end
+
 -- Enabled mods with a loadable options_schema, discovered the same way
 -- LauncherMods discovers manifests (mods/ one level deep; the launcher's
 -- readiness check has already mounted a portable install's game folder).
@@ -375,6 +392,12 @@ end
 local function modRows(opts, mod)
   local rows = {}
   local modId = mod.id
+  local defaults = {}
+  for _, schemaRow in ipairs(mod.schema) do
+    if type(schemaRow) == "table" and type(schemaRow.key) == "string" then
+      defaults[schemaRow.key] = schemaRow.default
+    end
+  end
   local function stored()
     local t = opts.modOptions
     return t and t[modId] or nil
@@ -396,6 +419,8 @@ local function modRows(opts, mod)
         or not OPTION_TYPES[row.type] then
       -- malformed rows are skipped silently here; the in-game manager is
       -- where schema errors are reported to the author
+    elseif not modOptionVisible(opts, modId, row, defaults) then
+      -- Dependent settings do not take up a row in the Android launcher.
     elseif row.type == "toggle" then
       rows[#rows + 1] = { label = row.label or row.key,
         value = function() return get(row) and Strings("ON") or Strings("OFF") end,
@@ -440,6 +465,15 @@ local function modRows(opts, mod)
         setText = function(text) set(row.key, text) end }
     end
   end
+  local visibleKeys = {}
+  for _, row in ipairs(mod.schema) do
+    if type(row) == "table" and type(row.key) == "string"
+        and OPTION_TYPES[row.type]
+        and modOptionVisible(opts, modId, row, defaults) then
+      visibleKeys[#visibleKeys + 1] = row.key
+    end
+  end
+  rows._signature = table.concat(visibleKeys, "\0")
   if #rows > 0 then
     rows[#rows + 1] = { label = Strings("RESET DEFAULTS"),
       value = function() return "" end,
@@ -594,16 +628,31 @@ function LauncherSettings.open(hooks, version)
   end
   -- Mod options are generation-agnostic (the manager's options_schema
   -- contract), so they ride along either way.
-  for _, mod in ipairs(discoverModSchemas(opts)) do
+  local mods = discoverModSchemas(opts)
+  for _, mod in ipairs(mods) do
     local rows = modRows(opts, mod)
     if #rows > 0 then
-      sections[#sections + 1] = { title = mod.name, rows = rows }
+      sections[#sections + 1] = { title = mod.name, rows = rows, mod = mod }
     end
   end
   return {
     opts = opts,
     version = version,
     sections = sections,
+    refresh = function()
+      local changed = false
+      for _, section in ipairs(sections) do
+        local mod = section.mod
+        if mod then
+          local rows = modRows(opts, mod)
+          if section.rows._signature ~= rows._signature then
+            section.rows = rows
+            changed = true
+          end
+        end
+      end
+      return changed
+    end,
     save = function() SaveData.saveOptions(opts) end,
   }
 end

--- a/src/import/LauncherView.lua
+++ b/src/import/LauncherView.lua
@@ -2513,6 +2513,11 @@ local function buildSettingsModal(imp, m)
 
   -- Settings rows are PAGINATED, flattened across sections so a page is a
   -- uniform run of rows.  Section titles ride along as their own entry.
+  if model.refresh and model.refresh() then
+    -- Rebuild the flattened cache after a parent setting changes so Android
+    -- removes dependent controls and recalculates pagination immediately.
+    imp._settingsFlat = nil
+  end
   local flat = imp._settingsFlat
   if not flat or flat.model ~= model then
     flat = { model = model }

--- a/src/mods/ManagerState.lua
+++ b/src/mods/ManagerState.lua
@@ -15,6 +15,7 @@ local Theme = require("src.ui.Theme")
 local OptionRows = require("src.ui.OptionRows")
 local Strings = require("src.core.Strings")
 local ModProfile = require("src.mods.ModProfile")
+local OptionVisibility = require("src.mods.OptionVisibility")
 
 local ManagerState = {}
 ManagerState.__index = ManagerState
@@ -955,6 +956,42 @@ function ManagerState:optionValue(modId, row)
   return v
 end
 
+function ManagerState:optionVisible(modId, row, schema, defaults)
+  if not defaults then
+    defaults = {}
+    for _, schemaRow in ipairs(schema or self.optionSchema or {}) do
+      if type(schemaRow) == "table" and type(schemaRow.key) == "string" then
+        defaults[schemaRow.key] = schemaRow.default
+      end
+    end
+  end
+  return OptionVisibility.isVisible(row, function(key, default)
+    return self:optionValue(modId, { key = key, default = default })
+  end, defaults)
+end
+
+function ManagerState:refreshOptionRows(preferredId)
+  if not (self.optionMod and self.optionSchema) then return end
+  local previousId
+  if not preferredId and self.optionRows then
+    local old = self.optionRows[self.cursor]
+    previousId = old and old.id
+  end
+  local rows = self:buildOptionRows(self.optionMod, self.optionSchema)
+  self.optionRows = rows
+  local wanted = preferredId or previousId
+  if wanted then
+    for i, row in ipairs(rows) do
+      if row.id == wanted then
+        self.cursor = i
+        break
+      end
+    end
+  end
+  self.cursor = clampIndex(self.cursor, math.max(1, #rows))
+  self.scroll = OptionRows.clampScroll(self.cursor, self.scroll or 0, #rows, nil)
+end
+
 function ManagerState:setOption(modId, key, value)
   local save = self.game.save
   if save and save.options then
@@ -979,12 +1016,20 @@ end
 function ManagerState:buildOptionRows(m, schema)
   local rows = {}
   local modId = m.id
+  local defaults = {}
+  for _, schemaRow in ipairs(schema) do
+    if type(schemaRow) == "table" and type(schemaRow.key) == "string" then
+      defaults[schemaRow.key] = schemaRow.default
+    end
+  end
   for _, row in ipairs(schema) do
     if type(row) ~= "table" or type(row.key) ~= "string" or row.key == ""
         or not OPTION_TYPES[row.type] then
       -- malformed rows are skipped, reported where the errors screen reads
       Runtime.reportError(modId, "options row skipped: "
         .. tostring(type(row) == "table" and (row.key or row.type) or row))
+    elseif not self:optionVisible(modId, row, schema, defaults) then
+      -- A dependent option stays out of the cursor and draw lists entirely.
     elseif row.type == "toggle" then
       rows[#rows + 1] = { id = row.key, label = row.label or row.key,
         value = function()
@@ -1068,6 +1113,7 @@ function ManagerState:buildOptionRows(m, schema)
           self:setOption(modId, row.key, row.default)
         end
       end
+      self:refreshOptionRows("__reset")
       self:notify("DEFAULTS RESTORED")
     end }
   return rows
@@ -1079,6 +1125,8 @@ function ManagerState:openOptions(m)
     self:notify("NO OPTIONS")
     return
   end
+  self.optionMod = m
+  self.optionSchema = schema
   self.optionRows = self:buildOptionRows(m, schema)
   self:goTo("options")
 end
@@ -1099,11 +1147,17 @@ function ManagerState:updateOptions(input)
       or input:wasPressed("a") then
     local dir = input:wasPressed("left") and -1 or 1
     local row = rows[self.cursor]
+    local changed = false
     if row.activate and input:wasPressed("a") then
       self:confirmSound()
       row.activate()
     elseif row.step then
-      row.step(self.game, dir)
+      changed = row.step(self.game, dir) == true
+    end
+    if changed and row.id then
+      self:refreshOptionRows(row.id)
+      rows = self.optionRows or {}
+      n = #rows
     end
   end
   self.scroll = OptionRows.clampScroll(self.cursor, self.scroll or 0, n, nil)

--- a/src/mods/OptionVisibility.lua
+++ b/src/mods/OptionVisibility.lua
@@ -1,0 +1,41 @@
+-- Declarative visibility rules for per-mod option rows.
+--
+-- The launcher and the in-game mod manager both render the same option
+-- schema, but they read values from different owners.  Keep the condition
+-- evaluator independent of either UI and let callers supply a value getter.
+
+local OptionVisibility = {}
+
+local function matches(condition, get, defaults)
+  if condition == nil or type(condition) ~= "table" then return true end
+
+  if type(condition.all) == "table" then
+    for _, child in ipairs(condition.all) do
+      if not matches(child, get, defaults) then return false end
+    end
+    return true
+  end
+
+  if type(condition.key) ~= "string" or condition.key == "" then
+    return true
+  end
+
+  local default = condition.default
+  if default == nil and defaults then default = defaults[condition.key] end
+  local actual = get(condition.key, default)
+  if condition.notEquals ~= nil then
+    return actual ~= condition.notEquals
+  end
+
+  local expected = condition.equals
+  if expected == nil then expected = condition.value end
+  return actual == expected
+end
+
+function OptionVisibility.isVisible(row, get, defaults)
+  if type(row) ~= "table" then return false end
+  if type(get) ~= "function" then return true end
+  return matches(row.visibleIf, get, defaults)
+end
+
+return OptionVisibility

--- a/tests/engine/launcher_settings_visibility_test.lua
+++ b/tests/engine/launcher_settings_visibility_test.lua
@@ -1,0 +1,84 @@
+-- Android launcher settings must apply the same visibleIf contract as the
+-- in-game mod manager, including live updates from a parent toggle.
+
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.harness")
+local check = T.check
+local loveStub = require("tests.love_stub")
+_G.love = loveStub
+
+local LauncherSettings = require("src.import.LauncherSettings")
+local SaveData = require("src.core.SaveData")
+
+local oldLoadOptions, oldFs = SaveData.loadOptions, love.filesystem
+local opts = { mods = {}, modOptions = {} }
+local schemaSource = [[return {
+  { key = "master", label = "MASTER", type = "toggle", default = false },
+  { key = "detail", label = "DETAIL", type = "toggle", default = true,
+    visibleIf = { key = "master", equals = true } },
+  { key = "nested", label = "NESTED", type = "toggle", default = true,
+    visibleIf = { all = {
+      { key = "master", equals = true },
+      { key = "detail", equals = true },
+    } } },
+}]]
+local files = {
+  ["mods/launcher_fixture/manifest.json"] =
+    '{"id":"launcher_fixture","name":"Launcher Fixture",'
+    .. '"version":"1.0.0","entry":"main.lua",'
+    .. '"options_schema":"options.lua"}',
+  ["mods/launcher_fixture/options.lua"] = schemaSource,
+}
+local fs = {
+  getInfo = function(path)
+    if path == "mods" or path == "mods/launcher_fixture" then
+      return { type = "directory" }
+    end
+    if files[path] then return { type = "file" } end
+    return nil
+  end,
+  getDirectoryItems = function(path)
+    if path == "mods" then return { "launcher_fixture" } end
+    return {}
+  end,
+  read = function(path) return files[path] end,
+  load = function(path)
+    if not files[path] then return nil end
+    return assert(load(files[path], path))
+  end,
+}
+love.filesystem = fs
+SaveData.loadOptions = function() return opts end
+
+local ok, err = xpcall(function()
+  local model = LauncherSettings.open()
+  local section
+  for _, candidate in ipairs(model.sections) do
+    if candidate.mod and candidate.mod.id == "launcher_fixture" then
+      section = candidate
+      break
+    end
+  end
+  check(section ~= nil, "Android launcher discovers a mod option schema")
+  check(#section.rows == 2 and section.rows[1].label == "MASTER",
+    "Android launcher omits hidden dependent rows initially")
+  section.rows[1].step(1)
+  local refreshed = model.refresh()
+  check(refreshed and #section.rows == 4
+    and section.rows[2].label == "DETAIL"
+    and section.rows[3].label == "NESTED",
+    "Android launcher reveals direct and nested dependencies live")
+  section.rows[2].step(-1)
+  check(model.refresh() and #section.rows == 3
+    and section.rows[2].label == "DETAIL",
+    "Android launcher hides a nested row when its default-true parent is off")
+  section.rows[1].step(-1)
+  check(model.refresh() and #section.rows == 2,
+    "Android launcher hides dependent rows after disabling the parent")
+end, debug.traceback)
+
+SaveData.loadOptions, love.filesystem = oldLoadOptions, oldFs
+if not ok then error(err, 0) end
+
+T.finish("launcher_settings_visibility")


### PR DESCRIPTION
## Summary

Fix selective hiding of dependent mod options on Android and Windows.

## What changed

- Centralized option-visibility evaluation so dependent options are evaluated against current settings.
- Preserved the launcher and mod-manager visibility behavior across platforms.
- Added a focused regression test covering visible, hidden, and chained dependent options.

## Root cause

The Android launcher path was not applying the same dependency visibility evaluation used by the other launcher path, so selectively hidden mod options remained visible.

## Validation

- Focused regression test: `tests/engine/launcher_settings_visibility_test.lua` — 5/5 checks passed.
- Revalidated the fix on the latest upstream changes.
- Built the Android APK and Windows win64 package from the latest upstream plus this fix.

## Tracking

Fixes #1263