### PR TITLE
Render WIDE battle HUD in window space

### DIFF
--- a/src/battle/WideBattle.lua
+++ b/src/battle/WideBattle.lua
@@ -92,6 +92,40 @@ local function levelAt(battle, battler, x, y)
   end
 end
 
+-- Move an already-rendered boxed HUD region out of the native 304x144 battle
+-- surface during the physical-window composite.  `windowHUD = false` is a
+-- deliberately battle-local escape hatch for screenshot A/B drivers; normal
+-- WIDE battles use the window layout.  The ordinary UI anchor gate remains
+-- held, so battle-owned TextBox / ChoiceBox states do not move with these.
+local function battleIsTopState(battle)
+  local stack = battle.game and battle.game.stack
+  return not (stack and stack.top) or stack:top() == battle
+end
+
+local function anchorHUD(battle, x, y, w, h, anchor)
+  if battle.windowHUD == false then return end
+  -- Full-screen battle overlays own the UI above the still-running arena.
+  -- Since the detached HUD canvas is normally composited last, registering
+  -- these regions while NamingScreen/ListMenu/PartyMenu/BagMenu is topmost
+  -- would incorrectly place status panels in front of that newer screen.
+  if not battleIsTopState(battle) then return end
+  local renderer = battle.game and battle.game.renderer
+  if renderer and renderer.setBattleUIAnchor then
+    -- Screen-shake translation is active while the HUD draws.  Capture the
+    -- pixels where they actually landed, intersected with the same native
+    -- canvas edge that clipped the legacy composition.
+    x = x + (battle.windowHUDOffsetX or 0)
+    y = y + (battle.windowHUDOffsetY or 0)
+    local x2 = math.min(WideBattle.WIDTH, x + w)
+    local y2 = math.min(WideBattle.HEIGHT, y + h)
+    x, y = math.max(0, x), math.max(0, y)
+    w, h = x2 - x, y2 - y
+    if w > 0 and h > 0 then
+      renderer:setBattleUIAnchor(x, y, w, h, anchor)
+    end
+  end
+end
+
 -- One side's status box: name and level on the first line, a long HP bar
 -- under it, and the numeric HP on the player's box only (the foe's exact
 -- HP is never shown, like the original).
@@ -114,6 +148,8 @@ local function drawStatusPanel(battle, battler, x, y, player)
     Font.draw(("%3d/%3d"):format(shownHP(battler), battler.mon.stats.hp),
       x + tw * 8 - 64, y + 24)
   end
+  anchorHUD(battle, x, y, tw * 8, th * 8,
+            player and "bottomright" or "topleft")
 end
 
 -- the party ball rows DrawAllPokeballs puts up with the intro text, moved
@@ -144,7 +180,6 @@ local function drawHUDs(battle, slide)
       and not battle.showPlayerBack and slide == 0 then
     drawStatusPanel(battle, battle.player, 184, 56, true)
   end
-  drawIntroBalls(battle)
 end
 
 local function drawMessageBox(battle)
@@ -268,6 +303,15 @@ local function drawTextArea(battle)
   else
     Font.drawBox(0, 13, 38, 5)
   end
+  -- A transparent TextBox / ChoiceBox pushed above the battle starts at the
+  -- classic y=96, while this strip starts at y=104.  Moving only this crop
+  -- would tear that overlay across two coordinate spaces.  Leave the strip in
+  -- the native composition until the battle itself owns the top of the stack.
+  if battleIsTopState(battle) then
+    anchorHUD(battle, 0, WideBattle.FIELD_BOTTOM,
+              WideBattle.WIDTH, WideBattle.HEIGHT - WideBattle.FIELD_BOTTOM,
+              "bottom")
+  end
 end
 
 -- Battle animations are authored in the original 160px coordinate space.
@@ -309,17 +353,29 @@ end
 -- The whole 304x144 composition for one frame.
 function WideBattle.draw(battle)
   local g = love.graphics
+  local renderer = battle.game and battle.game.renderer
+  local windowHUD = battle.windowHUD ~= false and renderer
+                    and renderer.beginBattleHUDPass
+                    and renderer.endBattleHUDPass
   -- The field is the display mode's paper.  Under a forced-mono mode the
   -- whole surface is remapped downstream (WideBattle.zones), so the field
   -- goes down as DMG white and comes out of that pass as the mode's paper;
   -- painting the resolved shade there would run it through the remap twice
   -- and land a shade off the letterbox the renderer fills around it.
-  if monoMode() then
-    g.setColor(1, 1, 1, 1)
+  local transparentField = windowHUD and not battle.blankForAskName
+                           and battle.bgMode and battle:bgMode() == "world"
+  if transparentField then
+    -- The world/voxel pass is already underneath this canvas.  Leaving its
+    -- field transparent is what lets that scene occupy the native battle
+    -- rectangle as well as the physical-window margins.
   else
-    g.setColor(PaletteFX.paperShade(battle.data))
+    if monoMode() then
+      g.setColor(1, 1, 1, 1)
+    else
+      g.setColor(PaletteFX.paperShade(battle.data))
+    end
+    g.rectangle("fill", 0, 0, WideBattle.WIDTH, WideBattle.HEIGHT)
   end
-  g.rectangle("fill", 0, 0, WideBattle.WIDTH, WideBattle.HEIGHT)
   -- AskName clears the field the same way the classic layout does
   if battle.blankForAskName then return end
 
@@ -346,6 +402,7 @@ function WideBattle.draw(battle)
   inRegion(160 + sx, sy, 144, WideBattle.FIELD_BOTTOM, 136 + sx, sy,
     function() battle:drawPicsLayer(slide, 0, 0, "enemy", true) end)
   battle.wideRegion = nil
+  drawIntroBalls(battle)
 
   -- A battle sets rWY to 0 (engine/battle/core.asm), so the window the
   -- shakes move IS the whole screen: PredefShakeScreenHorizontally,
@@ -359,12 +416,26 @@ function WideBattle.draw(battle)
     if sx == 0 and sy == 0 then return fn() end
     g.push()
     g.translate(sx, sy)
+    battle.windowHUDOffsetX, battle.windowHUDOffsetY = sx, sy
     fn()
+    battle.windowHUDOffsetX, battle.windowHUDOffsetY = nil, nil
     g.pop()
   end
-  shaken(function() drawHUDs(battle, slide) end)
   drawAnimationLayer(battle)
-  shaken(function() drawTextArea(battle) end)
+
+  if windowHUD then
+    local previous = renderer:beginBattleHUDPass()
+    shaken(function() drawHUDs(battle, slide) end)
+    shaken(function() drawTextArea(battle) end)
+    if fx and fx.flash and fx.flash > 0 and battle.frame % 4 < 2 then
+      g.setColor(1, 1, 1, 0.85)
+      g.rectangle("fill", 0, 0, WideBattle.WIDTH, WideBattle.HEIGHT)
+    end
+    renderer:endBattleHUDPass(previous)
+  else
+    shaken(function() drawHUDs(battle, slide) end)
+    shaken(function() drawTextArea(battle) end)
+  end
 
   if fx and fx.flash and fx.flash > 0 and battle.frame % 4 < 2 then
     g.setColor(1, 1, 1, 0.85)

--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -403,13 +403,13 @@ function Game.uiAnchorsHeldInStack(stack)
 end
 
 -- Where Game:draw starts drawing this frame.  Normally the topmost opaque
--- state (StateStack:visibleBase) -- but BATTLE BG "world" composes the battle
--- over the LIVE map, and an opaque state pushed on top of it (the party menu,
--- the bag) becomes that base, cutting the overworld -- and with it the world
--- pass -- out of the frame entirely.  The backdrop the battle established
--- then collapses to endFrame's flat black clear for as long as the menu is
--- up.  So a world-bg battle keeps the frame starting from underneath itself
--- until it leaves the stack, the same hold uiFill and the dim already use.
+-- state (StateStack:visibleBase) -- but an opaque menu pushed over a WIDE
+-- battle must not prevent that battle from drawing.  Native WIDE battles own
+-- the 304x144 surround around a centred classic menu, while external arena
+-- providers establish their window-sized scene from BattleState:draw.  If the
+-- menu becomes the draw base, neither owner runs and the menu's white field
+-- replaces the whole presentation.  BATTLE BG "world" additionally needs the
+-- overworld below the battle, as before.
 --
 -- Only the START of the draw moves.  The clear stays keyed to the real
 -- visibleBase, so the menu still gets its opaque canvas and draws exactly as
@@ -420,9 +420,13 @@ function Game.drawBaseInStack(stack, visibleBase)
   local states = stack and stack.states or {}
   for i = visibleBase - 1, 1, -1 do
     local state = states[i]
-    if state and state.bgMode and state:bgMode() == "world" then
+    local worldBattle = state and state.bgMode and state:bgMode() == "world"
+    local wideBattle = state and state.isWideBattleLayout
+      and state:isWideBattleLayout()
+    if worldBattle or wideBattle then
       -- restart the search from under the battle: the highest opaque state at
-      -- or below it (the overworld), not the menu sitting over it
+      -- or below it (the battle itself for white/black WIDE, the overworld for
+      -- a non-opaque world-backed battle), not the menu sitting over it
       for j = i, 1, -1 do
         if states[j].isOpaque then return j end
       end
@@ -430,6 +434,17 @@ function Game.drawBaseInStack(stack, visibleBase)
     end
   end
   return visibleBase
+end
+
+-- Whether this frame's UI canvas must preserve transparency for the world
+-- pass below it.  Usually visibleBase answers that directly.  A classic
+-- opaque menu over a world-backed WIDE battle is the exception: the menu
+-- paints its own centred 160x144 field, while the owning 304x144 surface's
+-- side margins must remain transparent.  Clearing that wider owner white
+-- turns the old-man/Oak item list (and every similar battle overlay) into a
+-- full-window white sheet.
+function Game.uiCanvasTransparent(worldBelow, worldDrawn, wideBattle)
+  return worldBelow or (worldDrawn and wideBattle ~= nil)
 end
 
 -- Shift classic SGB zones to the centred UI. A full-width base zone extends
@@ -502,7 +517,8 @@ function Game:draw()
   -- menu to its top right, and the whole UI steps down with the zoom.
   Renderer.uiCentered = not Game.dynamicUI(self.save)
   Renderer.uiAnchorHold = Game.uiAnchorsHeldInStack(self.stack)
-  Renderer:beginFrame(worldBelow)
+  Renderer:beginFrame(Game.uiCanvasTransparent(
+    worldBelow, worldDrawn, wideBattle))
   for i = drawFrom, #self.stack.states do
     local state = self.stack.states[i]
     local wideState = state and state.isWideBattleLayout

--- a/src/render/Renderer.lua
+++ b/src/render/Renderer.lua
@@ -94,6 +94,7 @@ function Renderer:init()
   -- reason -- worldViewSize() already works in drawable pixels.
   self.uiWidth, self.uiHeight = self.WIDTH, self.HEIGHT
   self.canvas = PixelCanvas.new(self.uiWidth, self.uiHeight, "nearest")
+  self.battleHUDCanvas = nil
   self.worldCanvas = nil
   self.worldActive = false
   -- tilt mode only: a transparent overlay canvas the size of the world
@@ -202,8 +203,37 @@ function Renderer:setUISize(w, h)
   w, h = math.floor(w), math.floor(h)
   if w == self.uiWidth and h == self.uiHeight and self.canvas then return end
   if self.canvas and self.canvas.release then self.canvas:release() end
+  if self.battleHUDCanvas and self.battleHUDCanvas.release then
+    self.battleHUDCanvas:release()
+  end
+  self.battleHUDCanvas = nil
   self.uiWidth, self.uiHeight = w, h
   self.canvas = PixelCanvas.new(w, h, "nearest")
+end
+
+-- Transparent native-pixel layer for WIDE battle furniture.  WideBattle
+-- draws its existing status/menu functions here exactly once, then endFrame
+-- places their registered rectangles in physical-window space.  Keeping this
+-- separate from `canvas` avoids cutting HUD-shaped holes out of an already
+-- flattened white battle composition.
+function Renderer:beginBattleHUDPass()
+  local w, h = self:uiSize()
+  if not self.battleHUDCanvas
+     or self.battleHUDCanvas:getWidth() ~= w
+     or self.battleHUDCanvas:getHeight() ~= h then
+    if self.battleHUDCanvas and self.battleHUDCanvas.release then
+      self.battleHUDCanvas:release()
+    end
+    self.battleHUDCanvas = PixelCanvas.new(w, h, "nearest")
+  end
+  local previous = love.graphics.getCanvas and love.graphics.getCanvas() or self.canvas
+  love.graphics.setCanvas(self.battleHUDCanvas)
+  love.graphics.clear(0, 0, 0, 0)
+  return previous
+end
+
+function Renderer:endBattleHUDPass(previous)
+  love.graphics.setCanvas(previous or self.canvas)
 end
 
 -- LOVE-unit draw scales endFrame uses for the UI blit: integer framebuffer
@@ -671,6 +701,17 @@ end
 -- centred letterbox.  Declared during the element's own draw, in UI-canvas
 -- pixels, and consumed by endFrame this frame only.
 --   anchor: "bottom" | "topright" | "topleft" | "bottomright"
+local function addUIAnchor(renderer, x, y, w, h, anchor, windowClamped,
+                           canvas, extract)
+  renderer.uiAnchors = renderer.uiAnchors or {}
+  renderer.uiAnchors[#renderer.uiAnchors + 1] = {
+    x = x, y = y, w = w, h = h, anchor = anchor,
+    windowClamped = windowClamped and true or false,
+    canvas = canvas,
+    extract = extract ~= false,
+  }
+end
+
 function Renderer:setUIAnchor(x, y, w, h, anchor)
   -- UI LAYOUT = CENTERED (uiCentered, set per frame by Game:draw from
   -- save.options.uiLayout): every element stays where it was drawn in the
@@ -684,9 +725,17 @@ function Renderer:setUIAnchor(x, y, w, h, anchor)
   -- battle -- keeps every element inside it, so the box blits where it was
   -- drawn in the canvas instead of being pulled to the window edge.
   if self.uiAnchorHold then return end
-  self.uiAnchors = self.uiAnchors or {}
-  self.uiAnchors[#self.uiAnchors + 1] =
-    { x = x, y = y, w = w, h = h, anchor = anchor }
+  addUIAnchor(self, x, y, w, h, anchor, false, self.canvas, true)
+end
+
+-- WIDE battle HUD regions are already complete, palette-correct pixels in the
+-- battle canvas.  Register one for the window compositor without opening the
+-- normal UI-anchor gate: BattleState intentionally holds TextBox, ChoiceBox
+-- and menu anchors inside its screen, and that contract must remain intact.
+-- Only WideBattle calls this seam, with exact opaque HUD rectangles.
+function Renderer:setBattleUIAnchor(x, y, w, h, anchor)
+  addUIAnchor(self, x, y, w, h, anchor, true,
+              self.battleHUDCanvas or self.canvas, false)
 end
 
 -- zones: optional list of SGB palette regions (see PaletteFX) in
@@ -1000,11 +1049,27 @@ function Renderer:endFrame(zones, worldZones)
       elseif a.anchor == "topright" then
         dx = ww - gapR - dw
         dy = a.y * Uy
+      elseif a.anchor == "topleft" then
+        dx = a.x * Ux
+        dy = a.y * Uy
+      elseif a.anchor == "bottomright" then
+        dx = ww - gapR - dw
+        dy = wh - gapB - dh
       else -- unknown anchor: leave it where it is
         dx, dy = uox + a.x * Ux, uoy + a.y * Uy
       end
+      -- Battle HUD regions deliberately leave the native battle rectangle,
+      -- but never the physical window.  When a pathological tiny window is
+      -- smaller than a region, pin its near edge at zero and let the existing
+      -- framebuffer clip make the unavoidable cut.
+      if a.windowClamped then
+        dx = math.max(0, math.min(math.max(0, ww - dw), dx))
+        dy = math.max(0, math.min(math.max(0, wh - dh), dy))
+      end
       placed[#placed + 1] = { a = a, dx = dx, dy = dy, dw = dw, dh = dh }
-      rest = subtractRect(rest, uox + a.x * Ux, uoy + a.y * Uy, dw, dh)
+      if a.extract then
+        rest = subtractRect(rest, uox + a.x * Ux, uoy + a.y * Uy, dw, dh)
+      end
     end
     for _, r in ipairs(rest) do
       blit(self.canvas, Ux, Uy, zones, Ux, Uy, uox, uoy, r[1], r[2], r[3], r[4])
@@ -1013,7 +1078,7 @@ function Renderer:endFrame(zones, worldZones)
       -- shift the draw origin so canvas pixel (a.x, a.y) lands on (dx, dy).
       -- The zone scissors are computed from the same origin, so an SGB
       -- region travels with the element instead of staying in the letterbox.
-      blit(self.canvas, Ux, Uy, zones, Ux, Uy,
+      blit(p.a.canvas or self.canvas, Ux, Uy, zones, Ux, Uy,
            p.dx - p.a.x * Ux, p.dy - p.a.y * Uy, p.dx, p.dy, p.dw, p.dh)
     end
   end

--- a/tests/drivers/wide_battle_window_hud_test.lua
+++ b/tests/drivers/wide_battle_window_hud_test.lua
@@ -1,0 +1,127 @@
+-- Visual proof for WIDE battle HUD regions composited in physical-window
+-- space.  Captures the same deterministic battle with the legacy in-canvas
+-- placement and the new window placement.  Every capture uses BATTLE SIZE =
+-- FILL so the proof matches the target configuration.
+--
+--   POKEPORT_DRIVER=tests/drivers/wide_battle_window_hud_test.lua \
+--     POKEPORT_IDENTITY=wide-window-hud POKEPORT_TOUCH=0 \
+--     SHOT_DIR=/tmp/shots love .
+return function(game)
+  local U = dofile("tests/drivers/util.lua")
+  local DIR = os.getenv("SHOT_DIR") or "/tmp/shots"
+  local BattleState = require("src.battle.BattleState")
+  local Pokemon = require("src.pokemon.Pokemon")
+
+  -- Exercise the real desktop-sized margins instead of a synthetic test
+  -- window.  The game keeps its native-pixel FILL scaling inside this mode.
+  love.window.setFullscreen(true, "desktop")
+  U.wait(30)
+
+  game.save.options.battleLayout = "wide"
+  game.save.options.battleBg = "world"
+  game.save.options.battleFit = "fill"
+  game.save.party = { Pokemon.new(game.data, "MEW", 50) }
+  U.teleport(game, "ROUTE_1", 5, 5, "down")
+  U.wait(60)
+
+  local battle = BattleState.newWild(game, "PIDGEY", 20,
+    { onFinish = function() end })
+  game.overworld:pushBattle(battle)
+  U.wait(360)
+
+  -- Pin the command screen so every capture compares identical battle state.
+  battle.introSlide = 0
+  battle.introBalls = nil
+  battle.showEnemyTrainer = false
+  battle.showPlayerBack = false
+  battle.enemySendingOut = false
+  battle.sendingOut = false
+  battle.phase = "menu"
+  battle.menuIndex = 1
+
+  battle.windowHUD = false
+  U.wait(3)
+  U.shot(game, DIR .. "/wide_window_hud_0_legacy_fill.png")
+
+  battle.windowHUD = true
+  U.wait(3)
+  U.shot(game, DIR .. "/wide_window_hud_1_window_fill.png")
+
+  battle.phase = "moveSelect"
+  battle.moveIndex = 1
+  U.wait(3)
+  U.shot(game, DIR .. "/wide_window_hud_2_moves_fill.png")
+
+  battle.phase = "messages"
+  battle:startMessage({ text = "WIDE HUD IN WINDOW SPACE" })
+  U.wait(3)
+  U.shot(game, DIR .. "/wide_window_hud_3_message_fill.png")
+
+  -- Oak/old-man catch tutorials and ordinary battle ITEM actions push this
+  -- opaque 160x144 list above the WIDE battle.  Its own field stays centred;
+  -- the unused 304px owner margins must keep showing the world instead of
+  -- becoming one full-window white clear.
+  battle.phase = "menu"
+  battle.current = nil
+  -- Exercise the provider-backed case that exposed the real regression:
+  -- the WIDE battle must still draw under this overlay even when BATTLE BG
+  -- is not "world".  A deterministic window-sized surface stands in for the
+  -- Dramaless/Stadium world override, and the wrapper below suppresses the
+  -- native paper field exactly as those providers do.  If BattleState:draw
+  -- is skipped, this surface is never presented and the screenshot goes all
+  -- white again.
+  game.save.options.battleBg = "black"
+  local g = love.graphics
+  local ww, wh = g.getDimensions()
+  local provider = g.newCanvas(ww, wh)
+  local previous = g.getCanvas()
+  g.setCanvas(provider)
+  g.clear(0.10, 0.12, 0.14, 1)
+  g.setColor(0.18, 0.24, 0.20, 1)
+  for x = 0, ww, 96 do g.rectangle("fill", x, 0, 48, wh) end
+  g.setColor(0.28, 0.34, 0.30, 1)
+  g.rectangle("fill", 0, wh * 0.58, ww, wh * 0.42)
+  g.setColor(1, 1, 1, 1)
+  g.setCanvas(previous)
+
+  local nativeDraw = battle.draw
+  battle.draw = function(self)
+    self.game.renderer:setWorldOverride(provider)
+    g.clear(0, 0, 0, 0)
+    local rectangle = g.rectangle
+    local fieldSuppressed = false
+    g.rectangle = function(mode, x, y, w, h, ...)
+      if not fieldSuppressed and mode == "fill"
+          and x == 0 and y == 0 and w == 304 and h == 144 then
+        fieldSuppressed = true
+        return
+      end
+      return rectangle(mode, x, y, w, h, ...)
+    end
+    local ok, result = pcall(nativeDraw, self)
+    g.rectangle = rectangle
+    if not ok then error(result, 0) end
+    return result
+  end
+  local ListMenu = require("src.ui.ListMenu")
+  game.stack:push(ListMenu.new(game, "ITEMS", {
+    { value = "POKE_BALL", label = "POKé BALL", right = "x1" },
+  }, { script = function() end }))
+  U.wait(3)
+  U.shot(game, DIR .. "/wide_window_hud_4_item_overlay_fill.png")
+
+  -- Captured-mon nickname entry is another opaque classic screen.  It must
+  -- own the whole UI layer: the detached foe/player panels may not be
+  -- composited afterward over its letter grid.
+  game.stack:pop()
+  local NamingScreen = require("src.ui.NamingScreen")
+  game.stack:push(NamingScreen.new(game, {
+    title = "NICKNAME?", maxLen = 10, onDone = function() end,
+  }))
+  U.wait(3)
+  U.shot(game, DIR .. "/wide_window_hud_5_nickname_overlay_fill.png")
+
+  U.log("WIDE window-HUD proof captured in " .. DIR)
+  U.log("0 is the legacy 304x144 composition; 1-5 use physical-window HUD regions")
+  while true do coroutine.yield() end
+end

--- a/tests/engine/battle_fixed_menu_scale.lua
+++ b/tests/engine/battle_fixed_menu_scale.lua
@@ -92,6 +92,11 @@ local menu = { isOpaque = true } -- PartyMenu / ListMenu
 local whiteBattle = setmetatable(
   { game = { save = { options = { battleBg = "white" } } } },
   { __index = BattleState })
+local wideWhiteBattle = setmetatable(
+  { game = { save = { options = {
+      battleBg = "white", battleLayout = "wide",
+  } } } },
+  { __index = BattleState })
 local function stack(...) return { states = { ... },
   visibleBase = function(self)
     for i = #self.states, 1, -1 do
@@ -111,12 +116,28 @@ T.eq(s2:visibleBase(), 1, "the battle alone already drew from the overworld")
 T.eq(Game.drawBaseInStack(s2, s2:visibleBase()), 1, "and still does")
 local s3 = stack(overworld, whiteBattle, menu)
 T.eq(Game.drawBaseInStack(s3, s3:visibleBase()), 3,
-  "a white-bg battle has no map to hold, so nothing moves")
+  "a classic white-bg battle has no presentation to hold, so nothing moves")
+local s3wide = stack(overworld, wideWhiteBattle, menu)
+T.eq(Game.drawBaseInStack(s3wide, s3wide:visibleBase()), 2,
+  "an opaque WIDE battle still draws beneath its classic menu")
 local s4 = stack(overworld, menu)
 T.eq(Game.drawBaseInStack(s4, s4:visibleBase()), 2,
   "and a menu outside a battle is untouched")
 T.eq(Game.drawBaseInStack(stack(overworld), 1), 1, "a lone base is safe")
 T.eq(Game.drawBaseInStack(nil, 1), 1, "and so is no stack at all")
+
+-- An opaque classic menu paints only its own centred 160x144 field.  When a
+-- WIDE world-backed battle keeps the 304x144 owner surface underneath it,
+-- that owner's unused margins must remain transparent instead of inheriting
+-- beginFrame's white opaque clear.
+T.eq(Game.uiCanvasTransparent(true, true, nil), true,
+  "the ordinary overworld UI canvas remains transparent")
+T.eq(Game.uiCanvasTransparent(false, true, worldBattle), true,
+  "a classic menu over a world-backed WIDE battle preserves transparent margins")
+T.eq(Game.uiCanvasTransparent(false, true, nil), false,
+  "a classic world battle keeps its ordinary opaque full-screen menu")
+T.eq(Game.uiCanvasTransparent(false, false, worldBattle), false,
+  "a WIDE battle without a world pass keeps its opaque backdrop")
 
 -- ------------------------------------------- the YES/NO stays with its screen
 

--- a/tests/engine/wide_battle_layout.lua
+++ b/tests/engine/wide_battle_layout.lua
@@ -61,4 +61,76 @@ Renderer:setUISize(99999, 99999)
 T.eq(select(1, Renderer:uiSize()), 160, "an oversized surface falls back")
 Renderer:setUISize(160, 144)
 
+-- The WIDE HUD uses a dedicated registration path.  It must bypass the two
+-- gates that continue to hold ordinary battle TextBox / ChoiceBox anchors,
+-- without weakening those gates globally.
+Renderer.uiAnchors = nil
+Renderer.uiCentered = true
+Renderer.uiAnchorHold = true
+Renderer:setUIAnchor(0, 104, 304, 40, "bottom")
+T.eq(Renderer.uiAnchors, nil,
+  "ordinary UI anchors remain held inside a battle")
+Renderer:setBattleUIAnchor(0, 104, 304, 40, "bottom")
+T.eq(#(Renderer.uiAnchors or {}), 1,
+  "the dedicated WIDE HUD region reaches the window compositor")
+T.eq(Renderer.uiAnchors[1].windowClamped, true,
+  "a battle HUD region is constrained to the physical window")
+T.eq(Renderer.uiAnchors[1].extract, false,
+  "a battle HUD region does not cut a hole in the main battle canvas")
+Renderer.uiAnchors = nil
+Renderer.uiCentered = false
+Renderer.uiAnchorHold = false
+
+-- The actual WIDE path draws those regions into a transparent layer and
+-- restores the main battle canvas before the frame compositor runs.
+local mainCanvas = Renderer.canvas
+local previous = Renderer:beginBattleHUDPass()
+T.eq(previous, mainCanvas, "the HUD pass remembers the battle canvas")
+T.check(Renderer.battleHUDCanvas ~= mainCanvas,
+  "the HUD pass owns a separate transparent canvas")
+T.eq(love.graphics.getCanvas(), Renderer.battleHUDCanvas,
+  "HUD drawing is redirected to the transparent canvas")
+Renderer:endBattleHUDPass(previous)
+T.eq(love.graphics.getCanvas(), mainCanvas,
+  "ending the HUD pass restores the battle canvas")
+
+-- At a 1000x700 window the 304x144 surface fits at 3x, centred at (44,134).
+-- Pin the exact draw origins of all three extracted regions: these are real
+-- physical-window coordinates, not points outside the source canvas.
+local g = love.graphics
+local realDims, realPixelDims, realDraw =
+  g.getDimensions, g.getPixelDimensions, g.draw
+g.getDimensions = function() return 1000, 700 end
+g.getPixelDimensions = function() return 1000, 700 end
+local draws = {}
+g.draw = function(canvas, x, y, rotation, sx, sy)
+  if canvas == Renderer.canvas then
+    draws[#draws + 1] = { x = x, y = y, sx = sx, sy = sy }
+  end
+end
+Renderer:setUISize(WideBattle.WIDTH, WideBattle.HEIGHT)
+Renderer.uiCentered, Renderer.uiFill = true, false
+Renderer:beginFrame(false)
+Renderer:setBattleUIAnchor(0, 0, 128, 32, "topleft")
+Renderer:setBattleUIAnchor(184, 56, 120, 40, "bottomright")
+Renderer:setBattleUIAnchor(0, 104, 304, 40, "bottom")
+Renderer:endFrame(WideBattle.zones(), nil)
+
+local function sawOrigin(x, y)
+  for _, d in ipairs(draws) do
+    if d.x == x and d.y == y and d.sx == 3 and d.sy == 3 then return true end
+  end
+  return false
+end
+T.check(sawOrigin(0, 0), "the foe panel is composited at the physical top-left")
+T.check(sawOrigin(88, 268),
+  "the player panel keeps its lower-right gaps in window space")
+T.check(sawOrigin(44, 268),
+  "the full-width bottom strip is composited against the window bottom")
+
+g.getDimensions, g.getPixelDimensions, g.draw = realDims, realPixelDims, realDraw
+Renderer:setUISize(160, 144)
+Renderer.uiAnchors = nil
+Renderer.uiCentered, Renderer.uiFill = false, false
+
 T.finish("wide battle layout")

--- a/tests/engine/wide_battle_shake_bug562.lua
+++ b/tests/engine/wide_battle_shake_bug562.lua
@@ -28,7 +28,7 @@ local HudTiles = require("src.render.HudTiles")
 local g = love.graphics
 local realPush, realPop = g.push, g.pop
 local tx, ty, stack = 0, 0, {}
-local scissors, marks
+local scissors, marks, anchors
 
 g.push = function(...) stack[#stack + 1] = { tx, ty }; realPush(...) end
 g.pop = function()
@@ -57,6 +57,12 @@ HudTiles.drawHPBar = function() mark("hpbar") end
 -- question: are the two pic regions and everything else moving as one?
 local function battleWith(fx, sprites)
   return {
+    game = { renderer = {
+      setBattleUIAnchor = function(_, x, y, w, h, anchor)
+        anchors[#anchors + 1] =
+          { x = x, y = y, w = w, h = h, anchor = anchor }
+      end,
+    } },
     data = {},
     frame = 0,
     phase = "messages",
@@ -80,11 +86,15 @@ local function battleWith(fx, sprites)
   }
 end
 
-local function draw(fx, sprites)
+local function draw(fx, sprites, overlay)
   tx, ty, stack = 0, 0, {}
-  scissors, marks = {}, {}
-  WideBattle.draw(battleWith(fx, sprites))
-  return scissors, marks
+  scissors, marks, anchors = {}, {}, {}
+  local battle = battleWith(fx, sprites)
+  if overlay then
+    battle.game.stack = { top = function() return overlay end }
+  end
+  WideBattle.draw(battle)
+  return scissors, marks, anchors
 end
 
 local function marksNamed(list, name)
@@ -119,7 +129,7 @@ end
 -- The baseline the shaken frames are measured against: the player's 160x144
 -- region is inset 32px from the top of the wider field, the enemy's starts at
 -- x=160, and both draw their classic-space pics at the wide anchors.
-local s, m = draw(nil)
+local s, m, a = draw(nil)
 T.eq(s[1].x, 0, "unshaken, the player region clips from the left edge")
 T.eq(s[1].y, 32, "unshaken, the player region starts below the foe's HUD")
 T.eq(s[2].x, 160, "unshaken, the enemy region clips from the halfway mark")
@@ -130,25 +140,37 @@ T.eq(pics[1].tx, 20, "unshaken, the player pic sits on the player anchor")
 T.eq(pics[1].ty, 8, "unshaken, the player pic sits on the player baseline")
 T.eq(pics[2].tx, 136, "unshaken, the enemy pic sits on the enemy anchor")
 everythingAt(m, 0, 0, "no shake")
+T.eq(#a, 3, "the two status boxes and bottom strip register for window placement")
+T.eq(a[1].anchor, "topleft", "the foe status box uses the top window edge")
+T.eq(a[2].anchor, "bottomright", "the player status box uses the lower-right edge")
+T.eq(a[3].anchor, "bottom", "the message/menu strip uses the bottom window edge")
+T.eq(a[3].y, WideBattle.FIELD_BOTTOM,
+  "the bottom strip begins at the wide battlefield boundary")
+local _, _, overlayAnchors = draw(nil, nil, {})
+T.eq(#overlayAnchors, 0,
+  "a pushed battle overlay stays in front of every detached HUD region")
 
 -- -------------------------------------------------- horizontal shake (#562)
 -- TAIL WHIP is wAnimationType 6, AnimationShakeScreenHorizontallySlow b=3:
 -- the screen creeps out to 3px and back, twice, in silence.  Before the fix
 -- the two pic regions took the 3px and drawHUDs / drawTextArea did not, so
 -- the foe glided sideways over a stationary HUD and message box.
-s, m = draw({ shakeX = 3, shakeY = 0 })
+s, m, a = draw({ shakeX = 3, shakeY = 0 })
 T.eq(s[1].x, 3, "a horizontal shake carries the player region's clip with it")
 T.eq(s[2].x, 163, "...and the enemy region's")
 pics = marksNamed(m, "pics")
 T.eq(pics[1].tx, 23, "the player pic rides the shake")
 T.eq(pics[2].tx, 139, "the enemy pic rides the shake")
 everythingAt(m, 3, 0, "3px horizontal shake")
+T.eq(a[1].x, 3, "window HUD capture follows a horizontal screen shake")
+T.eq(a[3].w, WideBattle.WIDTH - 3,
+  "its source crop keeps the native canvas edge clipping")
 
 -- ---------------------------------------------------- vertical shake (#562)
 -- wAnimationType 1 (PredefShakeScreenVertically b=8) drops the whole window.
 -- The region rects move with their contents, so a pic pushed toward
 -- FIELD_BOTTOM is not sheared off its own window edge on the way down.
-s, m = draw({ shakeX = 0, shakeY = 8 })
+s, m, a = draw({ shakeX = 0, shakeY = 8 })
 T.eq(s[1].y, 40, "a vertical shake carries the player region's clip down")
 T.eq(s[1].h, WideBattle.FIELD_BOTTOM - 32,
   "the player region keeps its height, so the pic is not cropped short")
@@ -156,6 +178,9 @@ T.eq(s[2].y, 8, "the enemy region's clip drops the same 8px")
 pics = marksNamed(m, "pics")
 T.eq(pics[1].ty, 16, "the player pic drops with it")
 everythingAt(m, 0, 8, "8px vertical shake")
+T.eq(a[1].y, 8, "window HUD capture follows a vertical screen shake")
+T.eq(a[3].h, WideBattle.HEIGHT - WideBattle.FIELD_BOTTOM - 8,
+  "the shaken bottom strip is clipped at the native canvas edge")
 
 -- --------------------------------------------------- the animations-off path
 -- With ANIMATION = OFF an extracted anim that carries a shake flag falls back


### PR DESCRIPTION
## Summary

Render the existing WIDE battle HUD in physical window space instead of constraining it to the native 304×144 battle surface.

This allows status panels, command boxes, move selection, and message boxes to use the visible window area surrounding the battle scene without changing the existing HUD design or battle logic.

## What changed

- Add a transparent battle HUD layer separate from the native battle composition
- Composite WIDE status panels and battle boxes against the physical window edges
- Keep HUD elements inside the physical window at small window sizes
- Preserve battle shake, palettes, HP bars, text, menus, animations, and input behavior
- Preserve existing menu and overlay stacking
- Keep classic battle layout behavior unchanged

## Root cause

The WIDE battle scene and Gen 1 HUD were flattened into the same 304×144 canvas before that canvas was scaled into the application window. Once flattened, the compositor could not position HUD regions beyond the native battle surface.

The HUD is now drawn into a separate transparent native-pixel layer and placed during the final window composite.

## Compatibility

The new window-space HUD path is limited to `BATTLE LAYOUT = WIDE`.

Classic battle layouts and normal screen-space UI anchoring remain unchanged. The implementation was also tested with Dramaless Shape and Stadium Battle FX enabled.

## Validation

- `battle_fixed_menu_scale.lua`: 32/32
- `ui_layout_option.lua`: 20/20
- `wide_battle_layout.lua`: 33/33
- `wide_battle_shake_bug562.lua`: 40/40
- `battle_fit_option.lua`: 28/28
- Total: 153/153 focused checks passed
- Repeatable fullscreen screenshots captured using `POKEPORT_DRIVER`
- Automated screenshot configuration uses `BATTLE SIZE = FILL`
- FIXED screenshots captured manually with Dramaless Shape and Stadium Battle FX

## Screenshots

### BATTLE SIZE = FILL

#### Before: HUD constrained to the native battle composition

![Before: HUD constrained to the native battle composition](https://raw.githubusercontent.com/syybott/gen1recomp/pr-assets-wide-battle-window-hud/pr-assets/wide_window_hud_0_legacy_fill.png)

#### After: HUD positioned in physical window space

![After: BATTLE SIZE = FILL](https://raw.githubusercontent.com/syybott/gen1recomp/pr-assets-wide-battle-window-hud/pr-assets/wide_window_hud_1_window_fill.png)

### BATTLE SIZE = FIXED

#### Before: HUD constrained to the native battle composition

![Before: BATTLE SIZE = FIXED with Dramaless Shape and Stadium Battle FX](https://raw.githubusercontent.com/syybott/gen1recomp/pr-assets-wide-battle-window-hud/pr-assets/wide_window_hud_fixed_before_modded.png)

#### After: HUD positioned in physical window space

![After: BATTLE SIZE = FIXED with Dramaless Shape and Stadium Battle FX](https://raw.githubusercontent.com/syybott/gen1recomp/pr-assets-wide-battle-window-hud/pr-assets/wide_window_hud_fixed_modded.png)
