### PR TITLE
Add modern type chart gallery mod

### DIFF
--- a/mods/examples/modern_type_chart/.modkitignore
+++ b/mods/examples/modern_type_chart/.modkitignore
@@ -1,0 +1,1 @@
+tests/modern_type_chart_test.lua

--- a/mods/examples/modern_type_chart/CHANGELOG.md
+++ b/mods/examples/modern_type_chart/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+Format: [keep a changelog](https://keepachangelog.com/en/1.1.0/).
+
+## 1.0.0
+
+### Added
+
+- Post-Generation-I typings for Gust, Karate Chop, Sand-Attack, and Bite.
+- Dark-type relationships needed by Bite.
+- Super-effective Ghost damage against Psychic.

--- a/mods/examples/modern_type_chart/README.md
+++ b/mods/examples/modern_type_chart/README.md
@@ -1,0 +1,35 @@
+# Modern Type Chart
+
+Modernizes the move types that changed after Generation I and corrects the
+Ghost-versus-Psychic matchup without changing vanilla play.
+
+**Persona: the modernizer.** A player who likes the original campaign and
+mechanics but expects familiar move typings and type effectiveness.
+
+## Try it
+
+```sh
+python3 tools/modkit.py validate mods/examples/modern_type_chart --base imported
+luajit mods/examples/modern_type_chart/tests/modern_type_chart_test.lua
+python3 tools/modkit.py pack mods/examples/modern_type_chart
+```
+
+Then copy `mods/examples/modern_type_chart` to `mods/modern_type_chart` and
+enable it in the F10 mod manager.
+
+## Changes
+
+| Move | Generation I | Updated |
+|---|---|---|
+| Gust | Normal/physical | Flying/special |
+| Karate Chop | Normal/physical | Fighting/physical |
+| Sand-Attack | Normal/status | Ground/status |
+| Bite | Normal/physical | Dark/physical |
+
+The mod also adds Dark's relevant type-chart relationships and changes Ghost
+against Psychic from ineffective to super effective. Psychic attacks remain
+super effective against the Gastly family because they are also Poison type.
+
+It deliberately does not add Steel or Fairy, retype Pokemon, or change
+Struggle. Struggle remains classified as Normal after Generation I even though
+later games calculate its damage without type effectiveness.

--- a/mods/examples/modern_type_chart/main.lua
+++ b/mods/examples/modern_type_chart/main.lua
@@ -1,0 +1,31 @@
+return function(mod)
+  local moves = {
+    { "GUST",        { type = "FLYING",  category = "special" } },
+    { "KARATE_CHOP", { type = "FIGHTING", category = "physical" } },
+    { "SAND_ATTACK", { type = "GROUND",   category = "status" } },
+    { "BITE",        { type = "DARK",     category = "physical" } },
+  }
+  for _, change in ipairs(moves) do
+    if mod.content.moves:get(change[1]) then
+      mod.content.moves:patch(change[1], change[2])
+    else
+      mod.log:warn("%s is missing; type update skipped", change[1])
+    end
+  end
+
+  local chart = mod.content.type_chart
+  local function set(id, value)
+    if chart:get(id) then chart:patch(id, value) else chart:register(id, value) end
+  end
+
+  set("DARK", { name = "DARK", category = "special" })
+  for _, matchup in ipairs({
+    { "DARK>FIGHTING", 5 }, { "DARK>GHOST", 20 },
+    { "DARK>PSYCHIC_TYPE", 20 }, { "DARK>DARK", 5 },
+    { "FIGHTING>DARK", 20 }, { "BUG>DARK", 20 },
+    { "GHOST>DARK", 5 }, { "PSYCHIC_TYPE>DARK", 0 },
+    { "GHOST>PSYCHIC_TYPE", 20 },
+  }) do
+    set(matchup[1], { multiplier = matchup[2] })
+  end
+end

--- a/mods/examples/modern_type_chart/manifest.json
+++ b/mods/examples/modern_type_chart/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "modern_type_chart",
+  "name": "Modern Type Chart",
+  "version": "1.0.0",
+  "api": 2,
+  "entry": "main.lua",
+  "profile": "content",
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "category": "BALANCE",
+  "priority": 100,
+  "dependencies": [],
+  "optional_dependencies": [],
+  "conflicts": [],
+  "incompatible": [],
+  "games": ["gen1"],
+  "experimental": false,
+  "description": "Retypes the four Gen I moves changed later and corrects Ghost versus Psychic."
+}

--- a/mods/examples/modern_type_chart/mod.card
+++ b/mods/examples/modern_type_chart/mod.card
@@ -1,0 +1,24 @@
+return {
+  summary = "Later typings for four Gen I moves and a corrected Ghost matchup.",
+  author = "mfiumara",
+  contact = "https://github.com/mfiumara",
+  tags = { "balance", "data-only", "ruleset" },
+  differences = {
+    changed = {
+      "Gust is Flying/special",
+      "Karate Chop is Fighting/physical",
+      "Sand-Attack is Ground/status",
+      "Bite is Dark/physical",
+      "Ghost attacks are super effective against Psychic",
+    },
+    added = { "Dark type and its relevant matchup rows" },
+    known = {
+      "Pokemon typings and later-generation battle mechanics stay unchanged",
+      "Struggle keeps its Generation I typed-damage behavior",
+    },
+  },
+  credits = {
+    { who = "Bulbapedia contributors", for_ = "cross-generation move and type-chart documentation" },
+  },
+  compat = { engine = ">=1.0.0 <2.0.0", modApi = 2 },
+}

--- a/mods/examples/modern_type_chart/tests/modern_type_chart_test.lua
+++ b/mods/examples/modern_type_chart/tests/modern_type_chart_test.lua
@@ -1,0 +1,37 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.modkit")
+local data = T.fixtures.fresh()
+
+for i, id in ipairs({ "GUST", "KARATE_CHOP", "SAND_ATTACK", "BITE" }) do
+  data.moves[id] = {
+    id = id, index = 10 + i, name = id, type = "NORMAL",
+    power = id == "SAND_ATTACK" and 0 or 40,
+    accuracy = 100, pp = 20, effect = "NO_ADDITIONAL_EFFECT",
+    category = id == "SAND_ATTACK" and "status" or "physical",
+  }
+end
+data.type_chart.matchups[#data.type_chart.matchups + 1] = {
+  attacker = "GHOST", defender = "PSYCHIC_TYPE", multiplier = 0,
+}
+
+local run = T.sdk.loadMod("mods/examples/modern_type_chart", { data = data })
+T.eq(#run.errors, 0, "loads clean (" .. tostring(run.errors[1]) .. ")")
+T.eq(data.moves.GUST.type, "FLYING", "Gust is Flying")
+T.eq(data.moves.GUST.category, "special", "Gust is special")
+T.eq(data.moves.KARATE_CHOP.type, "FIGHTING", "Karate Chop is Fighting")
+T.eq(data.moves.SAND_ATTACK.type, "GROUND", "Sand-Attack is Ground")
+T.eq(data.moves.BITE.type, "DARK", "Bite is Dark")
+T.eq(data.moves.BITE.category, "physical", "Bite is physical")
+
+local TypeChart = require("src.battle.TypeChart")
+TypeChart.load(data)
+T.eq(TypeChart.effectiveness("GHOST", { "PSYCHIC_TYPE" }), 20,
+  "Ghost is super effective against Psychic")
+T.eq(TypeChart.effectiveness("DARK", { "PSYCHIC_TYPE" }), 20,
+  "Dark is super effective against Psychic")
+T.eq(TypeChart.effectiveness("PSYCHIC_TYPE", { "DARK" }), 0,
+  "Dark is immune to Psychic")
+
+run.release()
+T.finish("modern_type_chart")

--- a/tests/mod_examples_tests.lua
+++ b/tests/mod_examples_tests.lua
@@ -21,7 +21,7 @@ local GALLERY_ROOT = "mods/examples"
 local IDS = {
   "example_balance_tweaks", "example_shiny_palette", "example_jukebox",
   "example_lost_parcel", "example_weather", "example_dexnav",
-  "example_mini_conversion", "example_silly_oak",
+  "example_mini_conversion", "example_silly_oak", "modern_type_chart",
 }
 
 -- the closed vocabulary from 25 3.1; GAMEPLAY is the accepted v1 alias
@@ -263,6 +263,14 @@ check(#data.pokemon.VENUSAUR.learnset > 0, "#1 patch left the learnset alone")
 eq(data.items.TM_TOXIC.price, 2000, "#1 halved a TM price through each()")
 eq(data.items.POTION.price, 300, "#1 left non-TM prices alone")
 eq(data.encounters.ROUTE_1.grass.rate, 20, "#1 re-slotted Route 1")
+
+-- modern type chart: the four later typings and corrected Ghost matchup
+eq(data.moves.GUST.type, "FLYING", "modern chart makes GUST Flying")
+eq(data.moves.KARATE_CHOP.type, "FIGHTING",
+  "modern chart makes KARATE CHOP Fighting")
+eq(data.moves.SAND_ATTACK.type, "GROUND",
+  "modern chart makes SAND-ATTACK Ground")
+eq(data.moves.BITE.type, "DARK", "modern chart makes BITE Dark")
 
 -- #2 artist: palette records and the trueColor opt-out
 check(data.palettes.palettes.EXAMPLE_SHINY ~= nil, "#2 registered a palette record")


### PR DESCRIPTION
## What changed

Adds an opt-in `modern_type_chart` gallery mod that:

- retypes the four Generation I moves changed in Generation II:
  - Gust: Normal/physical → Flying/special
  - Karate Chop: Normal/physical → Fighting/physical
  - Sand-Attack: Normal/status → Ground/status
  - Bite: Normal/physical → Dark/physical
- adds Dark and the relevant matchup rows required by Bite
- corrects Ghost → Psychic from 0× to 2×
- documents explicit non-goals, including Pokémon retyping and typeless Struggle behavior

The default game remains unchanged because gallery mods are disabled by construction.

## Why

Gen1Recomp correctly imports Generation I's ROM-authored move types and type chart for faithful play. Players who prefer later canonical typings currently need to build this override themselves. A gallery mod demonstrates the existing `moves` and `type_chart` registry seams without weakening cartridge parity.

The full move audit found exactly four Generation I → II type changes. Struggle remains classified Normal after Generation I; later games make its damage typeless, which is a separate mechanic and intentionally outside this data-only mod.

References:

- https://bulbapedia.bulbagarden.net/wiki/List_of_changed_moves
- https://bulbapedia.bulbagarden.net/wiki/Type/Type_chart

## Impact

Only players who copy and enable the mod receive the updated behavior. No engine API or vanilla data changes are included.

## Validation

- `python3 tools/modkit.py validate mods/examples/modern_type_chart --base fixture --strict`
- `python3 tools/modkit.py validate mods/examples/modern_type_chart --base imported --strict`
- `python3 tools/modkit.py lint mods/examples/modern_type_chart`
- `luajit mods/examples/modern_type_chart/tests/modern_type_chart_test.lua` — 10/10
- `luajit tests/mod_examples_tests.lua` — 287/287
