### PR TITLE
Add opt-in marker for mod options screens

### DIFF
--- a/src/ui/Screens.lua
+++ b/src/ui/Screens.lua
@@ -124,6 +124,14 @@ local function build(game, id, ...)
     inst = factory.new(game, ...)
   end
   inst.screenId = inst.screenId or id
+  -- Standardized opt-in marker for mod-created options/settings screens.
+  -- A mod may declare `isModOptions = true` on its screen factory table or
+  -- on the returned instance.  Either way the flag is propagated so that other
+  -- UI mods can detect mod options screens reliably without brittle screenId
+  -- string-matching (issue #1697).
+  if factory.isModOptions and inst.isModOptions == nil then
+    inst.isModOptions = true
+  end
   return inst
 end
 


### PR DESCRIPTION
Fixes #1697

Adds a standardized `isModOptions` opt-in marker for mod-created options/settings screens.

Mods can declare `isModOptions = true` on their screen factory table, and `Screens.build()` propagates it to the returned screen instance unless the instance already defines its own value.

This gives UI mods a reliable way to identify mod options screens without depending on brittle `screenId` string matching.

Validated end-to-end with the Quality of Life mod and Gen1BetterMenus.