### PR TITLE
fix(tests): make launcher_patch_notes resilient to release note wording changes

### DIFF
--- a/tests/engine/launcher_patch_notes.lua
+++ b/tests/engine/launcher_patch_notes.lua
@@ -62,7 +62,7 @@ end
 
 do
   local body, ver = PatchNotes.body(nil)
-  check(type(body) == "string" and body:find("Issues closed", 1, true),
+  check(type(body) == "string" and (body:find("Download", 1, true) or body:find("Issues", 1, true)),
     "without a check result PatchNotes uses the stashed iOS app-repo notes")
   check(type(ver) == "string" and ver:find("^%d+%.%d+%.%d+$") ~= nil,
     "stashed notes name a release version")


### PR DESCRIPTION
### Summary
Updates `tests/engine/launcher_patch_notes.lua` to check for generic release note content rather than expecting a strict `"Issues closed"` string match.

### Rationale
In release `0.1.85`, `app-repo.json` release notes contained contributor attributions without an `"Issues closed"` header section, causing `tests/engine/launcher_patch_notes.lua` to fail in CI. This update prevents release note updates from failing the ROM-free test suite in the future.