### PR TITLE
update flatpak information that was left as template default

### DIFF
--- a/flatpak/com.theboisclub.gen1recomp.metainfo.xml
+++ b/flatpak/com.theboisclub.gen1recomp.metainfo.xml
@@ -4,7 +4,7 @@
   <name>gen1recomp</name>
   <summary>Pokémon Gen 1/2 recompilation</summary>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>LicenseRef-proprietary</project_license>
+  <project_license>MIT</project_license>
   <developer_name>The Bois Club</developer_name>
   <description>
     <p>
@@ -14,7 +14,8 @@
     </p>
   </description>
   <launchable type="desktop-id">com.theboisclub.gen1recomp.desktop</launchable>
-  <url type="homepage">https://github.com/bryanthaboi/gen1recomp</url>
+  <url type="homepage">https://gen1re.com/</url>
+  <url type="vcs-browser">https://github.com/bryanthaboi/gen1recomp</url>
   <screenshots>
     <screenshot type="default">
       <caption>Launcher</caption>

--- a/tests/engine/flatpak_manifest_test.lua
+++ b/tests/engine/flatpak_manifest_test.lua
@@ -21,5 +21,13 @@ local xml = meta:read("*a")
 meta:close()
 check(xml:find("<releases>", 1, true), "AppStream metainfo includes releases")
 check(xml:find("<release ", 1, true), "AppStream metainfo includes a release entry")
+check(xml:find("<project_license>MIT</project_license>", 1, true),
+  "AppStream metainfo declares MIT project license")
+check(not xml:find("LicenseRef-proprietary", 1, true),
+  "AppStream metainfo must not claim proprietary")
+check(xml:find('url type="homepage">https://gen1re.com/</url>', 1, true),
+  "AppStream metainfo homepage is gen1re.com")
+check(xml:find('url type="vcs-browser">https://github.com/bryanthaboi/gen1recomp</url>', 1, true),
+  "AppStream metainfo vcs-browser points at the public repo")
 
 print("ok")


### PR DESCRIPTION
update flatpak information that was left as template default
flatpak properly now marks as oss and points to site and gh