### PR TITLE
fix(gen2): stay below LuaJIT local limit

### DIFF
--- a/src/world/gen2/World.lua
+++ b/src/world/gen2/World.lua
@@ -34,7 +34,6 @@ local Font = require("src.render.Font")
 -- a mod has taken a facade (src/mods/Gen2Compat.lua).
 local Gen1Facade = require("src.mods.Gen2Compat")
 local GbcPalette = require("src.render.GbcPalette")
-local GameViewport = require("src.render.GameViewport")
 local Gen2Save = require("src.core.gen2.Save")
 local HallOfFame = require("src.core.gen2.HallOfFame")
 local HiddenItems = require("src.world.gen2.HiddenItems")
@@ -7549,7 +7548,7 @@ function World:interactBody()
 end
 
 function World:fitScale()
-  local w, h = GameViewport.dimensions()
+  local w, h = require("src.render.GameViewport").dimensions()
   return math.max(1, math.floor(math.min(w / 160, h / 144)))
 end
 
@@ -8376,7 +8375,7 @@ function World:rebuildNeighbors()
   self.neighbors = {}
   if not self.map then return end
   local s = self:zoomScale()
-  local ww, wh = GameViewport.dimensions()
+  local ww, wh = require("src.render.GameViewport").dimensions()
   local vw = math.ceil(ww / s)
   local vh = math.ceil(wh / s)
   if vw % 2 ~= 0 then vw = vw + 1 end
@@ -9743,7 +9742,7 @@ function World:drawGround(s)
     if canvas then
       bw, bh = canvas:getDimensions()
     else
-      bw, bh = GameViewport.dimensions()
+      bw, bh = require("src.render.GameViewport").dimensions()
     end
     BorderFill.draw(self, self:borderImageFor(self.map.id),
       cam.x, cam.y, bw, bh, s, self.map.id)
@@ -10003,7 +10002,7 @@ end
 
 function World:draw()
   local G = love.graphics
-  local w, h = GameViewport.dimensions()
+  local w, h = require("src.render.GameViewport").dimensions()
   self:refreshColorMode()
   G.clear(0.07, 0.05, 0.02, 1)
 


### PR DESCRIPTION
## Summary
- keep Gen 2 `World.lua` below LuaJIT's 200-local limit
- preserve the viewport behavior added by #1405
- use Lua's cached `require` at the four viewport call sites instead of adding another chunk-local

## Why
After #1405 merged onto the latest `dev`, `src/world/gen2/World.lua` crossed LuaJIT's hard 200-local limit. The post-merge headless run then failed while loading Gen 2, affecting eight existing engine suites and the new screen visibility suite.

This is deliberately a mechanical follow-up: no API, layout, or runtime behavior changes.

## Validation
- `luajit tests/run_modkit.lua`: 23/23 suites passed
- `luajit tests/run_engine.lua`: all Gen 2 and viewport suites passed (206/207 overall locally; the remaining `build_zip_pipe_guard_bug774` failure is the existing Windows shell-scan baseline and is Linux-CI clean)
- `git diff --check`