### PR TITLE
Route the museum 1F ticket clerk's remaining lines through Strings

### DIFF
--- a/data/scripts/story2.lua
+++ b/data/scripts/story2.lua
@@ -733,7 +733,8 @@ local function museumClerk(game, ow, done, onDecline)
   local t = game.data.text or {}
   if game.save.flags.EVENT_BOUGHT_MUSEUM_TICKET then
     game.stack:push(TextBox.new(game,
-      "Take your time,\nand enjoy it all!", done))
+      t._Museum1FScientist1TakePlentyOfTimeText
+        or "Take your time,\nand enjoy it all!", done))
     return
   end
   -- scripts/Museum1F.asm:72
@@ -751,10 +752,12 @@ local function museumClerk(game, ow, done, onDecline)
           { money = money }))
       elseif yes then
         game.stack:push(TextBox.new(game,
-          "You don't have\nenough money.", onDecline or done, { money = money }))
+          t._Museum1FScientist1DontHaveEnoughMoneyText
+            or "You don't have\nenough money.", onDecline or done, { money = money }))
       else
         game.stack:push(TextBox.new(game,
-          "Come again!", onDecline or done, { money = money }))
+          t._Museum1FScientist1ComeAgainText
+            or "Come again!", onDecline or done, { money = money }))
       end
     end }))
 end

--- a/tests/engine/museum_1f_clerk_translation_test.lua
+++ b/tests/engine/museum_1f_clerk_translation_test.lua
@@ -1,0 +1,68 @@
+-- The museum 1F ticket clerk's take-your-time/not-enough-money/come-again
+-- lines used to be bare English literals, invisible to game.data.text no
+-- matter what a translation mod put there. tests/engine/museum_money_box_
+-- bug1335.lua only ever runs with an empty game.data.text, so it can't
+-- tell a properly-wired t._Key or "..." fallback apart from a literal that
+-- never looked at t at all -- every assertion there passes either way.
+-- This test populates game.data.text with translated values and checks
+-- they actually reach the pushed TextBox, for all three lines.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.harness")
+
+package.loaded["src.render.TextBox"] = {
+  new = function(_, text, onDone, opts)
+    return { text = text, onDone = onDone, opts = opts }
+  end,
+}
+
+local M = assert(loadfile("data/scripts/story2.lua"))()
+local clerk = M.MUSEUM_1F.talk.TEXT_MUSEUM1F_SCIENTIST1
+
+local TRANSLATED = {
+  _Museum1FScientist1TakePlentyOfTimeText = "Prends ton temps\net profite bien !",
+  _Museum1FScientist1DontHaveEnoughMoneyText = "Tu n'as pas assez\nd'argent.",
+  _Museum1FScientist1ComeAgainText = "Reviens vite !",
+}
+
+local pushed
+local function mkGame(cash)
+  pushed = {}
+  return {
+    data = { text = TRANSLATED },
+    save = { money = cash, flags = {} },
+    stack = { push = function(_, box) pushed[#pushed + 1] = box end },
+  }
+end
+
+-- already ticketed: take-your-time line
+local g = mkGame(3000)
+g.save.flags.EVENT_BOUGHT_MUSEUM_TICKET = true
+clerk(g, nil, nil, function() end)
+T.eq(pushed[1].text, TRANSLATED._Museum1FScientist1TakePlentyOfTimeText,
+  "an existing ticket holder gets the translated take-your-time line")
+
+-- YES but short on cash: not-enough-money line
+g = mkGame(20)
+clerk(g, nil, nil, function() end)
+pushed[1].opts.choice(true)
+T.eq(pushed[2].text, TRANSLATED._Museum1FScientist1DontHaveEnoughMoneyText,
+  "short on cash opens the translated not-enough-money box")
+
+-- NO: come-again line
+g = mkGame(3000)
+clerk(g, nil, nil, function() end)
+pushed[1].opts.choice(false)
+T.eq(pushed[2].text, TRANSLATED._Museum1FScientist1ComeAgainText,
+  "declining opens the translated come-again box")
+
+-- unpopulated game.data.text still falls back to the English literal
+g = { data = { text = {} }, save = { money = 3000, flags = {} },
+  stack = { push = function(_, box) pushed[#pushed + 1] = box end } }
+pushed = {}
+g.save.flags.EVENT_BOUGHT_MUSEUM_TICKET = true
+clerk(g, nil, nil, function() end)
+T.check(tostring(pushed[1].text):find("Take your time", 1, true) ~= nil,
+  "an empty catalog still falls back to the English take-your-time line")
+
+T.finish("museum_1f_clerk_translation_test")


### PR DESCRIPTION
## Bug

`data/scripts/story2.lua`, function `museumClerk()` (~line 731-762), prints five different lines for the Pewter Museum 1F ticket clerk. Two of them already go through `game.data.text` with an English fallback (`t._Museum1FScientist1WouldYouLikeToComeInText or "..."`, `t._Museum1FScientist1ThankYouText or "..."`), but the other three are plain Lua literals that never look at `game.data.text` at all, so they always render in English regardless of the active language:

- `"Take your time,\nand enjoy it all!"` (ticket already bought)
- `"You don't have\nenough money."`
- `"Come again!"` (declining the ticket)

## Fix

Wrap the three remaining literals in the same `t._Key or "..."` pattern already used for the other two lines in this function, with the label names the ROM manifests already extract (`_Museum1FScientist1TakePlentyOfTimeText`, `_Museum1FScientist1DontHaveEnoughMoneyText`, `_Museum1FScientist1ComeAgainText`). No data-model change, and the English literal stays as the fallback when a mod doesn't override it.

## Testing

- Added `tests/engine/museum_1f_clerk_translation_test.lua`: the existing `tests/engine/museum_money_box_bug1335.lua` only ever runs with an empty `game.data.text`, so it can't tell a properly wired `t._Key or "..."` fallback apart from a literal that never looked at `t` at all — every assertion there passes either way. The new test populates `game.data.text` with translated values for the three keys and checks they actually reach the pushed `TextBox`, for all three lines, plus one check that an empty catalog still falls back to the English literal. Confirmed it catches the regression: reverting `story2.lua` to its pre-fix content fails 3 of the test's 4 checks.
- `scripts/test.sh --quick`: no new failures.
- Ran `tests/engine/museum_money_box_bug1335.lua` and `tests/engine/pewter_museum_escort_bug1391.lua` directly — both still pass, since they run with an empty `game.data.text` and the fix's fallback preserves the exact same English strings they check for.
