### PR TITLE
android: add asynchronous Canvas readback

### DIFF
--- a/mobile/android/love/src/jni/love/src/modules/graphics/Canvas.cpp
+++ b/mobile/android/love/src/jni/love/src/modules/graphics/Canvas.cpp
@@ -154,6 +154,16 @@ love::image::ImageData *Canvas::newImageData(love::image::Image *module, int sli
 	return module->newImageData(r.w, r.h, dataformat);
 }
 
+bool Canvas::requestImageData()
+{
+	return false;
+}
+
+love::image::ImageData *Canvas::pollImageData(love::image::Image *)
+{
+	return nullptr;
+}
+
 void Canvas::draw(Graphics *gfx, Quad *q, const Matrix4 &t)
 {
 	if (gfx->isCanvasActive(this))
@@ -232,4 +242,3 @@ StringMap<Canvas::SettingType, Canvas::SETTING_MAX_ENUM> Canvas::settingTypes(Ca
 
 } // graphics
 } // love
-

--- a/mobile/android/love/src/jni/love/src/modules/graphics/Canvas.h
+++ b/mobile/android/love/src/jni/love/src/modules/graphics/Canvas.h
@@ -81,6 +81,8 @@ public:
 	int getRequestedMSAA() const;
 
 	virtual love::image::ImageData *newImageData(love::image::Image *module, int slice, int mipmap, const Rect &rect);
+	virtual bool requestImageData();
+	virtual love::image::ImageData *pollImageData(love::image::Image *module);
 	virtual void generateMipmaps() = 0;
 
 	virtual int getMSAA() const = 0;

--- a/mobile/android/love/src/jni/love/src/modules/graphics/opengl/Canvas.cpp
+++ b/mobile/android/love/src/jni/love/src/modules/graphics/opengl/Canvas.cpp
@@ -23,6 +23,7 @@
 #include "Graphics.h"
 
 #include <algorithm> // For min/max
+#include <cstring>
 
 namespace love
 {
@@ -197,6 +198,9 @@ Canvas::Canvas(const Settings &settings)
 	, texture(0)
     , renderbuffer(0)
 	, actualSamples(0)
+	, readbackBuffer(0)
+	, readbackFence(nullptr)
+	, readbackSize(0)
 {
 	format = getSizedFormat(format);
 
@@ -314,6 +318,14 @@ bool Canvas::loadVolatile()
 
 void Canvas::unloadVolatile()
 {
+	if (readbackFence != nullptr)
+		glDeleteSync(readbackFence);
+	if (readbackBuffer != 0)
+		glDeleteBuffers(1, &readbackBuffer);
+	readbackFence = nullptr;
+	readbackBuffer = 0;
+	readbackSize = 0;
+
 	if (fbo != 0 || renderbuffer != 0 || texture != 0)
 	{
 		// This is a bit ugly, but we need some way to destroy the cached FBO
@@ -477,6 +489,68 @@ love::image::ImageData *Canvas::newImageData(love::image::Image *module, int sli
 
 	gl.bindFramebuffer(OpenGL::FRAMEBUFFER_ALL, current_fbo);
 
+	return data;
+}
+
+bool Canvas::requestImageData()
+{
+	if (readbackFence != nullptr || !isReadable()
+		|| !(GLAD_ES_VERSION_3_0 || GLAD_VERSION_3_2)
+		|| texType != TEXTURE_2D
+		|| (format != PIXELFORMAT_RGBA8 && format != PIXELFORMAT_sRGBA8)
+		|| actualSamples > 0)
+		return false;
+
+	auto gfx = Module::getInstance<Graphics>(Module::M_GRAPHICS);
+	if (gfx != nullptr && gfx->isCanvasActive(this))
+		throw love::Exception("Canvas:requestImageData cannot be called while that Canvas is active.");
+
+	const size_t size = (size_t) pixelWidth * (size_t) pixelHeight * 4;
+	if (readbackBuffer == 0)
+		glGenBuffers(1, &readbackBuffer);
+
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, readbackBuffer);
+	if (readbackSize != size)
+	{
+		glBufferData(GL_PIXEL_PACK_BUFFER, size, nullptr, GL_STREAM_READ);
+		readbackSize = size;
+	}
+
+	GLuint currentfbo = gl.getFramebuffer(OpenGL::FRAMEBUFFER_ALL);
+	gl.bindFramebuffer(OpenGL::FRAMEBUFFER_ALL, getFBO());
+	glReadPixels(0, 0, pixelWidth, pixelHeight, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+	readbackFence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+	gl.bindFramebuffer(OpenGL::FRAMEBUFFER_ALL, currentfbo);
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+	return readbackFence != nullptr;
+}
+
+love::image::ImageData *Canvas::pollImageData(love::image::Image *module)
+{
+	if (readbackFence == nullptr)
+		return nullptr;
+
+	GLenum status = glClientWaitSync(readbackFence, 0, 0);
+	if (status == GL_TIMEOUT_EXPIRED)
+		return nullptr;
+
+	glDeleteSync(readbackFence);
+	readbackFence = nullptr;
+	if (status == GL_WAIT_FAILED)
+		return nullptr;
+
+	love::image::ImageData *data = module->newImageData(pixelWidth, pixelHeight, PIXELFORMAT_RGBA8);
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, readbackBuffer);
+	void *pixels = glMapBufferRange(GL_PIXEL_PACK_BUFFER, 0, readbackSize, GL_MAP_READ_BIT);
+	if (pixels == nullptr)
+	{
+		glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+		data->release();
+		throw love::Exception("Could not map asynchronous Canvas readback.");
+	}
+	memcpy(data->getData(), pixels, readbackSize);
+	glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 	return data;
 }
 

--- a/mobile/android/love/src/jni/love/src/modules/graphics/opengl/Canvas.h
+++ b/mobile/android/love/src/jni/love/src/modules/graphics/opengl/Canvas.h
@@ -54,6 +54,8 @@ public:
 	ptrdiff_t getHandle() const override;
 
 	love::image::ImageData *newImageData(love::image::Image *module, int slice, int mipmap, const Rect &rect) override;
+	bool requestImageData() override;
+	love::image::ImageData *pollImageData(love::image::Image *module) override;
 	void generateMipmaps() override;
 
 	int getMSAA() const override
@@ -107,6 +109,9 @@ private:
 	GLenum status;
 
 	int actualSamples;
+	GLuint readbackBuffer;
+	GLsync readbackFence;
+	size_t readbackSize;
 
 	static SupportedFormat supportedFormats[PIXELFORMAT_MAX_ENUM];
 	static SupportedFormat checkedFormats[PIXELFORMAT_MAX_ENUM];

--- a/mobile/android/love/src/jni/love/src/modules/graphics/wrap_Canvas.cpp
+++ b/mobile/android/love/src/jni/love/src/modules/graphics/wrap_Canvas.cpp
@@ -116,6 +116,31 @@ int w_Canvas_newImageData(lua_State *L)
 	return 1;
 }
 
+int w_Canvas_requestImageData(lua_State *L)
+{
+	Canvas *canvas = luax_checkcanvas(L, 1);
+	bool requested = false;
+	luax_catchexcept(L, [&](){ requested = canvas->requestImageData(); });
+	luax_pushboolean(L, requested);
+	return 1;
+}
+
+int w_Canvas_pollImageData(lua_State *L)
+{
+	Canvas *canvas = luax_checkcanvas(L, 1);
+	love::image::Image *image = luax_getmodule<love::image::Image>(L, love::image::Image::type);
+	love::image::ImageData *data = nullptr;
+	luax_catchexcept(L, [&](){ data = canvas->pollImageData(image); });
+	if (data == nullptr)
+	{
+		lua_pushnil(L);
+		return 1;
+	}
+	luax_pushtype(L, data);
+	data->release();
+	return 1;
+}
+
 int w_Canvas_generateMipmaps(lua_State *L)
 {
 	Canvas *c = luax_checkcanvas(L, 1);
@@ -139,6 +164,8 @@ static const luaL_Reg w_Canvas_functions[] =
 	{ "getMSAA", w_Canvas_getMSAA },
 	{ "renderTo", w_Canvas_renderTo },
 	{ "newImageData", w_Canvas_newImageData },
+	{ "requestImageData", w_Canvas_requestImageData },
+	{ "pollImageData", w_Canvas_pollImageData },
 	{ "generateMipmaps", w_Canvas_generateMipmaps },
 	{ "getMipmapMode", w_Canvas_getMipmapMode },
 	{ 0, 0 }


### PR DESCRIPTION
## Summary

- add `Canvas:requestImageData()` and `Canvas:pollImageData()` to the bundled Android LÖVE runtime
- transfer RGBA pixels through an OpenGL pixel buffer and fence instead of blocking immediately
- allow one pending readback per Canvas
- release pending GPU resources during volatile unload

## Why

Mods that copy a rendered Canvas to a companion display, capture target, or streaming path currently have to use synchronous `newImageData()`, which can stall the render thread while the GPU finishes. The two-step API lets callers request a transfer and poll it on a later frame.

## Compatibility

This is fully opt-in. Existing Canvas methods and rendering paths are unchanged.

Unsupported canvases return `false`: the extension requires OpenGL ES 3.0 / OpenGL 3.2, a readable non-MSAA 2D Canvas, and RGBA8 or sRGBA8. Callers can retain their synchronous fallback.

## Testing

- `:love:assembleNormalDebug` built successfully for arm64-v8a, armeabi-v7a, and x86_64
- verified both Lua method names in the produced `liblove.so`
- `git diff --check`