### PR TITLE
Import the cart Choose ROM asked for

### DIFF
--- a/src/import/RomImporter.lua
+++ b/src/import/RomImporter.lua
@@ -1086,13 +1086,19 @@ end
 -- naive "first ROM wins" scan would re-import Red when the player tries to
 -- add Blue (issue #167).  Yellow and Gold carts are typically .gbc (Gold is
 -- 2 MiB).
-local function findPendingRom(ready)
+-- `wanted` narrows the scan to one version.  A Choose names the cart it is
+-- for, so without it several dumps sitting in the save directory answered in
+-- listing order and the selection was dropped: picking Red imported Blue
+-- (#1274).  The callers that are not a Choose, the Android USB-drop scans,
+-- pass nothing and still take the first pending cart of any version.
+local function findPendingRom(ready, wanted)
   for _, name in ipairs(love.filesystem.getDirectoryItems("")) do
     if name:lower():match("%.gbc?$") and love.filesystem.getInfo(name, "file") then
       local data = love.filesystem.read(name)
       if type(data) == "string" and isAcceptedRomSize(#data) then
         local version = GameVersion.forSha1(sha1(data))
-        if version and not ready[version] then
+        if version and not ready[version]
+            and (wanted == nil or version == wanted) then
           return name, data
         end
       end
@@ -2575,8 +2581,9 @@ function RomImporter:choose(version)
   if self.android then
     -- Prefer a not-yet-imported .gb/.gbc already in the save dir (USB copy, or
     -- a fresh SAF pick).  Never reuse an already-imported cart's file -- that
-    -- was the #167 failure mode (second Choose just re-extracted Red).
-    local name, data = findPendingRom(self.ready)
+    -- was the #167 failure mode (second Choose just re-extracted Red).  This
+    -- is a Choose, so it takes the cart that was asked for and nothing else.
+    local name, data = findPendingRom(self.ready, self.chooseVersion)
     if name then
       self:startData(data, name)
     elseif consumePickedRomError(self) then
@@ -2604,8 +2611,10 @@ function RomImporter:choose(version)
   -- Handheld Linux (Anbernic stock OS / PortMaster) rarely has zenity or
   -- kdialog.  Fall back to the same "drop a .gb/.gbc next to the game" scan
   -- used on Android, which works when the game is launched as an unpacked
-  -- directory (see build-rg34xxsp.sh).
-  local name, data = findPendingRom(self.ready)
+  -- directory (see build-rg34xxsp.sh).  Narrowed to the chosen version: with
+  -- four dumps in the folder the unnarrowed scan answered in listing order,
+  -- so Choose Red imported and decoded Blue (#1274).
+  local name, data = findPendingRom(self.ready, self.chooseVersion)
   if name then
     self:startData(data, name)
     return

--- a/tests/rom_importer_choose_version_test.lua
+++ b/tests/rom_importer_choose_version_test.lua
@@ -1,0 +1,126 @@
+-- #1274: with several cartridge dumps sitting in the save directory, Choose
+-- ROM imported whichever version was not yet ready rather than the one the
+-- player picked.  Select Red, get Blue.
+--
+-- The fallback exists for devices with no file picker (handheld Linux with
+-- no zenity or kdialog, and the Android USB-drop path), where chooseRom
+-- returns nil and the importer scans the save directory instead.  That scan,
+-- findPendingRom, answered with the first dump whose SHA-1 mapped to any
+-- not-yet-ready version, so the selection was dropped on the floor.
+--
+-- Self-contained: `luajit tests/rom_importer_choose_version_test.lua`
+package.path = "./?.lua;./?/init.lua;" .. package.path
+if not _G.love then _G.love = require("tests.love_stub") end
+
+local S = require("tests.harness").suite("rom importer honours the chosen version")
+local eq = S.eq
+local check = S.check
+
+local RomImporter = require("src.import.RomImporter")
+local GameVersion = require("src.core.GameVersion")
+
+local ROM_BYTES = 1024 * 1024
+
+-- One dump per version, each a blob of the right size whose first byte says
+-- which cart it is.  love.data.hash is stubbed to answer with the real SHA-1
+-- from GameVersion, so GameVersion.forSha1 does its own lookup unchanged.
+local MARK = { R = "red", B = "blue", Y = "yellow" }
+local FILES = {
+  ["blue.gb"] = string.rep("B", ROM_BYTES),
+  ["red.gb"] = string.rep("R", ROM_BYTES),
+  ["yellow.gbc"] = string.rep("Y", ROM_BYTES),
+}
+-- Deliberately not alphabetical and not selection order: the bug returned
+-- whatever getDirectoryItems listed first.
+local LISTING = { "blue.gb", "red.gb", "yellow.gbc" }
+
+love.system = love.system or {}
+love.data = love.data or {}
+
+local saved = {
+  getOS = love.system.getOS,
+  hash = love.data.hash,
+  encode = love.data.encode,
+  getDirectoryItems = love.filesystem.getDirectoryItems,
+  getInfo = love.filesystem.getInfo,
+  read = love.filesystem.read,
+  getSaveDirectory = love.filesystem.getSaveDirectory,
+}
+
+-- Not OS X, Windows or Linux, so chooseRom returns nil without shelling out
+-- to a dialog that may or may not exist on the machine running the suite.
+-- The fallback under test is the same one every pickerless device takes.
+love.system.getOS = function() return "Unknown" end
+love.filesystem.getSaveDirectory = function() return "/tmp/pokemon-love2d" end
+love.filesystem.getDirectoryItems = function() return LISTING end
+love.filesystem.getInfo = function(name, filter)
+  if FILES[name] then return { type = "file", size = #FILES[name] } end
+  return nil
+end
+love.filesystem.read = function(name) return FILES[name] end
+-- RomImporter's sha1 helper is hash then encode-to-hex, so the pair is
+-- stubbed together: hash answers with the digest already in the form
+-- GameVersion stores, and encode hands it back untouched.
+love.data.hash = function(_, data)
+  local version = MARK[data:sub(1, 1)]
+  return version and GameVersion.info(version).sha1 or "0"
+end
+love.data.encode = function(_, _, digest) return digest end
+
+local function freshImporter()
+  return setmetatable({
+    android = false,
+    nativePicker = false,
+    workState = nil,
+    ready = { red = false, blue = false, yellow = false },
+    notice = nil,
+    modNotice = nil,
+    saveNotice = {},
+    baseRoms = {},
+    chooseVersion = nil,
+    startData = function(self, data, displayName)
+      self._started = { data = data, name = displayName }
+    end,
+    startPath = function(self, path) self._startedPath = path end,
+  }, RomImporter)
+end
+
+-- ------- the report: pick Red, get Red
+
+local ri = freshImporter()
+ri:choose("red")
+check(ri._started ~= nil, "a pickerless Choose still imports from the save dir")
+eq(ri._started and ri._started.name, "red.gb",
+  "and it imports the cart that was chosen, not the first pending one")
+
+-- ------- the same for a version listed after another pending dump
+
+ri = freshImporter()
+ri:choose("yellow")
+eq(ri._started and ri._started.name, "yellow.gbc",
+  "Yellow is imported for Yellow, with Blue and Red still pending")
+
+-- ------- a chosen version with no dump present imports nothing
+
+ri = freshImporter()
+ri.ready = { red = false, blue = false, yellow = false, gold = false }
+ri:choose("gold")
+check(ri._started == nil,
+  "choosing a version whose dump is absent imports no other cart")
+
+-- ------- an already-imported cart is still never re-extracted (#167)
+
+ri = freshImporter()
+ri.ready = { red = true, blue = false, yellow = false }
+ri:choose("red")
+check(ri._started == nil,
+  "and a version already imported is not extracted a second time")
+
+for name, fn in pairs(saved) do
+  if name == "getOS" then love.system.getOS = fn
+  elseif name == "hash" then love.data.hash = fn
+  elseif name == "encode" then love.data.encode = fn
+  else love.filesystem[name] = fn end
+end
+
+S.finish()

--- a/tests/run_tests.lua
+++ b/tests/run_tests.lua
@@ -3623,6 +3623,8 @@ runSuites({ "tests/rom_importer_android_mod_pick_test.lua" })
 -- ---------------------------------------------- import with no picker (#482)
 runSuites({ "tests/rom_importer_no_picker_test.lua" })
 runSuites({ "tests/rom_importer_double_pick_test.lua" })
+-- the same pickerless scan, asked for one version in particular (#1274)
+runSuites({ "tests/rom_importer_choose_version_test.lua" })
 -- ---------------------------------------------- Switch platform capabilities
 -- platform_nx_* / rom_importer_nx_* live in tests/engine/ (ROM-free T2) so
 -- CI's headless lane runs them without data/generated/.


### PR DESCRIPTION
Closes #1274.

`findPendingRom` answered with the first dump in the save directory whose
SHA-1 mapped to **any** not-yet-ready version:

```lua
local version = GameVersion.forSha1(sha1(data))
if version and not ready[version] then
  return name, data
end
```

On a device with no file picker that scan *is* the import, so the version the
player selected never reached it. With Red, Blue, Yellow and Gold sitting in
the folder, choosing Red imported and decoded Blue, exactly as reported.

`findPendingRom` now takes an optional version and narrows to it. Which
callers pass it is the whole change:

| call site | passes | why |
|---|---|---|
| `choose`, pickerless fallback | `self.chooseVersion` | a Choose names the cart it is for |
| `choose`, Android USB drop | `self.chooseVersion` | same, and it keeps the #167 guard |
| startup save-dir scan | nothing | no version was asked for |
| Android focus handler | nothing | same |

So the two Android USB-drop scans keep taking the first pending cart of any
version, which is what they exist for.

One behaviour change worth naming: choosing a version whose dump is not
present now imports **nothing** instead of silently importing a different
cart, and falls through to the notice that already says where to copy the
file. Decoding the wrong game seemed like the worse of the two.

### Tests

`tests/rom_importer_choose_version_test.lua` drives the real `choose` through
the pickerless path with three dumps in a stubbed save directory. Against the
code as it stood it is **1/5**, and the first failure is the report itself:

```
FAIL and it imports the cart that was chosen, not the first pending one (got blue.gb, want red.gb)
FAIL Yellow is imported for Yellow, with Blue and Red still pending (got blue.gb, want yellow.gbc)
FAIL choosing a version whose dump is absent imports no other cart
FAIL and a version already imported is not extracted a second time
```

It is registered in `tests/run_tests.lua` beside the other pickerless suites,
since the `rom_importer_*` files are listed there by name rather than globbed.
An unregistered suite is #1671 all over again.

`love.system.getOS` is stubbed to a platform that is not OS X, Windows or
Linux so `chooseRom` returns nil without shelling out to a dialog that may or
may not exist on the machine running the suite. The fallback under test is the
same one every pickerless device takes.

All nine `rom_importer_*` suites pass. `scripts/lint.sh --gate` is clean, 0
warnings and 0 errors across 482 files.

Five suites fail on this branch (`gen2_font_ui_test`, `gen2_menus_test`,
`mod_ui_tests`, `parity_android_permissions`, `run_content_red`). I ran the
whole of `tests/` and `tests/engine/` against `dev` at `51bc4c74` in a second
worktree: identical five, so nothing here regressed them.
