### PR TITLE
Translate the stat name in X-item, vitamin, and Light Screen/Reflect rose! messages

### DIFF
--- a/src/battle/TrainerAI.lua
+++ b/src/battle/TrainerAI.lua
@@ -124,7 +124,7 @@ function TrainerAI.useItem(battle, item)
   elseif X_STAT[item] then
     local stat = X_STAT[item]
     enemy.stages[stat] = math.min(6, (enemy.stages[stat] or 0) + 1)
-    table.insert(msgs, Strings("%s's\n%s rose!", displayName(enemy), stat:upper()))
+    table.insert(msgs, Strings("%s's\n%s rose!", displayName(enemy), Strings(stat:upper())))
   elseif item == "GUARD_SPEC" then
     enemy.mist = true
     table.insert(msgs, Strings("%s's\nprotected against\nstat changes!", displayName(enemy)))

--- a/src/battle/TrainerAI.lua
+++ b/src/battle/TrainerAI.lua
@@ -33,6 +33,15 @@ end
 local HEAL_AMOUNT = { POTION = 20, SUPER_POTION = 50, HYPER_POTION = 200 }
 local X_STAT = { X_ATTACK = "attack", X_DEFEND = "defense", X_SPEED = "speed" }
 
+-- Strings.source, not Strings: harvested at require time so the catalog
+-- generator can see the literal, same pattern as MoveEffects.lua's
+-- STAT_LABEL (#811) -- Strings(stat:upper()) alone is a dynamic argument
+-- the harvester can't discover.
+local STAT_LABEL = {
+  attack = Strings.source("ATTACK"), defense = Strings.source("DEFENSE"),
+  speed = Strings.source("SPEED"),
+}
+
 -- The trainer's ai_classes record from the merged registry; the direct
 -- require covers battles built without a loader.  A trainer record's
 -- aiClass field picks a record other than its own id.
@@ -124,7 +133,7 @@ function TrainerAI.useItem(battle, item)
   elseif X_STAT[item] then
     local stat = X_STAT[item]
     enemy.stages[stat] = math.min(6, (enemy.stages[stat] or 0) + 1)
-    table.insert(msgs, Strings("%s's\n%s rose!", displayName(enemy), Strings(stat:upper())))
+    table.insert(msgs, Strings("%s's\n%s rose!", displayName(enemy), Strings(STAT_LABEL[stat])))
   elseif item == "GUARD_SPEC" then
     enemy.mist = true
     table.insert(msgs, Strings("%s's\nprotected against\nstat changes!", displayName(enemy)))

--- a/src/battle/gen2/Battle.lua
+++ b/src/battle/gen2/Battle.lua
@@ -2429,7 +2429,7 @@ Battle.MOVE_EFFECTS.EFFECT_LIGHT_SCREEN = function(self, attacker)
   if (side.lightScreen or 0) > 0 then return fail(self) end
   side.lightScreen = Battle.SCREEN_TURNS
   self:emit({ kind = "message",
-    text = self:monName(attacker) .. "'s SPCL.DEF rose!" })
+    text = Strings("%s's SPCL.DEF rose!", self:monName(attacker)) })
 end
 
 Battle.MOVE_EFFECTS.EFFECT_REFLECT = function(self, attacker)
@@ -2437,7 +2437,7 @@ Battle.MOVE_EFFECTS.EFFECT_REFLECT = function(self, attacker)
   if (side.reflect or 0) > 0 then return fail(self) end
   side.reflect = Battle.SCREEN_TURNS
   self:emit({ kind = "message",
-    text = self:monName(attacker) .. "'s DEFENSE rose!" })
+    text = Strings("%s's DEFENSE rose!", self:monName(attacker)) })
 end
 
 -- engine/battle/move_effects/safeguard.asm:1

--- a/src/inventory/ItemEffects.lua
+++ b/src/inventory/ItemEffects.lua
@@ -59,6 +59,16 @@ local STONES = {
   LEAF_STONE = true, MOON_STONE = true,
 }
 
+-- Strings.source, not Strings: harvested at require time so the catalog
+-- generator can see the literal, same pattern as MoveEffects.lua's
+-- STAT_LABEL (#811) -- Strings(stat:upper()) alone is a dynamic argument
+-- the harvester can't discover.
+local STAT_LABEL = {
+  hp = Strings.source("HP"), attack = Strings.source("ATTACK"),
+  defense = Strings.source("DEFENSE"), speed = Strings.source("SPEED"),
+  special = Strings.source("SPECIAL"), accuracy = Strings.source("ACCURACY"),
+}
+
 -- vitamins: stat-exp boosters (ItemUseVitamin)
 local VITAMINS = { HP_UP = "hp", PROTEIN = "attack", IRON = "defense",
                    CARBOS = "speed", CALCIUM = "special" }
@@ -294,7 +304,7 @@ function ItemEffects.use(data, save, itemId, target, battle, moveIndex, ow)
           "Nothing happened!") }
       end
       b.stages[stat] = cur + 1
-      return "consumed", { Strings("%s's\n%s rose!", b.name, Strings(stat:upper())) }
+      return "consumed", { Strings("%s's\n%s rose!", b.name, Strings(STAT_LABEL[stat])) }
     end
     -- ItemUseDireHit/ItemUseGuardSpec always set the bit and consume
     -- the item, even when it is already active
@@ -493,7 +503,7 @@ function ItemEffects.use(data, save, itemId, target, battle, moveIndex, ow)
     -- Spanish ROM puts the stat before the name), so the extracted line
     -- cannot be filled positionally; the engine wording stands
     return "consumed", { Strings("%s's %s\nrose!", monName(data, target),
-      Strings(vitaminStat == "hp" and "HP" or vitaminStat:upper())) }
+      Strings(STAT_LABEL[vitaminStat])) }
   end
 
   -- PP UP boosts the move the player picked (ItemUsePPUp's move menu)

--- a/src/inventory/ItemEffects.lua
+++ b/src/inventory/ItemEffects.lua
@@ -294,7 +294,7 @@ function ItemEffects.use(data, save, itemId, target, battle, moveIndex, ow)
           "Nothing happened!") }
       end
       b.stages[stat] = cur + 1
-      return "consumed", { Strings("%s's\n%s rose!", b.name, stat:upper()) }
+      return "consumed", { Strings("%s's\n%s rose!", b.name, Strings(stat:upper())) }
     end
     -- ItemUseDireHit/ItemUseGuardSpec always set the bit and consume
     -- the item, even when it is already active
@@ -493,7 +493,7 @@ function ItemEffects.use(data, save, itemId, target, battle, moveIndex, ow)
     -- Spanish ROM puts the stat before the name), so the extracted line
     -- cannot be filled positionally; the engine wording stands
     return "consumed", { Strings("%s's %s\nrose!", monName(data, target),
-      vitaminStat == "hp" and "HP" or vitaminStat:upper()) }
+      Strings(vitaminStat == "hp" and "HP" or vitaminStat:upper())) }
   end
 
   -- PP UP boosts the move the player picked (ItemUsePPUp's move menu)

--- a/tests/engine/stat_rise_message_translation_test.lua
+++ b/tests/engine/stat_rise_message_translation_test.lua
@@ -1,0 +1,73 @@
+-- The stat name substituted into X-item/vitamin "rose!" messages must
+-- itself reach a translation catalog, not just the surrounding sentence
+-- template (src/inventory/ItemEffects.lua, src/battle/TrainerAI.lua).
+-- With no catalog loaded it stays English (the existing baseline); with
+-- one loaded that translates e.g. "ATTACK", the substituted word must
+-- change too -- that is the actual bug this suite guards against, which
+-- passing/failing sentences alone (as other suites already check)
+-- cannot tell apart from a raw stat:upper() that was never wrapped in
+-- Strings() at all.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.modkit")
+local Data = T.fixtures.fresh()
+local Pokemon = require("src.pokemon.Pokemon")
+local SaveData = require("src.core.SaveData")
+local ItemEffects = require("src.inventory.ItemEffects")
+local TrainerAI = require("src.battle.TrainerAI")
+local Strings = require("src.core.Strings")
+
+local function withCatalog(catalog, fn)
+  Strings.load({ strings = catalog })
+  local ok, err = pcall(fn)
+  Strings.load(nil)
+  if not ok then error(err, 0) end
+end
+
+-- ------------------------------------------------------- player X-item
+
+local save = SaveData.newGame()
+local player = { name = "FIXMON", stages = {} }
+local xBattle = { player = player, kind = "wild" }
+
+local _, baseline = ItemEffects.use(Data, save, "X_ATTACK", nil, xBattle)
+T.check(baseline[1]:find("ATTACK", 1, true) ~= nil,
+  "X ATTACK's rose! message names the stat in English with no catalog")
+
+withCatalog({ ATTACK = "ATTAQUE" }, function()
+  player.stages.attack = nil
+  local _, msgs = ItemEffects.use(Data, save, "X_ATTACK", nil, xBattle)
+  T.check(msgs[1]:find("ATTAQUE", 1, true) ~= nil,
+    "a catalog translating ATTACK reaches the X ATTACK rose! message")
+  T.check(msgs[1]:find("ATTACK", 1, true) == nil,
+    "...and the untranslated English stat name is gone")
+end)
+
+-- --------------------------------------------------------- player vitamin
+
+local target = Pokemon.new(Data, "FIXMON_A", 10)
+withCatalog({ DEFENSE = "DEFENSE_FR" }, function()
+  local _, msgs = ItemEffects.use(Data, save, "IRON", target)
+  T.check(msgs[1]:find("DEFENSE_FR", 1, true) ~= nil,
+    "a catalog translating DEFENSE reaches the IRON (vitamin) rose! message")
+end)
+
+local hpTarget = Pokemon.new(Data, "FIXMON_A", 10)
+withCatalog({ HP = "PV" }, function()
+  local _, msgs = ItemEffects.use(Data, save, "HP_UP", hpTarget)
+  T.check(msgs[1]:find("PV", 1, true) ~= nil,
+    "a catalog translating HP reaches the HP UP rose! message")
+end)
+
+-- ------------------------------------------------------- AI trainer X-item
+
+local enemy = { name = "FOE", stages = {} }
+local aiBattle = { enemy = enemy, trainer = { name = "TRAINER" }, data = Data }
+
+withCatalog({ SPEED = "VITESSE" }, function()
+  local msgs = TrainerAI.useItem(aiBattle, "X_SPEED")
+  T.check(msgs[2]:find("VITESSE", 1, true) ~= nil,
+    "a catalog translating SPEED reaches the AI trainer's X SPEED rose! message")
+end)
+
+T.finish("stat rise message translation")

--- a/tests/engine/stat_rise_message_translation_test.lua
+++ b/tests/engine/stat_rise_message_translation_test.lua
@@ -1,12 +1,13 @@
--- The stat name substituted into X-item/vitamin "rose!" messages must
--- itself reach a translation catalog, not just the surrounding sentence
--- template (src/inventory/ItemEffects.lua, src/battle/TrainerAI.lua).
--- With no catalog loaded it stays English (the existing baseline); with
--- one loaded that translates e.g. "ATTACK", the substituted word must
--- change too -- that is the actual bug this suite guards against, which
--- passing/failing sentences alone (as other suites already check)
--- cannot tell apart from a raw stat:upper() that was never wrapped in
--- Strings() at all.
+-- The stat name substituted into X-item/vitamin "rose!" messages, and
+-- Gold's whole Light Screen / Reflect "rose!" messages, must reach a
+-- translation catalog, not just the surrounding sentence template (RBY:
+-- src/inventory/ItemEffects.lua, src/battle/TrainerAI.lua; Gold:
+-- src/battle/gen2/Battle.lua). With no catalog loaded the message stays
+-- English (the existing baseline); with one loaded that translates the
+-- relevant word(s), the substitution must change too -- that is the
+-- actual bug this suite guards against, which passing/failing sentences
+-- alone (as other suites already check) cannot tell apart from text that
+-- never reached Strings() at all.
 package.path = "./?.lua;./?/init.lua;" .. package.path
 
 local T = require("tests.modkit")
@@ -69,5 +70,72 @@ withCatalog({ SPEED = "VITESSE" }, function()
   T.check(msgs[2]:find("VITESSE", 1, true) ~= nil,
     "a catalog translating SPEED reaches the AI trainer's X SPEED rose! message")
 end)
+
+-- ------------------------------------------------------- Gold: Light Screen / Reflect
+
+local Gen2Battle = require("src.battle.gen2.Battle")
+local Gen2Mon = require("src.battle.gen2.Mon")
+
+local GEN2_DATA = {
+  pokemon = {
+    MACHOP = {
+      id = "MACHOP", index = 66, name = "MACHOP",
+      baseStats = { hp = 70, attack = 80, defense = 50, speed = 35,
+        specialAttack = 35, specialDefense = 35 },
+      types = { "NORMAL", "NORMAL" }, catchRate = 180, baseExp = 75,
+      growthRate = "GROWTH_MEDIUM_FAST", genderRatio = 63,
+      levelMoves = { { level = 1, move = "TACKLE" } }, evolutions = {},
+    },
+  },
+  moves = {
+    TACKLE = { id = "TACKLE", name = "TACKLE", power = 35, type = "NORMAL",
+      accuracy = 95, pp = 35, effect = "EFFECT_NORMAL_HIT" },
+  },
+  type_chart = { types = { NORMAL = { id = "NORMAL", index = 0,
+    category = "physical" } }, matchups = {} },
+  items = {},
+}
+local perfectDvs = { attack = 15, defense = 15, speed = 15, special = 15 }
+perfectDvs.hp = Gen2Mon.hpDV(perfectDvs)
+
+local function newGen2Battle()
+  local player = Gen2Mon.new(GEN2_DATA, "MACHOP", 15, { dvs = perfectDvs })
+  player.moves = { { id = "TACKLE", pp = 35, maxPp = 35 } }
+  local wild = Gen2Mon.new(GEN2_DATA, "MACHOP", 15, { dvs = perfectDvs })
+  wild.moves = { { id = "TACKLE", pp = 35, maxPp = 35 } }
+  return Gen2Battle.new({ data = GEN2_DATA, party = { player }, wild = wild })
+end
+
+withCatalog({ ["%s's SPCL.DEF rose!"] = "%s voit sa DEF.SPÉ augmenter !" },
+  function()
+    local lsBattle = newGen2Battle()
+    Gen2Battle.MOVE_EFFECTS.EFFECT_LIGHT_SCREEN(lsBattle, lsBattle.player)
+    local events = lsBattle:takeEvents()
+    local found = false
+    for _, event in ipairs(events) do
+      if event.kind == "message"
+          and event.text:find("DEF.SPÉ augmenter", 1, true) then
+        found = true
+      end
+    end
+    T.check(found,
+      "a catalog translating Light Screen's rose! message reaches it")
+  end)
+
+withCatalog({ ["%s's DEFENSE rose!"] = "%s voit sa DEFENSE augmenter !" },
+  function()
+    local refBattle = newGen2Battle()
+    Gen2Battle.MOVE_EFFECTS.EFFECT_REFLECT(refBattle, refBattle.player)
+    local events = refBattle:takeEvents()
+    local found = false
+    for _, event in ipairs(events) do
+      if event.kind == "message"
+          and event.text:find("DEFENSE augmenter", 1, true) then
+        found = true
+      end
+    end
+    T.check(found,
+      "a catalog translating Reflect's rose! message reaches it")
+  end)
 
 T.finish("stat rise message translation")


### PR DESCRIPTION
# Translate the stat name in X-item, vitamin, and Light Screen/Reflect rose! messages

## Bug

Several "X's STAT rose!" battle messages substitute the raised stat's name as a raw, untranslated word, even though the surrounding sentence template is already translated:

- **RBY, player-side X-items and vitamins** (`src/inventory/ItemEffects.lua:297`, `:495-496`): both pass `stat:upper()` straight into `Strings("%s's\n%s rose!", ..., stat:upper())` as a plain Lua string, never itself looked up in the catalog. It always renders in English (`ATTACK`, `DEFENSE`, `SPEED`, `SPECIAL`, `HP`) regardless of the active language.
- **RBY, AI trainers** (`src/battle/TrainerAI.lua:127`): the same pattern, for an enemy trainer's X-item use.
- **Gold, Light Screen / Reflect** (`src/battle/gen2/Battle.lua:2429-2440`): worse — the *entire* message (`"'s SPCL.DEF rose!"` / `"'s DEFENSE rose!"`) is built by raw string concatenation, bypassing `Strings()` completely, unlike most other messages in the same file (e.g. `Strings("%s\nused %s!", ...)` a few lines up, which already goes through it).

## Fix

- `ItemEffects.lua` / `TrainerAI.lua`: wrap the substituted stat name in `Strings(...)`. Reusing a raw `Strings(stat:upper())` call would work at runtime but stay invisible to `tools/modkit.py`'s catalog harvester, which only recognizes a literal string immediately after `Strings(`/`Strings.source(` — a dynamic argument can't be discovered. So instead each file declares a small `STAT_LABEL` table at require time (`attack = Strings.source("ATTACK")`, etc.), the same pattern `src/battle/MoveEffects.lua` already uses for its own stat-change messages, and resolves it at use time with `Strings(STAT_LABEL[stat])`. No data-model change — `stat`/`vitaminStat` stay the same internal keys used everywhere else.
- `gen2/Battle.lua`: wrap the whole message template in `Strings(...)`, matching the file's own established pattern for other messages. The substituted name still comes from `monName()` as before.

`gen2/Battle.lua` has many more combat messages built the same unwrapped way (`fainted!`, `learned...`, `missed!`, and so on). That's a much larger, separate gap — not a missing hook (`Strings()` is already `require`d and used in that file), just volume — tracked on its own and deliberately left out of this PR.

## Testing

- Added `tests/engine/stat_rise_message_translation_test.lua`: no existing test could tell a properly translated stat name apart from a raw `stat:upper()` that never reached `Strings()` at all, since every existing assertion runs with no catalog loaded (where `Strings()` is an identity function either way). This one loads a real catalog translating one stat name at a time and checks it reaches the X-item, vitamin, and AI-trainer X-item messages — ROM-free, over `tests/fixture_data`. Confirmed it catches the regression: reverting `ItemEffects.lua`/`TrainerAI.lua` to their pre-fix state fails 5 of its 6 checks.
- `scripts/test.sh --quick`: no new failures (verified against `dev` at the same commit with this branch's changes reverted — the same 3 tiers fail identically either way; see "Known unrelated CI failure" below).
- Directly ran every test touching the changed code paths (`parity_battle_item_turn.lua`, `gen2_move_effects_test.lua`, `gen2_battle_test.lua`, `gen2_x_items_test.lua`) — all pass.
- Verified with the real `tools/modkit.py` harvester (`harvest_engine_strings`) that `"HP"`/`"ATTACK"`/`"DEFENSE"`/`"SPEED"`/`"SPECIAL"`/`"ACCURACY"` are now discovered directly from `ItemEffects.lua`'s and `TrainerAI.lua`'s own `Strings.source(...)` declarations, independent of any other call site.
- Manually verified in-game with the French translation mod loaded (Windows build): an X-item message goes from `PIKACHU gagne ATTACK!` to `PIKACHU gagne FOR!`, and a vitamin message from `LEVIATOR voit son ATTACK augmenter !` to `LEVIATOR voit son FOR augmenter !` — `FOR` is the confirmed French translation for `ATTACK` already present in the corpus.

X-Attack, before and after the fix:
<img width="1021" height="765" alt="Screenshot 2026-08-16 214126" src="https://github.com/user-attachments/assets/89c52cb2-9149-4660-a34e-89a339c2e5c7" />

<img width="1020" height="767" alt="Screenshot 2026-08-16 214430" src="https://github.com/user-attachments/assets/017d43e4-9d27-48f7-a01b-5cc4803c8c38" />

Protein, before and after the fix:
<img width="1022" height="765" alt="Screenshot 2026-08-16 214726" src="https://github.com/user-attachments/assets/b9226b1d-8983-4d93-8471-0bcba521c08a" />

<img width="1023" height="765" alt="Screenshot 2026-08-16 214633" src="https://github.com/user-attachments/assets/d0aab5b3-a9ab-4ea5-9ce4-18f151f7aaf9" />
