### PR TITLE
Raise postLog body ceiling to 512 KiB

### DIFF
--- a/src/mods/Net.lua
+++ b/src/mods/Net.lua
@@ -32,9 +32,14 @@ local Net = {}
 Net.MAX_INFLIGHT = 4
 -- Clamp on the caller's timeout, so a mod cannot pin a worker indefinitely.
 Net.MAX_SECONDS = 30
--- A log body ceiling.  Debug logs are kilobytes, and a server operator has no
--- reason to accept a mod uploading arbitrary megabytes to its endpoint.
-Net.MAX_BODY = 65536
+-- A log body ceiling.  A diagnostic ring (boot evidence + recent lines +
+-- status) routinely exceeds 64 KiB on a long session, so the ceiling is
+-- 512 KiB: generous for real support logs, still far under the 5 MiB the
+-- reference loghook endpoint accepts, and small enough that a misbehaving
+-- mod cannot upload arbitrary megabytes.  The body is staged to a file and
+-- streamed by the transport, so the ceiling is a budget, not a memory
+-- spike; callers that stay under it never notice it.
+Net.MAX_BODY = 512 * 1024
 
 local function fetch()
   return require("src.net.Fetch")


### PR DESCRIPTION
## Problem
`Net.MAX_BODY` (64 KiB) rejects legitimate diagnostic payloads. A long session's evidence ring (boot evidence + recent lines + status excerpt) routinely exceeds it: a real user's 651-line ring measured ~90 KB and `mod.postLog` returned `nil` with `log body too large` — the send was dropped and the mod could only report a bare failure.

## Change
`Net.MAX_BODY` 65536 → **512 KiB**, with the rationale documented at the constant.

- The transport stages the body to a temp file and streams it via curl (`--data-binary @file`), so the ceiling is a **budget, not a memory spike** — there is no argv or in-memory blowup at the new size.
- 512 KiB is generous for real support logs and stays far under the 5 MiB the reference loghook endpoint accepts at the HTTP layer.
- The limit is per-send; the per-mod in-flight ceiling (4) and the timeout clamp are unchanged, so a misbehaving mod still cannot monopolise the worker pool.

## Tests
`tests/modkit/cases/mod_postlog.lua` pins the ceiling via `Net.MAX_BODY + 1`, so it adapts automatically — **27/27 checks pass**. `tests/engine/host_shell_postlog.lua` — 9/9.

## Note
Consumers should still size their payloads sensibly: the PotatoVoxel sender trims its ring to fit and will use the new headroom once released against this change.
