### PR TITLE
SaveData: a fresh skeleton must not overwrite an existing playthrough binding

### DIFF
--- a/src/core/SaveData.lua
+++ b/src/core/SaveData.lua
@@ -1250,13 +1250,26 @@ function SaveData.ensurePlaythroughId(save, injectedFs)
   local isFresh = save == freshPlaythrough
   if isFresh then freshPlaythrough = nil end
   local byVersion = opts.playthroughIds and opts.playthroughIds[version]
-  id = not isFresh and byVersion and byVersion[scope] or nil
+  local existing = byVersion and byVersion[scope]
+  id = not isFresh and existing or nil
   if type(id) ~= "string" or id == "" then
     id = SaveData.newPlaythroughId()
-    opts.playthroughIds = opts.playthroughIds or {}
-    opts.playthroughIds[version] = opts.playthroughIds[version] or {}
-    opts.playthroughIds[version][scope] = id
-    SaveData.saveOptions(opts, injectedFs)
+    -- A fresh skeleton still gets its own id (two unsaved New Games sharing a
+    -- slot must stay distinct), and it is still persisted when the slot has no
+    -- binding yet -- that is the contract a tool relies on to resolve
+    -- `selected` at the title after a restart, before any normal SAVE.
+    --
+    -- What it must NOT do is OVERWRITE a binding that already exists. newGame()
+    -- marks a skeleton on the boot frame, before any save is loaded, and mods
+    -- initialise inside that window -- so a mod touching storage at init
+    -- replaced the real save's id with a throwaway, stranding that save's mod
+    -- storage and repeating on every launch.
+    if not (isFresh and type(existing) == "string" and existing ~= "") then
+      opts.playthroughIds = opts.playthroughIds or {}
+      opts.playthroughIds[version] = opts.playthroughIds[version] or {}
+      opts.playthroughIds[version][scope] = id
+      SaveData.saveOptions(opts, injectedFs)
+    end
   end
   save.meta.playthroughId = id
   return id


### PR DESCRIPTION
## The problem

`SaveData.ensurePlaythroughId()` treats a fresh New Game skeleton as having no id, mints one, and persists it into `opts.playthroughIds[version][scope]` — **even when that slot already names a playthrough**:

```lua
local isFresh = save == freshPlaythrough
id = not isFresh and byVersion and byVersion[scope] or nil   -- isFresh => nil
if type(id) ~= "string" or id == "" then
  id = SaveData.newPlaythroughId()
  opts.playthroughIds[version][scope] = id                   -- overwrites
  SaveData.saveOptions(opts, injectedFs)
end
```

`newGame()` marks the skeleton on the boot frame, before any save is loaded. Mods initialise inside that window, and it is the only point at which they can resolve storage — `Storage:selected` needs `TitleState`, which does not exist yet, so `Storage:context` → `_scope` → `ensurePlaythroughId` is the only path open to them.

So a mod touching `mod.storage` at init replaces the real save's id with a throwaway, stranding that save's mod storage — and it repeats on every launch.

## Observed

RG35XXSP, engine 0.2.1, PotatoVoxel 1.7.11:

- a new playthrough id in `options.lua` after **every** launch
- **32** orphaned `mod_storage/blue/<id>/` directories
- the mod's ~400 MB prebuilt mesh cache abandoned under the id `options.lua` previously named, so every map rebuilt from scratch

Measured directly: at boot `Storage:selected` returns nil and `context` returns a freshly minted id; ~5 s later, once `save.loaded` fires, both resolve to the save's real id. The mint in between is what destroys the mapping.

## The change

Only the **overwrite of an existing binding** is dropped. Both existing behaviours are kept:

- a fresh skeleton still gets its own id, so two unsaved New Games sharing a slot stay distinct
- it is still persisted when the slot has **no** binding yet — the contract `tests/modkit/cases/title_playthrough_context.lua` pins, where a tool persists before the first normal SAVE and the title must resolve it after a restart

## Tests

`./scripts/test.sh` — **ALL TIERS PASSED**

- `tests/modkit/cases/title_playthrough_context.lua` — 44/44
- `tests/engine/playthrough_identity.lua` — 18/18

*(An earlier revision of this PR skipped the persist for any fresh skeleton. That broke the title/tool contract above — CI caught it, `36/37` with `no_selected_playthrough`. The current revision narrows it to the overwrite case, which is the only part that causes the bug.)*
