### PR TITLE
fix(gen2): refresh caches missing trainer HUD balls

### DIFF
--- a/src/import/RomImporter.lua
+++ b/src/import/RomImporter.lua
@@ -136,6 +136,9 @@ local VERSION_REQUIRED_FILES_OVERRIDE = {
     -- costs nothing on a current cache and is the difference between every
     -- trainer battle opening with a picture and opening with none.
     "assets/generated/battle/trainers/falkner.png",
+    -- BattleStart_TrainerHuds cannot draw its party rows from a cache made
+    -- before the four ball tiles were extracted (#1502).
+    "assets/generated/battle/hud/balls.png",
     "assets/generated/audio/programs.bin",
   },
 }

--- a/tests/engine/rom_importer_source_tree_test.lua
+++ b/tests/engine/rom_importer_source_tree_test.lua
@@ -26,5 +26,7 @@ check(helperStart ~= nil, "requiredFilesFor helper exists")
 local helper = src:sub(helperStart, start)
 check(helper:find("VERSION_REQUIRED_FILES_OVERRIDE", 1, true) ~= nil,
   "requiredFilesFor consults VERSION_REQUIRED_FILES_OVERRIDE")
+check(src:find('"assets/generated/battle/hud/balls.png"', 1, true) ~= nil,
+  "Gold caches require the trainer HUD ball sheet")
 
 T.finish()


### PR DESCRIPTION
## Summary
- require Gold's extracted trainer HUD ball sheet as part of a complete ROM cache
- make caches created before the sheet was added re-import once instead of silently drawing only the HUD border
- cover the Gold cache contract with the existing importer regression test

## Why
The Gen 2 renderer and extractor already support the party ball rows, but an older Gold cache can still carry a valid completion marker without `assets/generated/battle/hud/balls.png`. `BattleHud:drawBallRow` then returns early, so updating the app alone cannot repair the display.

## Compatibility
- only stale Gold caches missing this file are invalidated
- current Gold caches remain ready
- Red, Blue, and Yellow cache requirements are unchanged
- no battle rendering or save data behavior changes

## Testing
- `RomImporter.lua` compiles under LuaJIT
- `rom_importer_source_tree_test.lua`: 7/7 checks passed

Closes #1502