### PR TITLE
mods: gate love.thread behind a compute permission

### DIFF
--- a/src/mods/Manifest.lua
+++ b/src/mods/Manifest.lua
@@ -12,7 +12,7 @@ local Manifest = {}
 Manifest.PROFILES = { content = true, overhaul = true, total_conversion = true }
 Manifest.PERMISSIONS = { network = true, filesystem = true,
                          engine_internals = true, steps = true,
-                         background = true }
+                         background = true, compute = true }
 
 -- link-relevant registries; a mod that writes into one of these while
 -- declaring affects_link = false gets an attributed warning from the loader

--- a/src/mods/Sandbox.lua
+++ b/src/mods/Sandbox.lua
@@ -79,13 +79,25 @@ local BLOCKED_LOVE = {
 
 -- Per-mod, because the compat overrides (src/mods/LegacyCompat.lua) are backed
 -- by that mod's own overlay and must not be shared.
-local function loveFacade(compat)
+local function loveFacade(compat, permissions)
   if not _G.love then return nil end
   local overrides = compat and compat.love
   return setmetatable({}, {
     __index = function(_, key)
       local override = overrides and overrides[key]
       if override ~= nil then return override end
+      if key == "thread" then
+        -- Threads open a fresh Lua state with a full standard library, so
+        -- they stay blocked unless the mod declares the `compute`
+        -- permission (the mod's own source runs in the worker, and the
+        -- worker ships source-only like every other mod file). The mod
+        -- must never receive arbitrary code from elsewhere: channels
+        -- carry data only.
+        if not (permissions or {}).compute then
+          error('love.thread needs the "compute" permission in manifest.json', 2)
+        end
+        return _G.love.thread
+      end
       local hint = BLOCKED_LOVE[key]
       if hint then
         error(("love.%s is not available to mods%s"):format(key,
@@ -215,7 +227,7 @@ function Sandbox.envFor(opts)
   opts = opts or {}
   local compat = opts.compat
   local env = baseGlobals()
-  env.love = loveFacade(compat)
+  env.love = loveFacade(compat, opts.permissions)
   env.require = sandboxedRequire(opts.modId, opts.permissions, compat)
   local loader = sandboxedLoad(env)
   env.load = loader


### PR DESCRIPTION
## What

The mod sandbox blocks `love.thread` wholesale because a thread opens a fresh Lua state with a full standard library. PotatoVoxel's cache prebuilder (1.7.5) wants to run its pure geometry phase (Structures analysis, mesh stream generation, aux flattening — no graphics, no storage) on worker threads to use more than one core on desktop fills.

This adds a `compute` permission:
- `Manifest.PERMISSIONS` gains `compute`
- `Sandbox.loveFacade` returns the real `love.thread` only when the mod's manifest declares it; otherwise the existing block message is unchanged

## Why it stays safe

- The permission is opt-in per mod, reviewed at load like every other permission
- The worker runs the mod's **own source** (source-only, bytecode-rejected like all mod files) and receives **data only** through channels — no arbitrary code entry
- Non-granting mods are untouched; existing sandbox behavior for every other `love.*` module is unchanged
- PotatoVoxel degrades to the serial pump on any engine without the grant (pcall-guarded), so this lands independently of the mod

## Testing

- Mod-side: `tools/thread_smoke` runs the real threaded round trip under desktop love; headless suites (140 cache + 287 main checks) pass with the pool inert
- Engine: no new tests — the facade change is a gate; existing mod-load tests still pass (no mod currently declares `compute`)