### PR TITLE
Give bide its two carve-outs on Gold

### DIFF
--- a/src/battle/gen2/Battle.lua
+++ b/src/battle/gen2/Battle.lua
@@ -1389,7 +1389,15 @@ function Battle:useMove(attacker, defender, moveId)
   -- free of PP and obedience in exactly the same way.
   local rolling = state.rolloutLock == moveId
 
-  if not (charging or rampaging or rolling) then
+  -- The doturn command returns early when the user's substatus carries
+  -- SUBSTATUS_BIDE (effect_commands.asm:978-979), and StoreEnergy's
+  -- continuation skips straight to unleashenergy on every turn after the
+  -- first (move_effects/bide.asm:61-62).  So the whole run costs the one PP
+  -- the opening turn spent, the same way a rampage costs one.
+  local biding = def.effect == "EFFECT_BIDE"
+    and state.bideMove == moveId and (state.bideTurns or 0) > 0
+
+  if not (charging or rampaging or rolling or biding) then
     if move and (move.pp or 0) <= 0 then
       self:emit({ kind = "message", text = "No PP left for this move!" })
       return
@@ -2133,6 +2141,8 @@ Battle.MOVE_EFFECTS.EFFECT_BIDE = function(self, attacker, defender, def, moveId
   if not state.bideTurns then
     state.bideTurns = Effects.bideTurns(self.random)
     state.bideStored = 0
+    -- what the lock below holds the user on, the way rampageMove does
+    state.bideMove = moveId
     self:emit({ kind = "message",
       text = self:monName(attacker) .. " is storing energy!" })
     return
@@ -2144,7 +2154,7 @@ Battle.MOVE_EFFECTS.EFFECT_BIDE = function(self, attacker, defender, def, moveId
     return
   end
   local damage = Effects.bideDamage(state.bideStored)
-  state.bideTurns, state.bideStored = nil, nil
+  state.bideTurns, state.bideStored, state.bideMove = nil, nil, nil
   self:emit({ kind = "message",
     text = self:monName(attacker) .. " unleashed energy!" })
   if damage <= 0 then return fail(self) end
@@ -3780,6 +3790,15 @@ function Battle:lockedInMove(mon)
   if state.rolloutLock then return state.rolloutLock end
   if state.rampageMove and (state.rampageTurns or 0) > 0 then
     return state.rampageMove
+  end
+  -- The player's menu is skipped while SUBSTATUS_BIDE is set
+  -- (core.asm:574-576) and CheckEnemyLockedIn masks the same bit
+  -- (:5648-5651), so a storing bide holds both sides.  Without it the counter
+  -- never reached zero and bideStored kept banking, so the next bide
+  -- unleashed an inflated hit.  Gen 1 holds the menu at
+  -- BattleState:fightLockedAction.
+  if state.bideMove and (state.bideTurns or 0) > 0 then
+    return state.bideMove
   end
   return nil
 end

--- a/tests/engine/gen2_bide_lock_and_pp.lua
+++ b/tests/engine/gen2_bide_lock_and_pp.lua
@@ -1,0 +1,165 @@
+-- Bide on Gold, against the two carve-outs the cart makes for it.
+--
+-- PP (#1664): the doturn command returns early when the user's substatus
+-- carries SUBSTATUS_BIDE (engine/battle/effect_commands.asm:978-979), and
+-- StoreEnergy's continuation skips straight to unleashenergy on every turn
+-- after the first (engine/battle/move_effects/bide.asm:61-62), so the whole
+-- run costs the one PP the opening turn spent.
+--
+-- Lock-in (#1665): the player's menu is skipped while SUBSTATUS_BIDE is set
+-- (engine/battle/core.asm:574-576) and CheckEnemyLockedIn masks the same bit
+-- (:5648-5651), so neither side can pick anything else while bide stores.
+-- Gen 1 already holds the menu this way, at BattleState:fightLockedAction.
+--
+--   luajit tests/engine/gen2_bide_lock_and_pp.lua
+--
+-- ROM-free: the fixtures below are the extractor's shapes.
+
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = require("tests.love_stub")
+
+local T = require("tests.harness")
+local Battle = require("src.battle.gen2.Battle")
+local Mon = require("src.battle.gen2.Mon")
+
+local check, eq = T.check, T.eq
+
+-- ---------------------------------------------------------------- fixtures
+
+local TYPES = {
+  NORMAL = { id = "NORMAL", index = 0, category = "physical" },
+}
+
+local MOVES = {
+  BIDE = { id = "BIDE", name = "BIDE", power = 0, type = "NORMAL",
+    accuracy = 100, pp = 10, effect = "EFFECT_BIDE" },
+  TACKLE = { id = "TACKLE", name = "TACKLE", power = 35, type = "NORMAL",
+    accuracy = 100, pp = 35, effect = "EFFECT_NORMAL_HIT" },
+  GROWL = { id = "GROWL", name = "GROWL", power = 0, type = "NORMAL",
+    accuracy = 100, pp = 40, effect = "EFFECT_ATTACK_DOWN" },
+}
+
+local GROWTH = {
+  GROWTH_MEDIUM_SLOW = { numerator = 6, denominator = 5, squared = -15,
+    linear = 100, constant = 140 },
+}
+
+local function species(id, index)
+  return { id = id, index = index, name = id,
+    baseStats = { hp = 60, attack = 60, defense = 60, speed = 60,
+      specialAttack = 60, specialDefense = 60 },
+    types = { "NORMAL", "NORMAL" }, catchRate = 255, baseExp = 60,
+    growthRate = "GROWTH_MEDIUM_SLOW", genderRatio = 31,
+    levelMoves = { { level = 1, move = "TACKLE" } }, evolutions = {} }
+end
+
+local POKEMON = {
+  growthRates = GROWTH,
+  MACHOP = species("MACHOP", 66),
+  RATTATA = species("RATTATA", 19),
+}
+
+local DATA = { pokemon = POKEMON, moves = MOVES,
+  type_chart = { types = TYPES, matchups = {} }, items = {} }
+
+local perfect = { attack = 15, defense = 15, speed = 15, special = 15 }
+perfect.hp = Mon.hpDV(perfect)
+
+-- The smallest roll that is neither a critical hit nor a miss.
+local function detRandom(n)
+  if (n or 1) <= 1 then return 0 end
+  return 1
+end
+
+-- A level 50 player against a level 5 foe, so nothing faints mid-run and the
+-- turn count is the only thing under test.  The foe attacks so bide banks
+-- something real.
+local function newBattle()
+  local player = Mon.new(DATA, "MACHOP", 50, { dvs = perfect })
+  player.moves = {
+    { id = "BIDE", pp = 10, maxPp = 10 },
+    { id = "TACKLE", pp = 35, maxPp = 35 },
+  }
+  local wild = Mon.new(DATA, "RATTATA", 5, { dvs = perfect })
+  wild.moves = { { id = "TACKLE", pp = 35, maxPp = 35 } }
+  local battle = Battle.new({ data = DATA, party = { player }, wild = wild,
+    random = detRandom })
+  return battle, player
+end
+
+local function slot(mon, id)
+  for _, move in ipairs(mon.moves or {}) do
+    if move.id == id then return move end
+  end
+end
+
+local function said(events)
+  local out = {}
+  for _, event in ipairs(events or {}) do
+    if event.kind == "message" and event.text then out[#out + 1] = event.text end
+  end
+  return table.concat(out, " | ")
+end
+
+-- Run bide to its unleash, picking `pick` every turn.  Returns the number of
+-- turns it took and the text of the last one.
+local function runBide(battle, pick)
+  local turns, last = 0, ""
+  for _ = 1, 8 do
+    turns = turns + 1
+    last = said(battle:takeTurn({ kind = "move", move = pick }))
+    if last:find("unleashed energy!", 1, true) then break end
+  end
+  return turns, last
+end
+
+-- ---- #1664: the whole run costs one PP ------------------------------------
+do
+  local battle, player = newBattle()
+  local bide = slot(player, "BIDE")
+  local turns = runBide(battle, "BIDE")
+  check(turns > 1, "bide stored for at least one turn before unleashing")
+  eq(bide.pp, bide.maxPp - 1,
+    ("bide spent one PP across %d turns, not one per turn"):format(turns))
+end
+
+-- ---- #1665: the menu is held while bide stores ----------------------------
+do
+  local battle, player = newBattle()
+  battle:takeTurn({ kind = "move", move = "BIDE" })
+
+  eq(battle:lockedInMove(player), "BIDE",
+    "lockedInMove holds the user on bide while it stores")
+  eq(battle:forcedMove(player), "BIDE",
+    "and forcedMove reports the same, which is what the menu reads")
+
+  local usable = battle:usableMoves(player)
+  eq(#usable, 1, "only one move is selectable while bide stores")
+  eq(usable[1] and usable[1].id, "BIDE", "and it is bide")
+end
+
+-- ---- #1665: picking something else cannot strand the counter --------------
+-- Without the lock the menu's TACKLE ran, bideTurns never reached zero and
+-- bideStored kept banking, so the next bide unleashed an inflated hit.
+do
+  local battle, player = newBattle()
+  local tackle = slot(player, "TACKLE")
+  battle:takeTurn({ kind = "move", move = "BIDE" })
+  local turns = runBide(battle, "TACKLE")
+
+  check(turns <= 7, "bide still reaches its unleash when the menu says TACKLE")
+  eq(tackle.pp, tackle.maxPp, "and the move the menu named was never spent")
+  eq(battle:volatile(player).bideTurns, nil,
+    "the counter is cleared rather than stranded")
+end
+
+-- ---- the lock ends with the unleash ---------------------------------------
+do
+  local battle, player = newBattle()
+  runBide(battle, "BIDE")
+  eq(battle:lockedInMove(player), nil, "the lock lifts once bide unleashes")
+  eq(battle:volatile(player).bideStored, nil, "and the store is cleared with it")
+end
+
+T.finish("gold bide lock-in and pp")


### PR DESCRIPTION
Closes #1664 and #1665. They land together because the lock needs a record of
which move it is holding, and the PP exemption reads the same field.

### #1665, the lock

`Battle:lockedInMove` returned only `state.rolloutLock` and `state.rampageMove`,
so nothing held either side on bide. The menu and the ai could both pick
something else while it stored, `bideTurns` never reached zero, and
`bideStored` kept banking for the rest of the battle, so the next bide
unleashed an inflated hit.

The cart skips `MoveSelectionScreen` while `SUBSTATUS_BIDE` is set:

```
	ld a, [wPlayerSubStatus3]
	and 1 << SUBSTATUS_BIDE
	jr nz, .locked_in          ; engine/battle/core.asm:574-576
```

and `CheckEnemyLockedIn` masks the same bit alongside charged and rampage
(`:5648-5651`). Gen 1 already holds the menu, at
`BattleState:fightLockedAction`, so this is the Gen 2 side catching up rather
than a new idea.

`state.bideMove` is the record. It is set beside `bideTurns` and cleared with
it, which is the shape `rampageMove` already uses.

### #1664, the PP

The carve-out in `useMove` read `if not (charging or rampaging or rolling)`,
with no bide term, so a bide that stored for three turns cost 3 PP.

`doturn` returns before `.consume_pp` when the user carries the bit:

```
	ld a, [de]
	and 1 << SUBSTATUS_IN_LOOP | 1 << SUBSTATUS_RAMPAGE | 1 << SUBSTATUS_BIDE
	ret nz                     ; engine/battle/effect_commands.asm:978-979
```

and StoreEnergy's continuation skips straight to `unleashenergy_command` on
every turn after the first (`engine/battle/move_effects/bide.asm:61-62`). So
the whole run costs the one PP the opening turn spent, the same way a rampage
costs one.

The bit is set by StoreEnergy, which runs after `doturn`, so the opening turn
still pays. That ordering is why the guard tests `bideTurns` rather than the
move id alone.

### Tests

`tests/engine/gen2_bide_lock_and_pp.lua` drives real turns and asserts the run
costs one PP, that the menu is held while bide stores, that a menu naming
another move cannot strand the counter, and that the lock lifts with the
unleash. `tests/run_engine.lua` picks it up on its own: **289/289 suites, ALL
TESTS PASSED**.

Against the code as it stood it is **4/11, 7 failures**, including the
stranding itself:

```
FAIL bide spent one PP across 4 turns, not one per turn (got 6, want 9)
FAIL lockedInMove holds the user on bide while it stores (got nil, want BIDE)
FAIL the counter is cleared rather than stranded (got 3, want nil)
```

`tests/gen2_battle_test.lua` stays at 705 checks, 0 failures.

`scripts/lint.sh --gate` is clean, 0 warnings and 0 errors across 482 files.

Five suites fail on this branch (`gen2_font_ui_test`, `gen2_menus_test`,
`mod_ui_tests`, `parity_android_permissions`, `run_content_red`). I ran the
whole of `tests/` and `tests/engine/` against `dev` at `15fc04e0` in a second
worktree: identical five, so nothing here regressed them.

### One thing I did not touch

Bide's turn count. With `Effects.bideTurns` rolling 2 or 3 and the decrement
happening on the turns after the opening one, a run takes 4 turns end to end
in this port. Whether that matches `wPlayerCharging` on the cart is a separate
question from either issue here, so I left it alone rather than fold a third
change in.
