### PR TITLE
feat(mod-api): expose developer mode to mods

### DIFF
--- a/docs/modding.md
+++ b/docs/modding.md
@@ -695,6 +695,13 @@ hotkeys. Either set `POKEPORT_DEV=1` in the environment or pass
 love . --developer
 ```
 
+Every sandboxed mod receives the strict boolean `mod.dev`. It is fixed when
+the loader is created and is `true` only for this developer-mode boot. Mods may
+use it to register diagnostic commands or screens and to emit verbose seed or
+balance traces without reading `os.getenv`; production behavior should remain
+quiet when it is `false`. The value grants no permission and exposes no host
+environment data.
+
 While developer mode is active:
 
 - `` ` `` (backtick) opens the console overlay — a Lua REPL with `game`,

--- a/docs/rfcs/0017-public-mod-developer-mode-signal.md
+++ b/docs/rfcs/0017-public-mod-developer-mode-signal.md
@@ -1,0 +1,71 @@
+# RFC 0017: Public mod developer-mode signal
+
+## Status
+
+Proposed.
+
+## Motivation
+
+The engine already has one fixed developer-mode decision per boot, enabled by
+`POKEPORT_DEV=1` or `--developer`, but a sandboxed mod cannot observe that
+decision through the public API. Commands, screens, and exports can expose a
+diagnostic surface, but none can make it developer-only. `force_enable_env`
+controls whether a mod is enabled rather than explaining the boot mode, and
+the legacy `os.getenv` compatibility shim deliberately hides arbitrary host
+environment values and reports compatibility usage.
+
+The concrete consumer is **Adaptive Trainers**. Its approved Chapter 30
+diagnostics must expose trainer, boss, Rival, and League projections and log
+random-choice seed labels only while `POKEPORT_DEV` is active; a production
+boot must emit only normal errors and warnings. Without a public signal the mod
+must either ship an ungated diagnostic surface, use a legacy environment shim,
+or leave the required runtime tooling disconnected.
+
+## Decision and plan extended
+
+This implements **D-AT-005: developer diagnostics follow the engine's fixed
+developer-mode authority**. The consuming work is tracked in Adaptive Trainers
+Task 9:
+[`docs/superpowers/plans/2026-08-14-adaptive-trainers.md`](https://github.com/MaxTomahawk/gen1recomp-adaptive-trainers/blob/main/docs/superpowers/plans/2026-08-14-adaptive-trainers.md).
+
+The engine delta is generic. It contains no trainer state, diagnostic schema,
+seed labels, commands, screens, or Adaptive Trainers policy.
+
+## Exact API delta
+
+Every sandboxed mod API object receives:
+
+```lua
+if mod.dev then
+  mod.commands:register("diagnose", function(ctx)
+    -- mod-owned developer tooling
+  end)
+end
+```
+
+`mod.dev` is a strict boolean snapshot of the loader's existing developer-mode
+decision. It is fixed for the engine boot. Assigning another value on a mod's
+private API table cannot change the loader, another mod, or engine developer
+mode. The signal grants no permission and exposes no environment value, command
+line, path, or host API.
+
+## Migration and compatibility
+
+Existing mods change nothing. The field is additive, requires no manifest
+permission, and is allocated only as part of an API object for a loaded mod.
+With no mods, no API object or export table is created and developer mode keeps
+its existing engine behavior. Existing developer console and hot-reload
+behavior is unchanged.
+
+## Verification
+
+- `tests/modkit/cases/dev_mode.lua` loads a sandboxed public mod with the
+  injected developer tripwire disabled and enabled, proves a strict boolean,
+  and proves no legacy environment report is produced.
+- `tests/engine/dev_mode_no_mod_parity.lua` is the separate no-mod parity test;
+  it proves both tripwire states allocate no mod or export object, preserve the
+  active dataset object, and retain the same deterministic link fingerprint.
+
+## Deprecation etiquette
+
+Nothing is removed, renamed, superseded, or deprecated.

--- a/src/mods/Loader.lua
+++ b/src/mods/Loader.lua
@@ -270,7 +270,7 @@ function Loader.new(opts)
     modSave = {}, modOptions = {}, optionSchemas = {}, imageCache = {},
     modInput = {}, modEnv = {}, stepsQueues = {},
     fs = (opts and opts.fs) or (love and love.filesystem),
-    dev = dev,
+    dev = dev == true,
     safeMode = false,
     -- Which generation this boot is (1 or 2).  Fixed at construction: the
     -- active version is set once in main.lua's bootGame before anything
@@ -980,6 +980,9 @@ function Loader:_api(mod)
     id = modId,
     version = mod.manifest.version,
     path = mod.path,
+    -- Fixed for this engine boot. Mods can gate diagnostic surfaces without
+    -- reading the host environment or opting into a legacy compatibility shim.
+    dev = loader.dev == true,
     -- a deep copy: what a mod does to its own view never reaches the loader
     manifest = Merge.deepCopy(mod.manifest),
     content = {},

--- a/tests/engine/dev_mode_no_mod_parity.lua
+++ b/tests/engine/dev_mode_no_mod_parity.lua
@@ -1,0 +1,22 @@
+-- Developer-mode reflection is allocated only with a mod API object; toggling
+-- the engine tripwire with no mods leaves the fixture dataset unchanged.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.modkit")
+local Fingerprint = require("src.link.Fingerprint")
+
+for _, enabled in ipairs({ false, true }) do
+  local data = T.fixtures.fresh()
+  local expected = Fingerprint.compute(data, {})
+  local run = T.sdk.loadNone({ data = data, dev = enabled })
+  T.eq(#run.errors, 0, "no-mod boot remains clean")
+  T.eq(next(run.loader.mods), nil, "no mod API object is allocated")
+  T.eq(next(run.loader.exports), nil, "no mod export table is allocated")
+  T.check(run.data == data,
+    "no-mod boot preserves the active dataset object")
+  T.eq(Fingerprint.compute(run.data, {}), expected,
+    "developer-mode state leaves the no-mod link surface byte-equivalent")
+  run.release()
+end
+
+T.finish("developer-mode no-mod parity")

--- a/tests/modkit/cases/dev_mode.lua
+++ b/tests/modkit/cases/dev_mode.lua
@@ -1,0 +1,41 @@
+-- A sandboxed mod can distinguish an engine developer boot without reading
+-- the host environment or using a legacy compatibility shim.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.modkit")
+
+local FILES = {
+  ["mods/dev_probe/manifest.json"] = [[{
+    "id": "dev_probe",
+    "name": "Developer Mode Probe",
+    "version": "1.0.0",
+    "entry": "main.lua",
+    "api": 2
+  }]],
+  ["mods/dev_probe/main.lua"] = [[
+local mod = ...
+mod.exports.value = mod.dev
+mod.exports.valueType = type(mod.dev)
+]],
+}
+
+for _, enabled in ipairs({ false, true, "yes", 1 }) do
+  local expectedDev = enabled == true
+  local run = T.sdk.loadMod("mods/dev_probe", {
+    fs = T.sdk.memfs(FILES), dev = enabled,
+  })
+  T.eq(#run.errors, 0,
+    "developer-mode probe loads cleanly")
+  local out = run.loader.exports.dev_probe or {}
+  T.eq(out.value, expectedDev,
+    "mod.dev reflects the fixed engine developer-mode state")
+  T.eq(run.loader.dev, expectedDev,
+    "loader developer-mode state is a strict boolean")
+  T.eq(out.valueType, "boolean",
+    "mod.dev is always a strict boolean")
+  T.eq(#run.loader:legacyReport("dev_probe"), 0,
+    "reading mod.dev needs no legacy host-environment shim")
+  run.release()
+end
+
+T.finish("public mod developer-mode signal")


### PR DESCRIPTION
## Summary

- expose the loader's fixed developer-mode decision to each sandboxed mod as a strict boolean `mod.dev`
- document the public signal and its security/permission boundary
- add separate sandboxed public-API and guarded no-mod parity coverage
- record the generic decision in RFC 0017

## Motivation / consuming mod

The concrete consumer is [Adaptive Trainers](https://github.com/MaxTomahawk/gen1recomp-adaptive-trainers), whose approved Chapter 30 diagnostics require trainer, boss, Rival, and League projections plus random-choice seed-label logging only while `POKEPORT_DEV` is active. Production boots must remain quiet apart from normal errors and warnings.

The blocked call site is the mod's `main.lua`: it must decide whether to register its diagnostic command/screen and seed tracing. The engine already fixes developer mode at loader construction from `POKEPORT_DEV=1` or `--developer`, but that authority is private.

## Why existing public seams are insufficient

- `mod.commands`, `mod.screens`, and `mod.exports` can expose diagnostics, but none says whether this is a developer boot.
- `force_enable_env` controls whether a mod is enabled; it does not identify the reason or expose the loader's developer-mode decision.
- sandboxed `os.getenv` intentionally hides arbitrary host environment values and records legacy compatibility use.
- an unconditional diagnostic surface would violate the consuming mod's production behavior requirement.

A private Loader import or environment workaround would cross the sandbox boundary and couple the mod to internal boot policy.

## Exact generic API delta

Every loaded sandboxed mod API object receives `mod.dev`, a strict boolean snapshot of the loader's fixed developer-mode state. It grants no permission and exposes no environment value, argv, path, controller, or Adaptive Trainers policy. Assigning to one mod's private API table cannot change the loader, another mod, or engine mode.

## Compatibility and no-mod behavior

The field is additive and requires no manifest change or permission. Existing mods do nothing. With no mods installed, no API object or export table is allocated; the active dataset and deterministic link fingerprint remain unchanged. Existing developer console, force-enable, and hot-reload behavior is unchanged.

Nothing is removed, renamed, superseded, or deprecated.

## RFC and docs

- RFC: `docs/rfcs/0017-public-mod-developer-mode-signal.md`
- Public documentation: `docs/modding.md` under Developer console
- Decision: D-AT-005; consuming plan Task 9 is linked from the RFC
- No generated registry reference changes apply because this adds no registry, schema field, event, or hook catalog entry.

## Verification

Locally run on current `bryanthaboi/gen1recomp:dev` (`e88f2ef060cb8bd1d45d53a6aaa46f997f308791`):

- `luajit tests/modkit/cases/dev_mode.lua` — 20/20
- `luajit tests/engine/dev_mode_no_mod_parity.lua` — 10/10
- `luajit tests/run_modkit.lua` — 25/25 suites
- `luajit tests/mod_examples_tests.lua` — 195/195
- `./scripts/test.sh` — engine 293/293, modkit 25/25, cold restart; all available tiers passed
- `./scripts/lint.sh --gate` — 0 warnings, 0 errors across 482 files
- `git diff --check` — clean

`./scripts/test.sh` skipped T3 because no private `data/` or `generated/` imports are present. The required lint tool was available for the final branch verification; CI remains authoritative after push.

## Route B checklist

- [x] RFC with concrete consuming mod, traceable decision/plan, exact API delta, and migration note
- [x] Backward-compatibility and no-mod statement
- [x] Separate guarded no-mod parity test
- [x] Separate sandboxed public-API test
- [x] Public docs updated; generated registry docs not applicable
- [x] Additive deprecation etiquette documented
- [ ] RFC label applied to the PR (the repository currently exposes no RFC-named label; maintainer action may be required)
- [ ] CI green and maintainer review inspected
