### PR TITLE
Route the Gen2 #DEX screen's kind/text through the pokemon registry

### DIFF
--- a/docs/modding/reference/registries.md
+++ b/docs/modding/reference/registries.md
@@ -821,7 +821,7 @@ mod.content.phone_contacts:patch("PHONE_YOUNGSTER_JOEY", { map = "ROUTE_31" })
 | `catchRate` | integer 0..255 | yes |
 | `cry` | cries id | no |
 | `dex` | integer >= 1 | yes |
-| `dexEntry` | {heightFt, heightIn, heightM?, kind, text, weight, weightKg?} | no |
+| `dexEntry` | {heightFt, heightIn, heightM?, kind, text, text2?, weight, weightKg?} | no |
 | `evolutions` | list of {item?, level?, method, species} | yes |
 | `frontSize` | integer 1..7 | yes |
 | `growthRate` | growth_rates id | yes |

--- a/src/core/Game2.lua
+++ b/src/core/Game2.lua
@@ -1024,6 +1024,11 @@ function Game2:load()
   require("src.core.gen2.Phone").useRegistry(self.data)
   require("src.core.gen2.Decorations").useRegistry(self.data)
   require("src.core.gen2.Apricorns").useRegistry(self.data)
+  -- data.gen2Pokedex is a separate table from the `pokemon` registry's own
+  -- merge target (data.pokemon): a translation mod's
+  -- mod.content.pokemon:patch(id, { dexEntry = ... }) would otherwise never
+  -- reach the #DEX screen. See src/core/gen2/PokedexText.lua.
+  require("src.core.gen2.PokedexText").apply(self.data)
 
   -- Rendering pipelines: the engine half of the render_pipelines registry
   -- (src/render/Pipelines.lua).  install() points it at GOLD's merged dataset

--- a/src/core/gen2/PokedexText.lua
+++ b/src/core/gen2/PokedexText.lua
@@ -1,0 +1,39 @@
+-- Projects a mod's `pokemon` registry dexEntry onto the #DEX screen's own
+-- data table.
+--
+-- data.gen2Pokedex.entries[species] (data/generated/pokedex.lua,
+-- RomExtractorGen2:extractPokedex) is what src/ui/gen2/PokedexMenu.lua
+-- actually reads for the KIND label and the two description pages
+-- (entry.kind, entry.text, entry.text2) -- a table loaded straight from
+-- disk in Game2:load, BEFORE mods:load runs, and never routed through a
+-- registry.  The `pokemon` registry's own merge target is the separate
+-- data.pokemon table (src/mods/Schemas.lua, R.pokemon: `target = "pokemon"`),
+-- which mod.content.pokemon:patch(id, { dexEntry = { kind = ..., text = ...,
+-- text2 = ... } }) already reaches -- so a translation mod's #DEX text was
+-- silently invisible in-game despite validating against the registry.
+--
+-- This is the missing link: called once after the merge (src/core/Game2.lua),
+-- the same way ItemEffects.applyHeldItems projects held_items onto
+-- data.gen2HeldItems.  height/weight/dex stay untouched -- game state, not
+-- text a translation carries.
+local PokedexText = {}
+
+function PokedexText.apply(data)
+  local dex = data and data.gen2Pokedex
+  local pokemon = data and data.pokemon
+  if not (dex and dex.entries and pokemon) then return 0 end
+  local count = 0
+  for species, entry in pairs(dex.entries) do
+    local def = pokemon[species]
+    local override = def and def.dexEntry
+    if override and (override.kind or override.text or override.text2) then
+      if override.kind then entry.kind = override.kind end
+      if override.text then entry.text = override.text end
+      if override.text2 then entry.text2 = override.text2 end
+      count = count + 1
+    end
+  end
+  return count
+end
+
+return PokedexText

--- a/src/mods/Schemas.lua
+++ b/src/mods/Schemas.lua
@@ -826,10 +826,14 @@ R.pokemon = {
                                item = f.opt(f.id("items")),
                                species = f.id("pokemon") }),
     spriteFront = f.path, spriteBack = f.path, frontSize = f.int(1, 7),
+    -- text2 is the #DEX entry's second description page (Pokedex_asm's bare
+    -- `page` macro, engine/pokedex/pokedex.asm): PokedexMenu:drawEntryBody
+    -- shows `entry.text` on page 1 and `entry.text2` on page 2, so a
+    -- translation needs both to cover the whole entry.
     dexEntry = f.opt(f.rec{ kind = f.str, heightFt = f.int(0),
                             heightIn = f.int(0, 11), weight = f.num,
                             heightM = f.opt(f.num), weightKg = f.opt(f.num),
-                            text = f.str }),
+                            text = f.str, text2 = f.opt(f.str) }),
     icon = f.opt(f.union{ f.str, f.rec{ image = f.path,
                                         frames = f.opt(f.int(1)) } }),
     cry = f.opt(f.id("cries")), palette = f.opt(f.id("palettes")),

--- a/src/ui/gen2/PokedexMenu.lua
+++ b/src/ui/gen2/PokedexMenu.lua
@@ -37,6 +37,13 @@ local TileSheet = require("src.ui.gen2.TileSheet")
 local Nests = require("src.core.gen2.Nests")
 local Sound = require("src.core.Sound")
 local Unown = require("src.core.gen2.Unown")
+local Strings = require("src.core.Strings")
+
+-- `db $3b, " OPTION ", $3c` / `db $3b, " SEARCH ", $3c"`: the panel titles
+-- drawn by drawOption/drawSearch below, declared here (rather than inline)
+-- so Strings.source puts them in the catalog harvest.
+local OPTION_LABEL = Strings.source(" OPTION ")
+local SEARCH_LABEL = Strings.source(" SEARCH ")
 
 local PokedexMenu = {}
 PokedexMenu.__index = PokedexMenu
@@ -776,7 +783,6 @@ function PokedexMenu:printEntry()
   local row = self:current()
   if not row then return end
   local Printer = require("src.core.Printer")
-  local Strings = require("src.core.Strings")
   local TextBox = require("src.render.TextBox")
   local name = (self.pokemon and self.pokemon[row.species]
     and self.pokemon[row.species].name) or tostring(row.species)
@@ -1385,7 +1391,7 @@ function PokedexMenu:drawOption()
   -- `db $3b, " OPTION ", $3c`: the two end-cap tiles are the dex sheet's, not
   -- font glyphs.
   self:tile(0x3b, 0, 1)
-  self:text(" OPTION ", 1, 1)
+  self:text(Strings(OPTION_LABEL), 1, 1)
   self:tile(0x3c, 9, 1)
   local rows = self:optionRows()
   for i, row in ipairs(rows) do
@@ -1405,7 +1411,7 @@ function PokedexMenu:drawSearch()
   self:fill(TILE_BG, 0, 0, Chrome.SCREEN_W, Chrome.SCREEN_H)
   self:border(0, 2, 14, 18)
   self:tile(0x3b, 0, 1)
-  self:text(" SEARCH ", 1, 1)
+  self:text(Strings(SEARCH_LABEL), 1, 1)
   self:tile(0x3c, 9, 1)
   self:text("TYPE1", 3, 4)
   self:text("TYPE2", 3, 6)

--- a/tests/gen2_pokedex_text_registry_test.lua
+++ b/tests/gen2_pokedex_text_registry_test.lua
@@ -1,0 +1,91 @@
+-- The #DEX screen (src/ui/gen2/PokedexMenu.lua) reads its KIND label and
+-- description pages from data.gen2Pokedex.entries, a table loaded straight
+-- from disk before mods:load runs -- a separate table from data.pokemon,
+-- the `pokemon` registry's own merge target
+-- (mod.content.pokemon:patch(id, { dexEntry = ... })). Without a projection
+-- step, a translation mod's #DEX text validates against the registry and
+-- never reaches the screen. src/core/gen2/PokedexText.lua is that
+-- projection, called once after the merge (src/core/Game2.lua). ROM-free:
+--   luajit tests/gen2_pokedex_text_registry_test.lua
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local S = require("tests.harness").suite("gen2 pokedex text registry")
+local check, eq = S.check, S.eq
+
+local PokedexText = require("src.core.gen2.PokedexText")
+
+-- A patched species (CYNDAQUIL, kind/text/text2 all overridden), one left
+-- alone (TOTODILE, no dexEntry at all in data.pokemon -- a mod that never
+-- touched it), and one gen2Pokedex has no matching data.pokemon row for
+-- (UNOWN, e.g. a form gen2Pokedex tracks that the pokemon registry does not).
+do
+  local data = {
+    pokemon = {
+      CYNDAQUIL = { name = "CYNDAQUIL", dexEntry = {
+        kind = "SOURIS DE FEU", text = "Page un traduite.",
+        text2 = "Page deux traduite.",
+      } },
+      TOTODILE = { name = "TOTODILE" },
+    },
+    gen2Pokedex = { entries = {
+      CYNDAQUIL = { id = "CYNDAQUIL", dex = 155, kind = "FIRE MOUSE",
+        height = 108, weight = 170,
+        text = "It is timid, and always curls itself up in a ball.",
+        text2 = "If attacked, it flares up its back for protection." },
+      TOTODILE = { id = "TOTODILE", dex = 158, kind = "BIG JAW",
+        height = 200, weight = 200, text = "English page one.",
+        text2 = "English page two." },
+      UNOWN = { id = "UNOWN", dex = 201, kind = "SYMBOL",
+        height = 50, weight = 50, text = "English only." },
+    } },
+  }
+
+  local touched = PokedexText.apply(data)
+  eq(touched, 1, "only the species a mod actually patched are touched")
+
+  local cyndaquil = data.gen2Pokedex.entries.CYNDAQUIL
+  eq(cyndaquil.kind, "SOURIS DE FEU", "kind reaches the #DEX entry")
+  eq(cyndaquil.text, "Page un traduite.", "page one reaches the #DEX entry")
+  eq(cyndaquil.text2, "Page deux traduite.", "page two reaches the #DEX entry")
+  eq(cyndaquil.dex, 155, "dex number is untouched -- it is not translatable text")
+  eq(cyndaquil.height, 108, "height is untouched -- game state, not prose")
+  eq(cyndaquil.weight, 170, "weight is untouched -- game state, not prose")
+
+  local totodile = data.gen2Pokedex.entries.TOTODILE
+  eq(totodile.kind, "BIG JAW", "a species with no dexEntry patch stays in English")
+  eq(totodile.text, "English page one.", "unpatched page one is untouched")
+
+  local unown = data.gen2Pokedex.entries.UNOWN
+  eq(unown.kind, "SYMBOL",
+    "a #DEX entry with no data.pokemon counterpart at all is left alone")
+end
+
+-- A patch that only sets `kind` (species_kinds without species_dex_text
+-- shipped, or vice versa) must not blank out the fields it did not touch.
+do
+  local data = {
+    pokemon = { ABRA = { name = "ABRA", dexEntry = { kind = "PSY" } } },
+    gen2Pokedex = { entries = {
+      ABRA = { id = "ABRA", dex = 63, kind = "PSI",
+        text = "English text.", text2 = "English text two." },
+    } },
+  }
+  PokedexText.apply(data)
+  local abra = data.gen2Pokedex.entries.ABRA
+  eq(abra.kind, "PSY", "kind alone is applied")
+  eq(abra.text, "English text.", "text is left alone when the patch omits it")
+  eq(abra.text2, "English text two.", "text2 is left alone when the patch omits it")
+end
+
+-- Missing tables at every level answer 0 rather than raising -- a Gen 1 boot,
+-- or a Gold boot with no mods loaded, never calls this with a shaped table.
+do
+  eq(PokedexText.apply(nil), 0, "nil data does not raise")
+  eq(PokedexText.apply({}), 0, "empty data does not raise")
+  eq(PokedexText.apply({ gen2Pokedex = { entries = {} } }), 0,
+    "no data.pokemon at all does not raise")
+end
+
+check(true, "PokedexText.apply covers the projection this fix adds")
+
+S.finish()


### PR DESCRIPTION
## Summary

- `src/ui/gen2/PokedexMenu.lua` reads its KIND label and both description pages from `data.gen2Pokedex.entries`, loaded straight from disk before `mods:load` runs -- a separate table from `data.pokemon`, the `pokemon` registry's own merge target. `mod.content.pokemon:patch(id, { dexEntry = ... })` therefore validated but never reached the screen: a translation mod's #DEX text was silently invisible in-game.
- Adds `src/core/gen2/PokedexText.lua` to project a patched `dexEntry` onto the #DEX table once, after the merge (`Game2:load`, alongside the other Gen 2 post-merge registries: `ItemEffects.applyHeldItems`, `Phone.useRegistry`, etc).
- Adds a `text2` field to the `dexEntry` schema for the entry's second description page, which the screen already reads (`entry.text2`) but the registry had no field for. Regenerated `docs/modding/reference/registries.md` accordingly.
- Also routes the `OPTION`/`SEARCH` panel titles (`PokedexMenu.lua`) through `Strings()`, the same `Strings.source` module-level literal pattern already used elsewhere in this screen and its siblings (`OptionsMenu.lua`, `ElevatorMenu.lua`, `ItemEffects.lua`).

Found and confirmed while building a Gold/Silver/Crystal translation mod -- `species_kinds`/`species_dex_text` catalogs validated against the registry and passed every gate, but the in-game #DEX screen still showed English. Traced to this missing projection.

## Test plan

- `luajit tests/gen2_pokedex_text_registry_test.lua` (new, 17 checks) -- covers the projection: a patched species reaches the screen, an untouched one stays in English, a partial patch (kind only) doesn't blank out text/text2, height/weight/dex numbers stay untouched, nil/missing tables at every level don't raise.
- Existing Pokédex/menu suites unaffected: `gen2_menus_test.lua` (697 checks), `gen2_dex_gift_test.lua` (18), `engine/pokedex_quit_bug571.lua` (16), `engine/pokedex_counts_bug639.lua` (9), `engine/gen2_dex_mode_persist_bug1474.lua` (9), `engine/gen2_pokedex_area_landmark_bug1267.lua` (3) -- all still pass.
- `luajit tools/gen_registry_docs.lua` re-run: `registries.md` diff is exactly the new `text2` field, no drift elsewhere.
- Verified in-game against a real Gold ROM build with a French translation mod: the #DEX kind label and both description pages now render translated.

Screenshots before and after the fix:
<img width="1022" height="766" alt="Screenshot 2026-08-26 200445" src="https://github.com/user-attachments/assets/8a87182e-b507-42e8-8503-51e42a2db2c4" />

<img width="1023" height="762" alt="Screenshot 2026-08-26 200631" src="https://github.com/user-attachments/assets/72c42c53-f3be-4ca8-ab12-572594475985" />

