### PR TITLE
Fix/save editor lifecycle

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -166,6 +166,11 @@ function closeEditor()
     require("src.import.CacheFs").unmountVersion(version)
     require("src.core.Data"):unloadGenerated()
   end
+  for k in pairs(package.loaded) do
+    if type(k) == "string" and (k:find("save%-editor") or k == "App" or k == "Kit" or k == "State" or k == "Catalog" or k == "SaveIO" or k == "Ops" or k == "MonOps" or k == "ItemOps" or k == "PadInput" or k == "Gen" or k == "Theme") then
+      package.loaded[k] = nil
+    end
+  end
   editorVersion = nil
   restoreWindow()
   Importer = editorHost

--- a/src/core/Data.lua
+++ b/src/core/Data.lua
@@ -280,11 +280,14 @@ function Data:unloadGenerated()
       if not pristine[key] then self[key] = nil end
     end
   end
+  self._pristineKeys = nil
   for _, name in ipairs(MODULES) do
     package.loaded["data.generated." .. name] = nil
+    self[name] = nil
   end
   for _, name in ipairs(OPTIONAL) do
     package.loaded["data.generated." .. name] = nil
+    self[name] = nil
   end
 end
 

--- a/tools/save-editor/Catalog.lua
+++ b/tools/save-editor/Catalog.lua
@@ -40,10 +40,11 @@ end
 
 local function shellListLua(dir)
   local out = {}
+  if not (io and io.popen) then return out end
   if package.config:sub(1, 1) == "\\" then
     -- cmd has no ls; dir /b prints bare names, so re-attach the directory
-    local p = io.popen(string.format('dir /b "%s\\*.lua" 2>nul', dir))
-    if p then
+    local ok, p = pcall(io.popen, string.format('dir /b "%s\\*.lua" 2>nul', dir))
+    if ok and p then
       for line in p:lines() do
         if line ~= "" then table.insert(out, dir .. "/" .. line) end
       end
@@ -51,8 +52,8 @@ local function shellListLua(dir)
     end
     return out
   end
-  local p = io.popen(string.format('ls "%s"/*.lua 2>/dev/null', dir))
-  if p then
+  local ok, p = pcall(io.popen, string.format('ls "%s"/*.lua 2>/dev/null', dir))
+  if ok and p then
     for line in p:lines() do
       table.insert(out, line)
     end
@@ -64,8 +65,8 @@ end
 local function readText(path)
   local fs = love and love.filesystem
   if fs and fs.read and fs.getInfo and fs.getInfo(path) then
-    local body = fs.read(path)
-    if body then return body end
+    local ok, body = pcall(fs.read, path)
+    if ok and body then return body end
   end
   local f = io.open(path, "r")
   if not f then return nil end
@@ -78,7 +79,7 @@ end
 -- scripts show up beside the vanilla EVENT_ ones
 function Catalog.scrapeEvents(scriptDir, headerPath, listFiles, extraDirs)
   listFiles = listFiles or function(dir)
-    return loveListLua(dir) or shellListLua(dir)
+    return loveListLua(dir) or shellListLua(dir) or {}
   end
 
   local found = {}
@@ -97,7 +98,8 @@ function Catalog.scrapeEvents(scriptDir, headerPath, listFiles, extraDirs)
     dirs[#dirs + 1] = dir
   end
   for _, dir in ipairs(dirs) do
-    for _, path in ipairs(listFiles(dir)) do
+    local files = listFiles(dir) or {}
+    for _, path in ipairs(files) do
       local body = readText(path)
       if body then eat(body) end
     end


### PR DESCRIPTION
take a look at this in the morning after you sleep, those hooligans can wait.

basically, android wasn't liking how the save editor was switching and accessing stuff across contexts with the new Gold game support added:

Android Editor Crash (Catalog.lua): When opening the save editor on Android, it tried shelling out (io.popen) to scan data/scripts. Android threw a fit because terminal commands are restricted on mobile, returning nil and crashing ipairs on open. Wrapped io.popen in pcall and defaulted to {} so Android stays happy.
Editor State Leaking (main.lua & Data.lua): When swapping between save slots or closing and re-opening, the save editor modules and _pristineKeys stayed cached in package.loaded. Switching between RBY and Gold slots was carrying dirty state across contexts. closeEditor() now wipes the editor modules out of package.loaded and resets Data so every session gets a fresh clean slate.