### PR TITLE
Reset ManagerState's draw color after Font.drawBox

### DIFF
--- a/src/mods/ManagerState.lua
+++ b/src/mods/ManagerState.lua
@@ -1297,6 +1297,7 @@ function ManagerState:drawOverlay()
   love.graphics.rectangle("fill", 2 * 8, ty * 8, 16 * 8, th * 8)
   love.graphics.setColor(1, 1, 1, 1)
   Font.drawBox(2, ty, 16, th)
+  love.graphics.setColor(0, 0, 0, 1)
   for i, line in ipairs(lines) do
     drawTruncated(line, 4 * 8, (ty + i) * 8, 14)
   end
@@ -1325,6 +1326,7 @@ function ManagerState:draw()
   love.graphics.rectangle("fill", 0, 0, 160, 144)
   love.graphics.setColor(1, 1, 1, 1)
   Font.drawBox(0, 0, 20, 18)
+  love.graphics.setColor(0, 0, 0, 1)
   Font.draw(self.banner or Strings("MOD MANAGER"), 16, 8)
   if self.screen == "list" then
     self:drawList()


### PR DESCRIPTION
# Reset ManagerState's draw color after Font.drawBox

## Bug

The in-game Mod Manager screen (`src/mods/ManagerState.lua`, reachable while playing, both RBY and Gold) renders **no visible text at all** once a mod activates TTF text mode (`mod.content.font:register("ttf", ...)`).
Everything on the screen — title, rows, footer, overlay — is white on white.

`ManagerState:draw()` sets the draw color to white right before calling `Font.drawBox`, which restores the caller's own color once it's done painting the box interior:

```lua
love.graphics.setColor(0, 0, 0, 1)               -- black
love.graphics.rectangle("fill", 0, 0, 160, 144)  -- full-screen background
love.graphics.setColor(1, 1, 1, 1)               -- white
Font.drawBox(0, 0, 20, 18)                       -- restores the CALLER's color: white
Font.draw(self.banner or Strings("MOD MANAGER"), 16, 8)  -- drawn while color is still white
```

Nothing resets the color back to black afterward, and the same pattern repeats in `drawOverlay()`. This is invisible on the vanilla tile font — `Font.drawBox`'s own tile glyphs are black-on-transparent regardless of the active color, so a leaked white color was harmless as long as every glyph was a tile. `Font.drawCode`'s TTF branch instead calls `love.graphics.print(...)`, which *does* draw in the current color, so once a mod's TTF font is active, any label drawn after the leak comes out white and disappears against the white background.

Every other screen that calls `Font.drawBox` (`TitleState.lua`, `StartMenu.lua`, `HallOfFame.lua`, `BoxMenu.lua`, `PartyMenu.lua`) resets to black right after — `ManagerState.lua` is the one screen missing that reset.

## Fix

Add `love.graphics.setColor(0, 0, 0, 1)` immediately after each of the two `Font.drawBox` calls in `ManagerState.lua`, matching the existing pattern used everywhere else in the codebase:
- `draw()`, right after `Font.drawBox(0, 0, 20, 18)`
- `drawOverlay()`, right after `Font.drawBox(2, ty, 16, th)`

Two-line change, display-only, no behavior change outside of the drawn color.

## Testing

- `scripts/test.sh --quick`: no new failures introduced by this change (verified by running the suite with and without the fix via `git stash` — the same 3 tiers fail identically in both cases, all unrelated pre-existing issues in this checkout, e.g. a LuaJIT "more than 200 local variables" load error in `src/world/gen2/World.lua`).
- No automated test covers `ManagerState`'s rendering; this is a rendering-only fix verified by reading the draw logic and confirmed against the exact color-leak sequence described above.
- Built a Windows (win64) distributable with the fix included and confirmed the two `setColor` calls are present in the packed `game.love`, for manual in-game verification (open the Mod Manager screen with a TTF-mode mod active).

Screenshots before and after the fix:

<img width="1021" height="766" alt="Screenshot 2026-08-16 194012" src="https://github.com/user-attachments/assets/047de192-1b1f-4732-88d1-a7fa3f1cb463" />

<img width="1021" height="764" alt="Screenshot 2026-08-16 194303" src="https://github.com/user-attachments/assets/8a477060-f950-43a1-bb16-b92dc8410c7c" />
