### PR TITLE
rg34xxsp launcher: also resolve GAMEDIR on split-tree firmwares (muOS)

### DIFF
--- a/build-rg34xxsp.sh
+++ b/build-rg34xxsp.sh
@@ -193,6 +193,26 @@ get_controls
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 GAMEDIR="$SHDIR/gen1recomp"
+# Anbernic stock keeps the launcher and the game folder side by side, so the
+# SHDIR-relative path above is correct there and is tried first.
+#
+# Other firmwares (muOS, and PortMaster's layout on several devices) keep
+# launcher scripts and port data in SEPARATE trees -- scripts under roms/ports,
+# data under ports -- so the sibling folder holds no game.
+#
+# Probe for the BINARY, not the directory: on a split layout this script has
+# usually already created "$SHDIR/gen1recomp/conf" and log.txt on an earlier
+# failed run (see mkdir/tee below), so an existence test matches a decoy of our
+# own making. Stock is unaffected -- its sibling holds the real binary and wins
+# on the first test.
+if [ ! -f "$GAMEDIR/bin/love.aarch64" ]; then
+  for candidate in "/$directory/ports/gen1recomp" \
+                   "/mnt/sdcard/ports/gen1recomp" \
+                   "/mnt/mmc/ports/gen1recomp" \
+                   "/roms/ports/gen1recomp"; do
+    if [ -f "$candidate/bin/love.aarch64" ]; then GAMEDIR="$candidate"; break; fi
+  done
+fi
 CONFDIR="$GAMEDIR/conf"
 mkdir -p "$CONFDIR"
 


### PR DESCRIPTION
## The problem

The generated launcher resolves the game folder as the script's sibling:

```sh
SHDIR="$(cd "$(dirname "$0")" && pwd)"
GAMEDIR="$SHDIR/gen1recomp"
...
cd "$GAMEDIR" || exit 1
```

That is correct on Anbernic stock, and I'm deliberately not touching it — the comment above it in `build-rg34xxsp.sh` explains that PortMaster's `$directory` was avoided there because Anbernic uses `roms/PORTS` with different casing and mount points.

But firmwares that keep launcher scripts and port data in **separate trees** have no game beside the script. muOS puts scripts in `roms/ports/` and port data in `ports/` (PortMaster's layout on several devices does the same), so `$SHDIR/gen1recomp` holds no game and the port never starts.

## The change

Try the sibling first, exactly as now. Fall back to the split layouts only when the sibling holds no game.

## Why it probes for the binary, not the directory

This is the part worth reviewing. On a split layout the launcher has usually **already created `$SHDIR/gen1recomp` itself** on an earlier failed run — `mkdir -p "$CONFDIR"` and the `tee` log redirect both run before anything checks whether the game is there.

On my muOS RG35XXSP that decoy exists right now and contains exactly:

```
/mnt/union/ROMS/Ports/gen1recomp/
├── conf/
└── log.txt
```

So a `[ -d "$GAMEDIR" ]` test matches a directory the script made itself, and resolution still fails. Testing for `bin/love.aarch64` avoids that. I had the directory test in this patch first and the device caught it.

## Verified

Resolution logic tested across four layouts:

| case | result |
|---|---|
| stock: sibling holds the binary | sibling wins |
| stock, with a populated path elsewhere too | sibling still wins |
| split: sibling is the self-made decoy (`conf/` + `log.txt`) | falls through to the real game dir |
| no game anywhere | value unchanged — same failure as today |

And live on a muOS RG35XXSP (engine 0.2.4): resolves to `/mnt/sdcard/ports/gen1recomp`, with `bin/love.aarch64` and `lovegame/` both present.

Stock behaviour is unchanged in every case — the fallback only runs when the current code would already have failed.
