### PR TITLE
feat(i18n): enable translation strings and mod reach across Gen 2 (Gold, Silver, Crystal)

### DIFF
--- a/src/battle/gen2/Battle.lua
+++ b/src/battle/gen2/Battle.lua
@@ -1292,14 +1292,14 @@ function Battle:dealDamage(attacker, defender, damage, opts)
   end
   if endured then
     self:emit({ kind = "message",
-      text = self:monName(defender) .. " endured the hit!" })
+      text = Strings("%s endured the hit!", self:monName(defender)) })
   elseif hungOn then
     -- HungOnText, named after the item the way the cart pipes it through
     -- wStringBuffer1.
     local def = self:itemDef(defender.item)
     self:emit({ kind = "message",
-      text = self:monName(defender) .. " hung on with "
-        .. ((def and def.name) or "FOCUS BAND") .. "!" })
+      text = Strings("%s hung on with\n%s!", self:monName(defender),
+        Strings((def and def.name) or "FOCUS BAND")) })
   end
   -- SUBSTATUS_RAGE: being hit while raging raises the rager's Attack.
   if defenderState.rage and damage > 0 and (defender.hp or 0) > 0 then
@@ -4090,8 +4090,8 @@ function Battle:tryRun(pSpd)
     return false
   end
   if self.trainer then
-    self:emit({ kind = "message", text = "No! There's no running from a "
-      .. "trainer battle!" })
+    self:emit({ kind = "message",
+      text = Strings("No! There's no running from a\ntrainer battle!") })
     self.runRefused = true
     return false
   end
@@ -4294,7 +4294,8 @@ function Battle:switchEnemy(index)
   local outgoing = self.enemy
   local trainerName = (self.trainer and self.trainer.name) or "TRAINER"
   self:emit({ kind = "message",
-    text = trainerName .. " withdrew " .. self:monName(outgoing) .. "!" })
+    text = Strings("%s withdrew\n%s!",
+      Strings(trainerName), self:monName(outgoing)) })
   self.enemyIndex = index
   self.enemy = mon
   -- AI_Switch (engine/battle/ai/items.asm:697)
@@ -4305,7 +4306,8 @@ function Battle:switchEnemy(index)
   self:emit({ kind = "send", side = "enemy", mon = self.enemy,
     hp = self.enemy.hp or 0, status = self.enemy.status or false,
     level = self.enemy.level, experience = self.enemy.experience,
-    text = trainerName .. " sent out " .. self:monName(self.enemy) .. "!" })
+    text = Strings("%s sent out\n%s!",
+      Strings(trainerName), self:monName(self.enemy)) })
   Runtime.emit("battle.battler_switched", {
     battle = self, side = self:sideRecord(self.enemy), battler = self.enemy,
     previous = outgoing,
@@ -4334,8 +4336,8 @@ function Battle:enemyUseItem(item)
     self:volatile(self.enemy).confuseCount = nil
   end
   self:emit({ kind = "message",
-    text = ((self.trainer and self.trainer.name) or "TRAINER")
-      .. " used " .. item .. "!" })
+    text = Strings("%s used\n%s!",
+      Strings((self.trainer and self.trainer.name) or "TRAINER"), Strings(item)) })
   return true
 end
 
@@ -4596,7 +4598,7 @@ local function runTurn(self, action, enemyAction)
     if not charging and not bideLocked
         and not self:hasUsableMoves(self.player) then
       self:emit({ kind = "message",
-        text = self:monName(self.player) .. " has no moves left!" })
+        text = Strings("%s has no moves left!", self:monName(self.player)) })
       move = Battle.STRUGGLE
     end
     -- CheckPlayerTurn's disabled arm spends the turn, whatever was selected
@@ -4607,7 +4609,8 @@ local function runTurn(self, action, enemyAction)
       local state = self:volatile(self.player)
       state.chargeMove, state.vanished = nil, nil
       self:emit({ kind = "message",
-        text = self:monName(self.player) .. "'s " .. move .. " is DISABLED!" })
+        text = Strings("%s's %s is DISABLED!",
+          self:monName(self.player), Strings(move)) })
       return
     end
     -- BattleCommand_CheckObedience runs at the head of the move's effect
@@ -4665,7 +4668,8 @@ local function runTurn(self, action, enemyAction)
       local state = self:volatile(self.enemy)
       state.chargeMove, state.vanished = nil, nil
       self:emit({ kind = "message",
-        text = self:monName(self.enemy) .. "'s " .. enemyMoveId .. " is DISABLED!" })
+        text = Strings("%s's %s is DISABLED!",
+          self:monName(self.enemy), Strings(enemyMoveId)) })
       return
     end
     self:useMove(self.enemy, self.player, enemyMoveId)
@@ -4794,7 +4798,7 @@ function Battle:tickWeather()
         local damage = Effects.sandstormDamage(maxHp)
         mon.hp = math.max(0, mon.hp - damage)
         self:emit({ kind = "message",
-          text = self:monName(mon) .. " is buffeted by the sandstorm!" })
+          text = Strings("%s is buffeted by the sandstorm!", self:monName(mon)) })
         -- .SandstormDamage plays ANIM_IN_SANDSTORM between two SwitchTurnCore
         -- calls, so it runs from the OTHER side (core.asm:1688-1693).
         self:emit({ kind = "damage", side = self:sideOf(mon),
@@ -4816,8 +4820,8 @@ function Battle:tickFutureSight(mon)
   state.futureSight, state.futureSightDamage, state.futureSightSide =
     nil, nil, nil
   if (target.hp or 0) <= 0 then return end
-  self:emit({ kind = "message", text = self:monName(target)
-    .. " took the FUTURE SIGHT attack!" })
+  self:emit({ kind = "message",
+    text = Strings("%s took the FUTURE SIGHT attack!", self:monName(target)) })
   self:dealDamage(mon, target, damage, {})
 end
 
@@ -4827,8 +4831,9 @@ function Battle:tickPerish(mon)
   if not state.perish or (mon.hp or 0) <= 0 then return end
   state.perish = state.perish - 1
   if state.perish > 0 then
-    self:emit({ kind = "message", text = self:monName(mon)
-      .. "'s PERISH count is " .. state.perish .. "!" })
+    self:emit({ kind = "message",
+      text = Strings("%s's PERISH count is %d!",
+        self:monName(mon), state.perish) })
     return
   end
   state.perish = nil
@@ -4850,7 +4855,7 @@ function Battle:tickSeedAndCurse(mon)
     local damage = math.min(math.max(1, math.floor(maxHp / 8)), mon.hp)
     mon.hp = mon.hp - damage
     self:emit({ kind = "message",
-      text = "LEECH SEED saps " .. self:monName(mon) .. "!" })
+      text = Strings("LEECH SEED saps\n%s!", self:monName(mon)) })
     -- ANIM_SAP plays between two SwitchTurnCore calls, from the seeder's side
     -- (core.asm:1013-1021).
     self:emit({ kind = "damage", side = self:sideOf(mon), amount = damage,
@@ -4862,7 +4867,7 @@ function Battle:tickSeedAndCurse(mon)
     local damage = math.max(1, math.floor(maxHp / 4))
     mon.hp = math.max(0, mon.hp - damage)
     self:emit({ kind = "message",
-      text = self:monName(mon) .. "'s hurt by the CURSE!" })
+      text = Strings("%s's hurt by the CURSE!", self:monName(mon)) })
     -- The curse arm borrows ANIM_IN_NIGHTMARE, on the sufferer's own turn
     -- (core.asm:1057-1060).
     self:emit({ kind = "damage", side = self:sideOf(mon), amount = damage,
@@ -4882,14 +4887,16 @@ function Battle:tickWrap(mon)
   if state.wrapCount <= 0 then
     state.wrapCount, state.wrapMove, state.wrapMoveId = nil, nil, nil
     self:emit({ kind = "message",
-      text = self:monName(mon) .. " was released from " .. moveName .. "!" })
+      text = Strings("%s was released from\n%s!",
+        self:monName(mon), Strings(moveName)) })
     return
   end
   local maxHp = mon.maxHp or (mon.stats and mon.stats.hp) or 16
   local damage = math.max(1, math.floor(maxHp / 16))
   mon.hp = math.max(0, mon.hp - damage)
   self:emit({ kind = "message",
-    text = self:monName(mon) .. "'s hurt by " .. moveName .. "!" })
+    text = Strings("%s's hurt by\n%s!",
+      self:monName(mon), Strings(moveName)) })
   -- The trapping move's own anim, played from the trapper's side between two
   -- SwitchTurnCore calls (core.asm:1198-1203).
   self:emit({ kind = "damage", side = self:sideOf(mon), amount = damage,
@@ -4915,7 +4922,7 @@ function Battle:tickScreens()
           if field == "safeguard" then
             -- engine/battle/core.asm:1527
             self:emit({ kind = "message",
-              text = self:monName(self[side]) .. "'s SAFEGUARD faded!" })
+              text = Strings("%s's SAFEGUARD faded!", self:monName(self[side])) })
           else
             self:emit({ kind = "message",
               text = Battle.SCREEN_SIDE_LABEL[side]
@@ -4941,7 +4948,7 @@ function Battle:tickCounters(mon)
     if state.encoreTurns <= 0 then
       state.encore, state.encoreTurns = nil, nil
       self:emit({ kind = "message",
-        text = self:monName(mon) .. "'s ENCORE ended!" })
+        text = Strings("%s's ENCORE ended!", self:monName(mon)) })
     end
   end
   if state.disabledTurns then
@@ -4949,7 +4956,7 @@ function Battle:tickCounters(mon)
     if state.disabledTurns <= 0 then
       state.disabled, state.disabledTurns = nil, nil
       self:emit({ kind = "message",
-        text = self:monName(mon) .. "'s move is no longer disabled!" })
+        text = Strings("%s's move is no longer disabled!", self:monName(mon)) })
     end
   end
 end
@@ -4997,7 +5004,8 @@ function Battle:tickHeldItem(mon)
     local healed = self:heal(mon, math.max(1, math.floor(maxHp / 16)))
     if healed > 0 then
       self:emit({ kind = "message",
-        text = name .. "'s " .. (def.name or "item") .. " restored health!" })
+        text = Strings("%s's %s restored health!",
+          name, Strings(def.name or "item")) })
     end
     return
   end
@@ -5007,7 +5015,8 @@ function Battle:tickHeldItem(mon)
     self:heal(mon, parameter > 0 and parameter or 10, { anim = "RECOVER" })
     mon.item = nil
     self:emit({ kind = "message",
-      text = name .. " ate the " .. (def.name or "BERRY") .. "!" })
+      text = Strings("%s ate the\n%s!",
+        name, Strings(def.name or "BERRY")) })
     return
   end
 
@@ -5019,7 +5028,8 @@ function Battle:tickHeldItem(mon)
     mon.toxicCounter = nil
     mon.item = nil
     self:emit({ kind = "status", side = self:sideOf(mon), status = nil,
-      text = name .. "'s " .. (def.name or "item") .. " cured its status!" })
+      text = Strings("%s's %s cured its status!",
+        name, Strings(def.name or "item")) })
   end
 
   -- UseConfusionHealingItem: HELD_HEAL_CONFUSION (a Bitter Berry) and the
@@ -5030,8 +5040,8 @@ function Battle:tickHeldItem(mon)
     self:volatile(mon).confuseCount = nil
     mon.item = nil
     self:emit({ kind = "message",
-      text = name .. "'s " .. (def.name or "item")
-        .. " cured its confusion!" })
+      text = Strings("%s's %s cured its confusion!",
+        name, Strings(def.name or "item")) })
   end
 end
 

--- a/src/battle/gen2/Battle.lua
+++ b/src/battle/gen2/Battle.lua
@@ -23,6 +23,7 @@ local Ai = require("src.battle.gen2.Ai")
 local Effects = require("src.battle.gen2.Effects")
 local Mon = require("src.battle.gen2.Mon")
 local Happiness = require("src.core.gen2.Happiness")
+local Strings = require("src.core.Strings")
 local Pokerus = require("src.core.gen2.Pokerus")
 local Roamers = require("src.core.gen2.Roamers")
 local Prize = require("src.battle.gen2.Prize")
@@ -943,7 +944,7 @@ local function checkTurn(self, mon, moveId)
   local vol = self:volatile(mon)
   if vol.recharge then
     vol.recharge = nil
-    self:emit({ kind = "message", text = name .. " must recharge!" })
+    self:emit({ kind = "message", text = Strings("%s must recharge!", name) })
     return false
   end
   -- The status arms, through the merged record.  beforeMovePriority is what
@@ -968,7 +969,7 @@ local function checkTurn(self, mon, moveId)
   -- moves once they write the same flag.
   if vol.flinched then
     vol.flinched = nil
-    self:emit({ kind = "message", text = name .. " flinched!" })
+    self:emit({ kind = "message", text = Strings("%s flinched!", name) })
     return false
   end
   -- SUBSTATUS_CONFUSED (CheckPlayerTurn past `.not_flinched`): the count
@@ -979,9 +980,9 @@ local function checkTurn(self, mon, moveId)
     vol.confuseCount = vol.confuseCount - 1
     if vol.confuseCount <= 0 then
       vol.confuseCount = nil
-      self:emit({ kind = "message", text = name .. "'s confused no more!" })
+      self:emit({ kind = "message", text = Strings("%s's confused no more!", name) })
     else
-      self:emit({ kind = "message", text = name .. " is confused!" })
+      self:emit({ kind = "message", text = Strings("%s is confused!", name) })
       if rand(self.random, 256) < 128 then
         self:confusionSelfHit(mon)
         return false
@@ -1277,7 +1278,7 @@ function Battle:dealDamage(attacker, defender, damage, opts)
     effectiveness = opts.effectiveness,
   })
   if opts.critical then
-    self:emit({ kind = "message", text = "A critical hit!" })
+    self:emit({ kind = "message", text = Strings("A critical hit!") })
   end
   -- SuperEffectiveText / NotVeryEffectiveText (data/text/battle.asm:603,608).
   -- The cart breaks both across the box's two lines and hyphenates "super-"
@@ -1522,7 +1523,7 @@ function Battle:useMove(attacker, defender, moveId)
     end
     if not picked or (self.copyDepth or 0) > 0 then
       self:markMissed()
-      self:emit({ kind = "message", text = "But it failed!" })
+      self:emit({ kind = "message", text = Strings("But it failed!") })
       return
     end
     self.copyDepth = (self.copyDepth or 0) + 1
@@ -1549,7 +1550,7 @@ function Battle:useMove(attacker, defender, moveId)
     end
     if not picked then
       self:markMissed()
-      self:emit({ kind = "message", text = "But it failed!" })
+      self:emit({ kind = "message", text = Strings("But it failed!") })
       return
     end
     state.lastMove = nil
@@ -1608,7 +1609,7 @@ function Battle:useMove(attacker, defender, moveId)
   -- BattleCommand_Snore (engine/battle/move_effects/snore.asm:1-9)
   if def.effect == "EFFECT_SNORE" and attacker.status ~= "sleep" then
     self:markMissed()
-    self:emit({ kind = "message", text = "But it failed!" })
+    self:emit({ kind = "message", text = Strings("But it failed!") })
     return
   end
 
@@ -1619,7 +1620,7 @@ function Battle:useMove(attacker, defender, moveId)
     local taken = state.tookThisTurn or 0
     if taken <= 0 or state.tookKind ~= counterKind then
       self:markMissed()
-      self:emit({ kind = "message", text = "But it failed!" })
+      self:emit({ kind = "message", text = Strings("But it failed!") })
       return
     end
     self:dealDamage(attacker, defender, Effects.counterDamage(taken),
@@ -1661,7 +1662,7 @@ function Battle:useMove(attacker, defender, moveId)
     -- so `selfdestruct` still runs ahead of failuretext.
     if def.effect == "EFFECT_SELFDESTRUCT" then self:selfdestructUser(attacker) end
     self:markMissed()
-    self:emit({ kind = "message", text = name .. "'s attack missed!" })
+    self:emit({ kind = "message", text = Strings("%s's attack\nmissed!", name) })
     return
   end
 
@@ -1685,7 +1686,7 @@ function Battle:useMove(attacker, defender, moveId)
   -- refusing the move only after it had already hit and healed.
   if def.effect == "EFFECT_DREAM_EATER" and defender.status ~= "sleep" then
     self:markMissed()
-    self:emit({ kind = "message", text = name .. "'s attack missed!" })
+    self:emit({ kind = "message", text = Strings("%s's attack\nmissed!", name) })
     return
   end
 
@@ -1714,7 +1715,7 @@ function Battle:useMove(attacker, defender, moveId)
     -- failuretext, so a missed Explosion still kills the user.
     if def.effect == "EFFECT_SELFDESTRUCT" then self:selfdestructUser(attacker) end
     self:markMissed()
-    self:emit({ kind = "message", text = name .. "'s attack missed!" })
+    self:emit({ kind = "message", text = Strings("%s's attack\nmissed!", name) })
     -- Fury Cutter's ramp resets the moment it misses.
     state.rampMove = nil
     state.rampCount = nil
@@ -1736,7 +1737,7 @@ function Battle:useMove(attacker, defender, moveId)
     local cost = Effects.substituteCost(maxHp)
     if (attacker.hp or 0) <= cost or (state.substitute or 0) > 0 then
       self:markMissed()
-      self:emit({ kind = "message", text = "But it failed!" })
+      self:emit({ kind = "message", text = Strings("But it failed!") })
       return
     end
     attacker.hp = attacker.hp - cost
@@ -1958,7 +1959,7 @@ function Battle:useMove(attacker, defender, moveId)
         and def.effect ~= "EFFECT_ACCURACY_DOWN_HIT"
         and self:aiRandomFail(attacker, target) then
       self:markMissed()
-      self:emit({ kind = "message", text = "But it failed!" })
+      self:emit({ kind = "message", text = Strings("But it failed!") })
     elseif not self:changeStageAgainstMist(attacker, target, change[1], change[2])
     then
       self:markMissed()
@@ -1997,7 +1998,7 @@ function Battle:useMove(attacker, defender, moveId)
     elseif Battle.AI_FAIL_STATUSES[status]
         and self:aiRandomFail(attacker, defender) then
       self:markMissed()
-      self:emit({ kind = "message", text = "But it failed!" })
+      self:emit({ kind = "message", text = Strings("But it failed!") })
     elseif not self:applyStatus(defender, status, attacker) then
       self:markMissed()
     end
@@ -2038,7 +2039,7 @@ Battle.MOVE_EFFECTS = {}
 -- marked the same way a missed one is.
 local function fail(self)
   self:markMissed()
-  self:emit({ kind = "message", text = "But it failed!" })
+  self:emit({ kind = "message", text = Strings("But it failed!") })
 end
 
 -- BattleCommand_Splash (engine/battle/move_effects/splash.asm): the whole
@@ -2426,7 +2427,7 @@ Battle.MOVE_EFFECTS.EFFECT_OHKO = function(self, attacker, defender, def, _,
   if not hit then
     self:markMissed()
     self:emit({ kind = "message",
-      text = self:monName(attacker) .. "'s attack missed!" })
+      text = Strings("%s's attack\nmissed!", self:monName(attacker)) })
     return
   end
   self:dealDamage(attacker, defender, defender.hp or 1,
@@ -2505,7 +2506,7 @@ Battle.MOVE_EFFECTS.EFFECT_HEAL = function(self, attacker, _, _, moveId)
   end
   -- effect_commands.asm:6058, RegainedHealthText.
   self:emit({ kind = "message",
-    text = self:monName(attacker) .. " regained health!" })
+    text = Strings("%s regained health!", self:monName(attacker)) })
 end
 
 -- BattleCommand_TimeBasedHealContinue (effect_commands.asm:6374) answers the
@@ -2517,7 +2518,7 @@ for effect, wants in pairs(Effects.SUN_HEAL) do
     if (attacker.hp or 0) >= maxHp then
       self:markMissed()
       self:emit({ kind = "message",
-        text = self:monName(attacker) .. "'s HP is full!" })
+        text = Strings("%s's HP is full!", self:monName(attacker)) })
       return
     end
     -- effect_commands.asm:6396-6417, the time of day and the weather (#1751).
@@ -2525,7 +2526,7 @@ for effect, wants in pairs(Effects.SUN_HEAL) do
       self.timeOfDay)
     self:heal(attacker, math.max(1, math.floor(maxHp * fraction)))
     self:emit({ kind = "message",
-      text = self:monName(attacker) .. " regained health!" })
+      text = Strings("%s regained health!", self:monName(attacker)) })
   end
 end
 
@@ -2982,10 +2983,10 @@ Battle.STATUSES = {
       if mon.statusTurns <= 0 then
         mon.status = nil
         mon.statusTurns = nil
-        battle:emit({ kind = "message", text = name .. " woke up!" })
+        battle:emit({ kind = "message", text = Strings("%s\nwoke up!", name) })
         return true
       end
-      battle:emit({ kind = "message", text = name .. " is fast asleep!" })
+      battle:emit({ kind = "message", text = Strings("%s\nis fast asleep!", name) })
       return false
     end,
   },
@@ -2995,7 +2996,7 @@ Battle.STATUSES = {
     catchBonus = 0, catchBonusIntended = 5,
     residual = function(_, _, maxHp)
       return math.max(1, math.floor(maxHp / Battle.POISON_FRACTION)),
-        " is hurt by poison!"
+        Strings.source("%s is hurt by poison!")
     end,
   },
   toxic = {
@@ -3009,7 +3010,7 @@ Battle.STATUSES = {
       local counter = mon.toxicCounter or 1
       mon.toxicCounter = counter + 1
       return math.max(1, math.floor(maxHp * counter / 16)),
-        " is hurt by poison!"
+        Strings.source("%s is hurt by poison!")
     end,
   },
   paralyze = {
@@ -3023,7 +3024,7 @@ Battle.STATUSES = {
       if rand(battle.random, Battle.PARALYSIS_SKIP_CHANCE) ~= 0 then
         return true
       end
-      battle:emit({ kind = "message", text = name .. "'s fully paralyzed!" })
+      battle:emit({ kind = "message", text = Strings("%s's\nfully paralyzed!", name) })
       return false
     end,
   },
@@ -3034,7 +3035,7 @@ Battle.STATUSES = {
     statPenalty = { stat = "attack", div = Battle.BURN_ATTACK_DIVISOR },
     residual = function(_, _, maxHp)
       return math.max(1, math.floor(maxHp / Battle.BURN_FRACTION)),
-        " is hurt by its burn!"
+        Strings.source("%s is hurt by its burn!")
     end,
   },
   freeze = {
@@ -3045,10 +3046,10 @@ Battle.STATUSES = {
     beforeMove = function(battle, mon, name)
       if rand(battle.random, Battle.THAW_CHANCE) == 0 then
         mon.status = nil
-        battle:emit({ kind = "message", text = name .. " thawed out!" })
+        battle:emit({ kind = "message", text = Strings("%s\nthawed out!", name) })
         return true
       end
-      battle:emit({ kind = "message", text = name .. " is frozen solid!" })
+      battle:emit({ kind = "message", text = Strings("%s\nis frozen solid!", name) })
       return false
     end,
   },
@@ -3174,7 +3175,7 @@ function Battle:applyStatus(mon, status, source)
   -- One major status at a time.
   if mon.status then
     self:emit({ kind = "message",
-      text = "But it failed!" })
+      text = Strings("But it failed!") })
     return false
   end
   mon.status = status
@@ -3251,7 +3252,7 @@ function Battle:tickStatus(mon)
   local damage, text = residual(self, mon, maxHp)
   if not damage or damage <= 0 then return end
   mon.hp = math.max(0, mon.hp - damage)
-  self:emit({ kind = "message", text = name .. (text or " is hurt!") })
+  self:emit({ kind = "message", text = Strings(text or "%s is hurt!", name) })
   -- Call_PlayBattleAnim_OnlyIfVisible runs on the sufferer's own turn
   -- (core.asm:970-976); a mod status the cart never had gets nothing.
   self:emit({ kind = "damage", side = self:sideOf(mon), amount = damage,
@@ -3274,8 +3275,7 @@ function Battle:resolveFaints()
     end
     self.enemyFaintAnnounced = self.enemy
     self:emit({ kind = "faint", side = "enemy",
-      text = (self.wild and "Wild " or "") .. self:monName(self.enemy)
-        .. " fainted!" })
+      text = Strings(self.wild and "Wild %s\nfainted!" or "Enemy %s\nfainted!", self:monName(self.enemy)) })
     -- battle.fainted, the payload BattleState:onFaint emits on Gen 1.
     -- `battler` is the mon itself here: Gen 2's engine has no battler wrapper.
     Runtime.emit("battle.fainted", { battle = self, battler = self.enemy,
@@ -3285,7 +3285,7 @@ function Battle:resolveFaints()
     if not nextIndex then
       if self.trainer then
         self:emit({ kind = "message",
-          text = (self.trainer.name or "TRAINER") .. " was defeated!" })
+          text = Strings("%s was defeated!", (Strings(self.trainer.name) or "TRAINER")) })
         self:printWinLossText("win")
         self:awardPrizeMoney()
       end
@@ -3354,7 +3354,7 @@ function Battle:resolveFaints()
     if self.faintAnnounced ~= self.player then
       self.faintAnnounced = self.player
       self:emit({ kind = "faint", side = "player",
-        text = self:monName(self.player) .. " fainted!" })
+        text = Strings("%s\nfainted!", self:monName(self.player)) })
       Runtime.emit("battle.fainted", { battle = self, battler = self.player,
         side = self:sideRecord(self.player) })
       self:faintHappiness(self.player)
@@ -3524,8 +3524,8 @@ function Battle:giveExperiencePass(loser, def, recipients, count, halved,
       if not silent then
         self:emit({ kind = "experience", index = index, amount = amount,
           -- BoostedExpPointsText, keyed on the traded arm alone.
-          text = self:monName(mon) .. " gained "
-            .. (traded and "a boosted " or "") .. amount .. " EXP. Points!" })
+          text = Strings(traded and "%s gained\na boosted\v%d EXP. Points!"
+            or "%s gained\n%d EXP. Points!", self:monName(mon), amount) })
       end
       if result.levels > 0 then
         -- "level up happiness mod", the cart's own comment, sitting right
@@ -3534,7 +3534,7 @@ function Battle:giveExperiencePass(loser, def, recipients, count, halved,
         -- ChangeHappiness is outside the level loop.
         Happiness.change(mon, "GAINLEVEL")
         self:emit({ kind = "level", index = index, level = mon.level,
-          text = self:monName(mon) .. " grew to level " .. mon.level .. "!",
+          text = Strings("%s grew to\nlevel %s!", self:monName(mon), mon.level),
           sfx = "Sfx_DexFanfare5079", waitSfx = true })
         for _, moveId in ipairs(result.learned) do
           local ok, reason, entry = Mon.learnMove(mon, moveId, self.data)
@@ -3544,7 +3544,7 @@ function Battle:giveExperiencePass(loser, def, recipients, count, halved,
             -- data/text/common_3.asm:119
             self:emit({ kind = "message",
               sfx = "Sfx_DexFanfare5079", waitSfx = true,
-              text = self:monName(mon) .. " learned " .. moveName .. "!" })
+              text = Strings("%s learned\n%s!", self:monName(mon), Strings(moveName)) })
           elseif reason == "full" then
             -- LearnMove's full-moveset arm calls ForgetMove, which asks with
             -- AskForgetMoveText (engine/pokemon/learn.asm:29-34, :121-124).
@@ -3770,7 +3770,7 @@ function Battle:switch(index)
   self:emit({ kind = "send", side = "player", mon = mon,
     hp = mon.hp or 0, status = mon.status or false,
     level = mon.level, experience = mon.experience,
-    text = "Go! " .. self:monName(mon) .. "!" })
+    text = Strings("Go! %s!", self:monName(mon)) })
   -- battle.battler_switched, the payload BattleState:resolveSwitch emits on
   -- Gen 1: the side record, whoever walked in, and whoever walked out.
   Runtime.emit("battle.battler_switched", {
@@ -3849,7 +3849,7 @@ function Battle:confusionSelfHit(mon)
   damage = math.min(damage, Damage.MAX_DAMAGE - Damage.MIN_DAMAGE)
     + Damage.MIN_DAMAGE
   self:emit({ kind = "message",
-    text = "It hurt itself in its confusion!" })
+    text = Strings("It hurt itself in\nits confusion!") })
   mon.hp = math.max(0, (mon.hp or 0) - damage)
   -- HitConfusion flickers with ANIM_HIT_CONFUSION on the self-hitter's own
   -- turn, not the move after-anim (effect_commands.asm:624-632, :521-529).
@@ -4085,7 +4085,7 @@ function Battle:tryRun(pSpd)
   -- trainer check and any speed math.  Without this, running from the Red
   -- Gyarados returned a WIN to the script and forfeited the one-shot shiny.
   if self:noEscapeBattleType() then
-    self:emit({ kind = "message", text = "Can't escape!" })
+    self:emit({ kind = "message", text = Strings("Can't escape!") })
     self.runRefused = true
     return false
   end
@@ -4100,7 +4100,7 @@ function Battle:tryRun(pSpd)
   -- and before the attempt is even counted.
   if self:volatile(self.enemy).trapsTarget
       or (self:volatile(self.player).wrapCount or 0) > 0 then
-    self:emit({ kind = "message", text = "Can't escape!" })
+    self:emit({ kind = "message", text = Strings("Can't escape!") })
     self.runRefused = true
     return false
   end
@@ -4108,11 +4108,11 @@ function Battle:tryRun(pSpd)
   -- engine/battle/core.asm:2614
   if self:runRoll(pSpd or self:effectiveSpeed(self.player),
       self:effectiveSpeed(self.enemy)) then
-    self:emit({ kind = "run", text = "Got away safely!" })
+    self:emit({ kind = "run", text = Strings("Got away safely!") })
     self:endBattle("run")
     return true
   end
-  self:emit({ kind = "message", text = "Can't escape!" })
+  self:emit({ kind = "message", text = Strings("Can't escape!") })
   return false
 end
 
@@ -4190,7 +4190,7 @@ end
 function Battle:enemyFled()
   self:endBattle("fled")
   self:emit({ kind = "run", side = "enemy",
-    text = "Wild " .. self:monName(self.enemy) .. " fled!" })
+    text = Strings("Wild %s\nfled!", self:monName(self.enemy)) })
   return true
 end
 

--- a/src/battle/gen2/Battle.lua
+++ b/src/battle/gen2/Battle.lua
@@ -2793,8 +2793,9 @@ Battle.MOVE_EFFECTS.EFFECT_FORCE_SWITCH = function(self, attacker, defender,
     -- the mon that was sent away.
     self.forcedSwitch = true
     self:emit({ kind = "run", side = self:sideOf(defender),
-      text = self:monName(defender)
-        .. (moveId == "ROAR" and " fled in fear!" or " was blown away!") })
+      text = moveId == "ROAR"
+        and Strings("%s fled in fear!", self:monName(defender))
+        or Strings("%s was blown away!", self:monName(defender)) })
     return
   end
 
@@ -2830,7 +2831,7 @@ Battle.MOVE_EFFECTS.EFFECT_FORCE_SWITCH = function(self, attacker, defender,
   self:emit({ kind = "send", side = self:sideOf(incoming), mon = incoming,
     hp = incoming.hp or 0, status = incoming.status or false,
     level = incoming.level, experience = incoming.experience,
-    text = self:monName(incoming) .. " was dragged out!" })
+    text = Strings("%s was dragged out!", self:monName(incoming)) })
   self:breakTrapsOnSend(incoming)
   self:spikesDamage(incoming)
   -- wForcedSwitch: the round ends here, skipping the between-turn effects.
@@ -2863,7 +2864,7 @@ Battle.MOVE_EFFECTS.EFFECT_TELEPORT = function(self, attacker, defender)
   self.outcome = "fled"
   self.forcedSwitch = true
   self:emit({ kind = "run", side = self:sideOf(attacker),
-    text = self:monName(attacker) .. " fled from battle!" })
+    text = Strings("%s fled from battle!", self:monName(attacker)) })
 end
 
 -- -------------------------------------------------------- the move effects

--- a/src/battle/gen2/Battle.lua
+++ b/src/battle/gen2/Battle.lua
@@ -1201,7 +1201,7 @@ function Battle:hitOnce(attacker, defender, def, opts)
     -- immune hit into MoveDelay and no animation at all.
     self:markMissed()
     self:emit({ kind = "message",
-      text = "It doesn't affect " .. self:monName(defender) .. "..." })
+      text = Strings("It doesn't affect %s...", self:monName(defender)) })
     return 0, info
   end
   -- BattleCommand_FalseSwipe (engine/battle/move_effects/false_swipe.asm):
@@ -1235,11 +1235,11 @@ function Battle:dealDamage(attacker, defender, damage, opts)
     local absorbed = math.min(state.substitute, damage)
     state.substitute = state.substitute - absorbed
     self:emit({ kind = "message",
-      text = "The SUBSTITUTE took damage for " .. self:monName(defender) .. "!" })
+      text = Strings("The SUBSTITUTE took damage for %s!", self:monName(defender)) })
     if state.substitute <= 0 then
       state.substitute = nil
       self:emit({ kind = "message",
-        text = self:monName(defender) .. "'s SUBSTITUTE broke!" })
+        text = Strings("%s's SUBSTITUTE broke!", self:monName(defender)) })
     end
     return absorbed
   end
@@ -1359,7 +1359,7 @@ function Battle:changeStage(target, stat, stages)
   local name = self:monName(target)
   if not applied then
     -- WontRiseAnymoreText / WontDropAnymoreText (data/text/battle.asm:718-732).
-    self:emit({ kind = "message", text = ("%s's %s won't %s anymore!"):format(
+    self:emit({ kind = "message", text = Strings("%s's %s won't %s anymore!",
       name, Effects.STAT_NAMES[stat] or stat,
       stages > 0 and "rise" or "drop") })
     return false
@@ -1401,7 +1401,7 @@ function Battle:useMove(attacker, defender, moveId)
   -- effect list runs, so nothing a previous move set can reach this one.
   self.moveEvent = nil
   if not def then
-    self:emit({ kind = "message", text = name .. " has no move to use!" })
+    self:emit({ kind = "message", text = Strings("%s has no move to use!", name) })
     return
   end
 
@@ -1602,7 +1602,7 @@ function Battle:useMove(attacker, defender, moveId)
     -- EFFECT_FLY (`cp DIG`, effect_commands.asm:5464).
     local text = charge.text
     if moveId == "DIG" then text = "%s dug a hole!" end
-    self:emit({ kind = "message", text = text:format(name) })
+    self:emit({ kind = "message", text = Strings(text, name) })
     return
   end
 
@@ -1634,7 +1634,7 @@ function Battle:useMove(attacker, defender, moveId)
     if def.effect == "EFFECT_SELFDESTRUCT" then self:selfdestructUser(attacker) end
     self:markMissed()
     self:emit({ kind = "message",
-      text = self:monName(defender) .. " protected itself!" })
+      text = Strings("%s protected itself!", self:monName(defender)) })
     return
   end
 
@@ -1699,7 +1699,7 @@ function Battle:useMove(attacker, defender, moveId)
     local rolled, number = Effects.magnitudePower(self.random)
     powerOverride = rolled
     self:emit({ kind = "message",
-      text = ("Magnitude %d!"):format(number) })
+      text = Strings("Magnitude %d!", number) })
   end
 
   -- data/moves/effects.asm:1607, :1649
@@ -1747,7 +1747,7 @@ function Battle:useMove(attacker, defender, moveId)
     self:emit({ kind = "damage", side = self:sideOf(attacker), amount = cost,
       hp = attacker.hp, anim = false })
     self:emit({ kind = "message",
-      text = name .. " made a SUBSTITUTE!" })
+      text = Strings("%s made a SUBSTITUTE!", name) })
     return
   end
 
@@ -1767,7 +1767,7 @@ function Battle:useMove(attacker, defender, moveId)
     if Damage.typeMultiplier(def.type, defenderTypes, matchups) == 0 then
       self:markMissed()
       self:emit({ kind = "message",
-        text = "It doesn't affect " .. self:monName(defender) .. "..." })
+        text = Strings("It doesn't affect %s...", self:monName(defender)) })
       return
     end
     self:dealDamage(attacker, defender, fixed, { move = def, moveId = moveId })
@@ -1874,11 +1874,11 @@ function Battle:useMove(attacker, defender, moveId)
       -- (effect_commands.asm:5674-5687).
       self:emit({ kind = "damage", side = self:sideOf(attacker),
         amount = recoil, hp = attacker.hp, anim = false })
-      self:emit({ kind = "message", text = name .. " is hit with recoil!" })
+      self:emit({ kind = "message", text = Strings("%s is hit with recoil!", name) })
     elseif Effects.DRAIN[def.effect] and dealt > 0 then
       self:heal(attacker, Effects.drainAmount(dealt))
       self:emit({ kind = "message",
-        text = self:monName(defender) .. "'s energy was drained!" })
+        text = Strings("%s's energy was drained!", self:monName(defender)) })
     end
 
     -- BattleCommand_RechargeNextTurn (effect_commands.asm:5899): HYPER BEAM
@@ -1939,7 +1939,7 @@ function Battle:useMove(attacker, defender, moveId)
         local trapText = Battle.TRAP_TEXT[moveId]
         self:emit({ kind = "message",
           text = trapText and trapText(self:monName(defender), name)
-            or (self:monName(defender) .. " was trapped!") })
+            or Strings("%s was trapped!", self:monName(defender)) })
       end
     end
   end
@@ -1994,7 +1994,7 @@ function Battle:useMove(attacker, defender, moveId)
     if self:statusRefusedByType(defender, def.type, status) then
       self:markMissed()
       self:emit({ kind = "message",
-        text = "It doesn't affect " .. self:monName(defender) .. "..." })
+        text = Strings("It doesn't affect %s...", self:monName(defender)) })
     elseif Battle.AI_FAIL_STATUSES[status]
         and self:aiRandomFail(attacker, defender) then
       self:markMissed()
@@ -3170,7 +3170,7 @@ function Battle:applyStatus(mon, status, source)
   if source and self:sideOf(source) ~= self:sideOf(mon)
       and self:safeguarded(mon) then
     self:emit({ kind = "message",
-      text = self:monName(mon) .. " is protected by SAFEGUARD!" })
+      text = Strings("%s is protected by SAFEGUARD!", self:monName(mon)) })
     return false
   end
   -- One major status at a time.
@@ -3184,9 +3184,16 @@ function Battle:applyStatus(mon, status, source)
   -- counter live, so a mod status can arm its own counter here too.
   local record = Battle.statusRecordFor(self.data, status)
   if record and record.onInflict then record.onInflict(self, mon) end
+  local statusTexts = {
+    poison = "%s was\npoisoned!",
+    toxic = "%s was badly\npoisoned!",
+    paralyze = "%s is paralyzed! It may be unable to move!",
+    burn = "%s was\nburned!",
+    freeze = "%s was\nfrozen solid!",
+  }
+  local msgPattern = statusTexts[status] or (record and record.inflictText) or "%s is afflicted!"
   self:emit({ kind = "status", side = self:sideOf(mon), status = status,
-    text = self:monName(mon)
-      .. ((record and record.inflictText) or " is afflicted!") })
+    text = Strings(msgPattern, self:monName(mon)) })
   -- battle.status_inflicted, the payload src/battle/StatusRegistry.lua emits on
   -- Gen 1, for the major status only -- confusion is a substatus in both
   -- generations and Gen 1 raises nothing for it either.  The `status` VALUE is
@@ -3214,7 +3221,7 @@ function Battle:applyConfusion(mon, turns, source)
   if source and self:sideOf(source) ~= self:sideOf(mon)
       and self:safeguarded(mon) then
     self:emit({ kind = "message",
-      text = self:monName(mon) .. " is protected by SAFEGUARD!" })
+      text = Strings("%s is protected by SAFEGUARD!", self:monName(mon)) })
     return false
   end
   local state = self:volatile(mon)
@@ -3223,14 +3230,13 @@ function Battle:applyConfusion(mon, turns, source)
   if held == "HELD_PREVENT_CONFUSE" then return false end
   if state.confuseCount then
     self:emit({ kind = "message",
-      text = self:monName(mon) .. "'s already confused!" })
+      text = Strings("%s's already confused!", self:monName(mon)) })
     return false
   end
   state.confuseCount = turns or (rand(self.random, 4) + 2)
   local record = Battle.statusRecordFor(self.data, "confuse")
   self:emit({ kind = "message",
-    text = self:monName(mon)
-      .. ((record and record.inflictText) or " became confused!") })
+    text = Strings("%s became\nconfused!", self:monName(mon)) })
   return true
 end
 
@@ -3321,8 +3327,9 @@ function Battle:resolveFaints()
       replacement = true,
       hp = self.enemy.hp or 0, status = self.enemy.status or false,
       level = self.enemy.level, experience = self.enemy.experience,
-      text = (self.trainer and self.trainer.name or "Foe") .. " sent out "
-        .. self:monName(self.enemy) .. "!" })
+      text = Strings("%s sent out\n%s!",
+        Strings(self.trainer and self.trainer.name or "Foe"),
+        self:monName(self.enemy)) })
     Runtime.emit("battle.battler_switched", {
       battle = self, side = self:sideRecord(self.enemy), battler = self.enemy,
       previous = previous,
@@ -5066,8 +5073,9 @@ function Battle:forcedReplacement(side, index)
     self:emit({ kind = "send", side = "enemy", mon = mon, replacement = true,
       hp = mon.hp or 0, status = mon.status or false,
       level = mon.level, experience = mon.experience,
-      text = ((self.trainer and self.trainer.name) or "Foe") .. " sent out "
-        .. self:monName(mon) .. "!" })
+      text = Strings("%s sent out\n%s!",
+        Strings((self.trainer and self.trainer.name) or "Foe"),
+        self:monName(mon)) })
     Runtime.emit("battle.battler_switched", {
       battle = self, side = self:sideRecord(mon), battler = mon,
       previous = previous,

--- a/src/battle/gen2/Effects.lua
+++ b/src/battle/gen2/Effects.lua
@@ -1,3 +1,5 @@
+local Strings = require("src.core.Strings")
+
 -- Gen 2 move effects, as data plus the small amount of arithmetic each one
 -- needs.  Ported from engine/battle/effect_commands.asm; the battle engine
 -- (src/battle/gen2/Battle.lua) owns the turn loop and calls in here for what a
@@ -88,10 +90,15 @@ end
 -- BattleCommand_StatUpMessage / StatDownMessage: one stage is "rose"/"fell",
 -- two are "sharply rose" / "sharply fell".
 function Effects.stageMessage(name, stat, applied)
-  local label = Effects.STAT_NAMES[stat] or stat
-  local sharply = math.abs(applied) >= 2 and "sharply " or ""
-  local verb = applied > 0 and "rose" or "fell"
-  return ("%s's %s %s%s!"):format(name, label, sharply, verb)
+  local label = Strings(Effects.STAT_NAMES[stat] or stat)
+  -- Uma frase inteira por caso em vez de "sharply " .. "rose": o adverbio e o
+  -- verbo so significam algo juntos, e em outra lingua nem ficam nesta ordem.
+  local forma
+  if applied >= 2 then forma = "%s's %s sharply rose!"
+  elseif applied > 0 then forma = "%s's %s rose!"
+  elseif applied <= -2 then forma = "%s's %s sharply fell!"
+  else forma = "%s's %s fell!" end
+  return Strings(forma, name, label)
 end
 
 -- ------------------------------------------------------------------ hit count

--- a/src/core/Game2.lua
+++ b/src/core/Game2.lua
@@ -508,7 +508,7 @@ function Game2:learnMoveOn(mon, moveId, onDone)
   end
   if ok then
     -- data/text/common_3.asm:119
-    return self:say(("%s learned\n%s!"):format(name, moveName),
+    return self:say(Strings("%s learned\n%s!", name, moveName),
       function() finish(true) end,
       TextBox.soundOpts(self, "Sfx_DexFanfare5079"))
   end
@@ -516,15 +516,14 @@ function Game2:learnMoveOn(mon, moveId, onDone)
   local askForget, pickMove, askStop
   -- DidNotLearnMoveText, then `ld b, 0` (learn.asm:110-113).
   local function decline()
-    self:say(("%s\ndid not learn\v%s."):format(name, moveName),
+    self:say(Strings("%s\ndid not learn\v%s.", name, moveName),
       function() finish(false) end)
   end
   -- ForgetMove's AskForgetMoveText + YesNoBox (learn.asm:123-127).
   askForget = function()
     self.stack:push(TextBox.new(self,
-      ("%s is\ntrying to learn\v%s.\fBut %s\ncan't learn more\vthan four moves."
-       .. "\fDelete an older\nmove to make room\vfor %s?")
-        :format(name, moveName, name, moveName),
+      Strings("%s is\ntrying to learn\v%s.\fBut %s\ncan't learn more\vthan four moves."
+       .. "\fDelete an older\nmove to make room\vfor %s?", name, moveName, name, moveName),
       nil, { choice = function(yes)
         if yes then return pickMove() end
         return askStop()
@@ -533,7 +532,7 @@ function Game2:learnMoveOn(mon, moveId, onDone)
   -- StopLearningMoveText, whose NO is `jp c, .loop` (learn.asm:104-108).
   askStop = function()
     self.stack:push(TextBox.new(self,
-      ("Stop learning\n%s?"):format(moveName), nil,
+      Strings("Stop learning\n%s?", moveName), nil,
       { choice = function(yes)
         if yes then return decline() end
         return askForget()
@@ -556,7 +555,7 @@ function Game2:learnMoveOn(mon, moveId, onDone)
         -- MoveCantForgetHMText, then `jr .loop` (learn.asm:183-197): the
         -- question stays up and the list comes back over it.
         if old and HM_MOVES[old.id] then
-          return self:say("HM moves can't be\nforgotten now.", pushList)
+          return self:say(Strings("HM moves can't be\nforgotten now."), pushList)
         end
         self.stack:pop() -- the question the list stood on
         local oldDef = (self.data.moves or {})[old and old.id]
@@ -566,8 +565,7 @@ function Game2:learnMoveOn(mon, moveId, onDone)
         -- pokemon.move_learned is raised here too.
         ModRuntime.emit("pokemon.move_learned", { mon = mon, moveId = moveId })
         -- engine/pokemon/learn.asm:115, data/text/common_3.asm:119
-        self:say(("1, 2 and… Poof!\f%s forgot\n%s.\fAnd…\f%s learned\n%s!")
-          :format(name, oldName, name, moveName),
+        self:say(Strings("1, 2 and… Poof!\f%s forgot\n%s.\fAnd…\f%s learned\n%s!", name, oldName, name, moveName),
           function() finish(true) end,
           TextBox.soundOpts(self, "Sfx_DexFanfare5079"))
       end,
@@ -576,7 +574,7 @@ function Game2:learnMoveOn(mon, moveId, onDone)
   -- MoveAskForgetText, a `done` text: the box stays while the list stands on
   -- it (learn.asm:136-137).
   pickMove = function()
-    self.stack:push(TextBox.new(self, "Which move should\nbe forgotten?", nil,
+    self.stack:push(TextBox.new(self, Strings("Which move should\nbe forgotten?"), nil,
       { stay = { onShown = pushList } }))
   end
   askForget()
@@ -611,14 +609,12 @@ function Game2:useFieldItem(itemId)
         if id == moveId then allowed = true end
       end
       if not allowed then
-        self:say(("%s can't learn %s!"):format(
-          require("src.battle.gen2.Mon").displayName(mon), moveName))
+        self:say(Strings("%s can't learn %s!", require("src.battle.gen2.Mon").displayName(mon), moveName))
         return
       end
       for _, move in ipairs(mon.moves or {}) do
         if move.id == moveId then
-          self:say(("%s already knows %s!"):format(
-            require("src.battle.gen2.Mon").displayName(mon), moveName))
+          self:say(Strings("%s already knows %s!", require("src.battle.gen2.Mon").displayName(mon), moveName))
           return
         end
       end

--- a/src/core/Strings.lua
+++ b/src/core/Strings.lua
@@ -129,6 +129,22 @@ function Strings.source(text)
   return text
 end
 
+-- One box page, translated and split on newlines.
+--
+-- The Gen 2 screens hold a page as a list of lines, one string each, and a
+-- catalog keyed on those lines would put the translation in a straitjacket:
+-- the same sentence does not break in the same places in another language,
+-- and a per-line key cannot move a word across the break.  Keying the whole
+-- page on one source -- newlines and all -- leaves the breaks to the catalog
+-- and prints the source's own layout when nothing translates it.
+function Strings.lines(source, ...)
+  local out = {}
+  for line in (Strings.get(source, ...) .. "\n"):gmatch("(.-)\n") do
+    out[#out + 1] = line
+  end
+  return out
+end
+
 setmetatable(Strings, { __call = function(_, ...) return Strings.get(...) end })
 
 return Strings

--- a/src/core/gen2/Phone.lua
+++ b/src/core/gen2/Phone.lua
@@ -56,6 +56,7 @@
 -- (the ring, the Click!, the countdown restart) is src/core/gen2/PhoneRing.lua.
 
 local Runtime = require("src.mods.Runtime")
+local Strings = require("src.core.Strings")
 
 local Phone = {}
 
@@ -751,21 +752,21 @@ end
 -- still returns its member id, which is better than a bare number.
 function Phone.contactName(id, trainerData)
   local contact = Phone.CONTACTS[id or -1]
-  if not contact then return Phone.NON_TRAINER_NAMES[0], nil end
+  if not contact then return Strings(Phone.NON_TRAINER_NAMES[0]), nil end
   if not contact.class then
-    return Phone.NON_TRAINER_NAMES[contact.number or 0]
-      or Phone.NON_TRAINER_NAMES[0], nil
+    return Strings(Phone.NON_TRAINER_NAMES[contact.number or 0]
+      or Phone.NON_TRAINER_NAMES[0]), nil
   end
   local class = trainerData and trainerData.classes
     and trainerData.classes[contact.class]
   if class and class.trainers then
     for _, row in ipairs(class.trainers) do
       if row.id == contact.member then
-        return row.name, class.name or contact.class
+        return Strings(row.name), Strings(class.name or contact.class)
       end
     end
   end
-  return contact.member, contact.class
+  return Strings(contact.member), Strings(contact.class)
 end
 
 -- ------------------------------------------------------- context helpers

--- a/src/mods/ManagerState.lua
+++ b/src/mods/ManagerState.lua
@@ -44,6 +44,11 @@ local TAB_LINE = { "[MODS] PROF ERRS", "MODS [PROF] ERRS", "MODS PROF [ERRS]" }
 local LIST_TOP = 3   -- first content row (tile y)
 local LIST_ROWS = 11 -- single-line rows in the scroll region
 
+-- Detail screen: the description starts here and the footer owns this line,
+-- so the action rows live strictly between them (see ManagerState:drawDetail).
+local DESC_ROW = 6
+local FOOTER_ROW = 15
+
 -- what the mod declared it does, shown before the player enables it
 local PERMISSION_ROWS = {
   engine_internals = { glyph = "!", text = "PATCHES ENGINE CODE" },
@@ -1006,6 +1011,17 @@ function ManagerState:setOption(modId, key, value)
     loader.modOptions[modId][key] = value
   end
   self:persistOptions()
+  -- persistOptions routes through game:writeOptions(), which Gold's Game2
+  -- does not define -- and Game2's save.options is the "gold" sub-block
+  -- (Save.OPTIONS_KEY), not the top-level table Loader reads modOptions
+  -- from.  So under Gold the write above is a no-op aimed at the wrong
+  -- table, and a mod's options silently reset on every boot.  Persist them
+  -- directly through saveOptions' documented partial path instead: a
+  -- caller-supplied subset folds over the on-disk file rather than
+  -- replacing it, and the modOptions sub-tree merges per mod.
+  if loader and loader.modOptions then
+    SaveData.saveOptions({ modOptions = loader.modOptions })
+  end
   if loader and loader.events then
     loader.events:emit("mod.options_changed",
       { mod = modId, key = key, value = value })
@@ -1046,6 +1062,28 @@ function ManagerState:buildOptionRows(m, schema)
     end
     self.cursor = clampIndex(self.cursor, #self.optionRows)
   end
+  -- A row that only takes effect on the next boot has to say so.  This
+  -- screen's footer promises "(NO RESTART)", which is right for a mod that
+  -- reads its options live and WRONG for one that decides at LOAD TIME what
+  -- to register -- a translation choosing which catalogs to apply is exactly
+  -- that, and a player who flips the row, sees nothing change and concludes
+  -- the option is broken is the failure this avoids.
+  --
+  -- `requires_restart` is an optional row field in the sense RFC 0008
+  -- allows: an engine that does not know it ignores it and behaves as before,
+  -- so a mod carrying it still loads on an older build.
+  local needsRestart = false
+  for _, row in ipairs(schema) do
+    if type(row) == "table" and row.requires_restart
+        and OPTION_TYPES[row.type] then
+      needsRestart = true
+    end
+  end
+  self.optionsNeedRestart = needsRestart
+  local function applied(row)
+    refresh(row.key)
+    if row.requires_restart then self:notify(Strings("RESTART TO APPLY")) end
+  end
   for _, row in ipairs(schema) do
     if type(row) ~= "table" or type(row.key) ~= "string" or row.key == ""
         or not OPTION_TYPES[row.type] then
@@ -1061,7 +1099,7 @@ function ManagerState:buildOptionRows(m, schema)
         end,
         step = function()
           self:setOption(modId, row.key, not self:optionValue(modId, row))
-          refresh(row.key)
+          applied(row)
           return true
         end }
     elseif row.type == "choice" then
@@ -1084,7 +1122,7 @@ function ManagerState:buildOptionRows(m, schema)
           end
           index = clampIndex(index + dir, #choices)
           self:setOption(modId, row.key, choices[index][2])
-          refresh(row.key)
+          applied(row)
           return true
         end }
     elseif row.type == "number" then
@@ -1100,7 +1138,7 @@ function ManagerState:buildOptionRows(m, schema)
         step = function(_, dir)
           local cur = tonumber(self:optionValue(modId, row)) or 0
           self:setOption(modId, row.key, clamp(cur + dir * (row.step or 1)))
-          refresh(row.key)
+          applied(row)
           return true
         end,
         activate = function()
@@ -1111,7 +1149,7 @@ function ManagerState:buildOptionRows(m, schema)
             onDone = function(qty)
               if qty then
                 self:setOption(modId, row.key, clamp(qty))
-                refresh(row.key)
+                applied(row)
               end
             end,
           }))
@@ -1129,7 +1167,7 @@ function ManagerState:buildOptionRows(m, schema)
             default = self:optionValue(modId, row),
             onDone = function(name)
               self:setOption(modId, row.key, name)
-              refresh(row.key)
+              applied(row)
             end,
           }))
         end }
@@ -1146,7 +1184,8 @@ function ManagerState:buildOptionRows(m, schema)
       end
       self.optionRows = self:buildOptionRows(m, schema)
       self.cursor = clampIndex(self.cursor, #self.optionRows)
-      self:notify("DEFAULTS RESTORED")
+      self:notify(needsRestart and Strings("RESTART TO APPLY")
+        or "DEFAULTS RESTORED")
     end }
   return rows
 end
@@ -1243,6 +1282,31 @@ function ManagerState:drawList()
   end
 end
 
+-- Where the detail screen's action rows go, and how many description lines
+-- are left over once they have their space.
+--
+-- The block is laid out UPWARD from the footer, not downward from a fixed
+-- row 11.  A mod with five rows -- one that declares options is enough:
+-- DISABLE, OPTIONS.., FOR .., GH .., BACK -- used to put its last row on
+-- line 15, exactly where drawFooter writes "A:CHOOSE B:BACK", and the two
+-- drew on top of each other.  Anchored to the bottom, the last row lands on
+-- line 14 whatever the count and the description gives up the height
+-- instead; it already scrolls, so it loses nothing else.
+--
+-- More rows than the block can hold (a mod erroring with every optional row
+-- present) scrolls to keep the cursor inside rather than spilling over the
+-- footer again.
+function ManagerState.detailLayout(count, cursor)
+  local top = math.max(FOOTER_ROW - count, DESC_ROW + 1)
+  local fits = FOOTER_ROW - top
+  local first = 1
+  if count > fits then
+    first = math.min(math.max((cursor or 1) - fits + 1, 1), count - fits + 1)
+  end
+  return { top = top, fits = fits, first = first,
+           visible = math.max(top - DESC_ROW, 1) }
+end
+
 function ManagerState:drawDetail()
   local m = self.currentMod
   if not m then return end
@@ -1263,19 +1327,19 @@ function ManagerState:drawDetail()
                 16, 4 * 8, 17)
   local lines = wrap(m.error and ("FAILED: " .. m.error)
     or (m.note and ("SKIPPED: " .. m.note)) or m.description, 16)
-  local visible = 5
-  for i = 1, visible do
+  local rows = self:rowsForScreen()
+  local at = ManagerState.detailLayout(#rows, self.cursor)
+  for i = 1, at.visible do
     local line = lines[self.descScroll + i - 1]
     if not line then break end
-    Font.draw(line, 16, (5 + i) * 8)
+    Font.draw(line, 16, (DESC_ROW + i - 1) * 8)
   end
-  if self.descScroll + visible <= #lines then
-    Font.drawCode(Theme.moreArrow, 17 * 8, 10 * 8)
+  if self.descScroll + at.visible <= #lines then
+    Font.drawCode(Theme.moreArrow, 17 * 8, (at.top - 1) * 8)
   end
-  local rows = self:rowsForScreen()
-  local y = 11
-  for i, row in ipairs(rows) do
-    drawTruncated(row.label, 32, y * 8, 15)
+  local y = at.top
+  for i = at.first, math.min(at.first + at.fits - 1, #rows) do
+    drawTruncated(rows[i].label, 32, y * 8, 15)
     if i == self.cursor then Font.drawCode(Theme.cursor, 24, y * 8) end
     y = y + 1
   end
@@ -1350,7 +1414,9 @@ function ManagerState:draw()
     OptionRows.draw(self.game, self.optionRows or {}, self.cursor,
                     self.scroll or 0)
     love.graphics.setColor(0, 0, 0, 1)
-    Font.draw(self.notice or Strings("B:DONE (NO RESTART)"), 8, 136)
+    Font.draw(self.notice or (self.optionsNeedRestart
+      and Strings("B:DONE - RESTART") or Strings("B:DONE (NO RESTART)")),
+      8, 136)
     love.graphics.setColor(1, 1, 1, 1)
     if self.overlay then self:drawOverlay() end
     return

--- a/src/mods/Schemas.lua
+++ b/src/mods/Schemas.lua
@@ -541,18 +541,24 @@ Schemas.GEN2 = {
   statuses = "gen2Statuses", move_effects = "gen2MoveEffects",
   item_effects = "gen2ItemEffects", balls = "gen2Balls",
   ai_classes = "gen2AiClasses", evolution_methods = "gen2EvolutionMethods",
-  -- The Gen 2-only six.  They have no Gen 1 target to keep (their specs carry
+  -- The Gen 2-only seven.  They have no Gen 1 target to keep (their specs carry
   -- none), so the routed path IS the only path they ever have, and the
   -- Schemas.GEN1 rows below are what makes writing to one on Red a reported
   -- drop rather than a merge into a table Red has never heard of.  Two of them
   -- merge onto a table that already exists when mods:load runs -- landmarks
   -- onto the cache's own gen2Landmarks.landmarks, held_items onto the view
-  -- src/core/Game2.lua builds from data.items -- and the other four come
+  -- src/core/Game2.lua builds from data.items, and pokedex onto the #DEX
+  -- cache loaded a line away from landmarks -- and the other four come
   -- into existence AS the merge, seeded from their module's literals by
   -- src/mods/Builtins.lua the way the battle-rule six are.
   held_items = "gen2HeldItems", phone_contacts = "gen2PhoneContacts",
   decorations = "gen2Decorations", apricorns = "gen2Apricorns",
   landmarks = "gen2Landmarks.landmarks", radio_channels = "gen2RadioChannels",
+  -- Same family as landmarks above: Game2 loads gen2Pokedex and gen2Landmarks
+  -- on adjacent lines, so the cache this writes into already exists when
+  -- mods:load runs, and the consumer (src/ui/gen2/PokedexMenu.lua) reads that
+  -- exact path -- no Builtins.lua registrant and no consumer change needed.
+  pokedex = "gen2Pokedex.entries",
   -- Still no Gen 2 home.  Every one of these is a system Gold reimplements
   -- WITHOUT reading a registry: the Gen 1 target is still built and merged
   -- into, but nothing in a Gold boot ever looks at it.  Closing one is a
@@ -636,6 +642,7 @@ Schemas.GEN2 = {
 Schemas.GEN1 = {
   held_items = false, phone_contacts = false, decorations = false,
   apricorns = false, landmarks = false, radio_channels = false,
+  pokedex = false,
 }
 
 -- The routing table for a generation: which one is consulted is the only
@@ -2193,6 +2200,31 @@ R.apricorns = {
   },
   example = 'mod.content.apricorns:override("RED_APRICORN", '
     .. '{ apricorn = "RED_APRICORN", ball = "ULTRA_BALL", event = 600, index = 1 })',
+}
+
+-- data/generated/pokedex.lua entries: one row per species, read by
+-- src/ui/gen2/PokedexMenu.lua for the #DEX pages.  `kind` is the category
+-- printed above the entry ("PSI", "FOSSIL"); `text` and `text2` are the two
+-- description screens, with <NEXT> marking a line break inside each.  Height
+-- and weight are the cart's own fixed-point digits (tenths of a foot, tenths
+-- of a pound), which is what printNumString formats.
+--
+-- Every field is optional so a translation can patch `kind`/`text`/`text2`
+-- without restating the measurements it does not change.
+R.pokedex = {
+  -- No `target`: a Gen 2-only registry carries none, and the route lives in
+  -- Schemas.GEN2 alone (tests/engine/gen2_content_registries.lua asserts it).
+  semantics = "record",
+  fields = {
+    id = f.opt(f.str),
+    dex = f.opt(f.int(0)),
+    kind = f.opt(f.str),
+    text = f.opt(f.str),
+    text2 = f.opt(f.str),
+    height = f.opt(f.int(0)),
+    weight = f.opt(f.int(0)),
+  },
+  example = 'mod.content.pokedex:patch("ABRA", { kind = "PSI" })',
 }
 
 -- data/maps/landmarks.asm.  The town-map places, which on Gold are one index

--- a/src/script/gen2/Vm.lua
+++ b/src/script/gen2/Vm.lua
@@ -76,10 +76,10 @@ local BATTLE_RESULTS = { win = 0, lose = 1, draw = 2 }
 -- _PutItemInPocketText and _PocketIsFullText (data/text/common_2.asm:1351,
 -- :1361).  The cache's items.lua carries the same four names on `pocket`.
 local POCKET_NAMES = {
-  ITEM = "ITEM POCKET",
-  KEY_ITEM = "KEY POCKET",
-  BALL = "BALL POCKET",
-  TM_HM = "TM POCKET",
+  ITEM = Strings.source("ITEM POCKET"),
+  KEY_ITEM = Strings.source("KEY POCKET"),
+  BALL = Strings.source("BALL POCKET"),
+  TM_HM = Strings.source("TM POCKET"),
 }
 
 -- CompareMoney (engine/events/money.asm) reports account minus amount as one
@@ -702,7 +702,7 @@ local function runCmd(self, cmd, op)
         -- :1351, data/items/pocket_names.asm:10-13).
         -- Script_specialsound's WaitSFX (scripting.asm:485): the box holds
         -- its press until the jingle ends.
-        self:showRaw(Strings("{PLAYER} put the\n%s in\nthe %s.",
+        self:showRaw(Strings("{PLAYER} put the\n%s in\vthe %s.",
           name, self:pocketName(item)), nil, nil, true)
       else
         self:showRaw(Strings("The %s\nis full…", self:pocketName(item)))
@@ -719,7 +719,7 @@ local function runCmd(self, cmd, op)
     -- the clobber would corrupt an unrelated {STRBUF} page.
     local name = self:curItemName()
     if name ~= "" then
-      self:showRaw(Strings("{PLAYER} put the\n%s in\nthe %s.",
+      self:showRaw(Strings("{PLAYER} put the\n%s in\vthe %s.",
         name, self:pocketName(self.curItem)))
     end
   elseif op == "pocketisfull" then
@@ -2416,7 +2416,7 @@ end
 -- overwhelming majority of the items these boxes name really live in.
 function Vm:pocketName(item)
   local pocket = self.getItemPocketFn and item and self.getItemPocketFn(item)
-  return POCKET_NAMES[pocket] or POCKET_NAMES.ITEM
+  return Strings(POCKET_NAMES[pocket] or POCKET_NAMES.ITEM)
 end
 
 function Vm:emitFace(doFace)

--- a/src/ui/gen2/BattleState.lua
+++ b/src/ui/gen2/BattleState.lua
@@ -2851,7 +2851,7 @@ end
 -- older cache, or BATTLE SCENE off) nothing ever wobbled, so it is the first.
 function BattleState:ballFailureText()
   local wobble = (self.ballThrow and self.ballThrow.wobble) or 1
-  return BALL_FAILURE_TEXT[math.max(1, math.min(#BALL_FAILURE_TEXT, wobble))]
+  return Strings(BALL_FAILURE_TEXT[math.max(1, math.min(#BALL_FAILURE_TEXT, wobble))])
 end
 
 -- UseBallInTrainerBattle (item_effects.asm:2579).  Not a bare refusal: the ball

--- a/src/ui/gen2/BattleState.lua
+++ b/src/ui/gen2/BattleState.lua
@@ -3258,11 +3258,11 @@ function BattleState:contestCatch(mon)
   self:stampCaughtData(mon, true)
   local kind, stock, fresh = BugContest.catch(self.save, mon)
   if kind ~= BugContest.ASK_SWITCH then
-    self:push({ kind = "message", text = "Caught " .. self:name(mon) .. "!" })
+    self:push({ kind = "message", text = Strings("Caught %s!", self:name(mon)) })
     return
   end
   self:push({ kind = "message",
-    text = "You already caught a " .. self:name(stock) .. "." })
+    text = Strings("You already caught a %s.", self:name(stock)) })
   self:push({ kind = "contest-switch", stock = stock, caught = fresh })
 end
 
@@ -3818,12 +3818,12 @@ function BattleState:drawMoveInfoBox(move)
   if not move then return end
   local fighter = self.battle and self.battle.player
   if fighter and self.battle:moveDisabled(fighter, move.id) then
-    Chrome.printThrough("Disabled!", 1, 10, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings("Disabled!"), 1, 10, Chrome.DEFAULT_BOX_PALETTE)
     return
   end
   local def = self.game and self.game.data and self.game.data.moves
     and self.game.data.moves[move.id]
-  Chrome.printThrough("TYPE/", 1, 9, Chrome.DEFAULT_BOX_PALETTE)
+  Chrome.printThrough(Strings("TYPE/"), 1, 9, Chrome.DEFAULT_BOX_PALETTE)
   local moveType = def and def.type
   Chrome.printThrough(moveType and (TYPE_NAMES[moveType] or moveType) or "",
     2, 10, Chrome.DEFAULT_BOX_PALETTE)

--- a/src/ui/gen2/BattleState.lua
+++ b/src/ui/gen2/BattleState.lua
@@ -153,8 +153,8 @@ local TEXT_ASK_FORGET_MOVE = Strings.source(
 local MENU = { "FIGHT", "<PK><MN>", "PACK", "RUN" }
 local MENU_ACTION = { FIGHT = "fight", ["<PK><MN>"] = "party",
   PACK = "item", RUN = "run" }
-local MENU_BOX_X = 8
-local MENU_COL_SPACING = 6
+local MENU_BOX_X = 2
+local MENU_COL_SPACING = 9
 
 -- ContestBattleMenuHeader is the same 2x2 grid moved out to menu_coords 2, 12
 -- with 12 tiles of column spacing, because its third label is "PARKBALL×" and
@@ -438,13 +438,13 @@ function BattleState.new(game, opts)
       -- (core.asm:8730); `intro` is what defers the enemy HUD to the step after
       -- it, which is where StartBattle's `call z, UpdateEnemyHUD` sits.
       self:push({ kind = "message", intro = true, cry = enemy,
-        text = "Wild " .. self:name(enemy) .. " appeared!" })
+        text = Strings("Wild %s\nappeared!", self:name(enemy)) })
     else
       local trainerName = (self.battle.trainer and self.battle.trainer.name)
         or "Foe"
       -- WantsToBattleText (core.asm:8701), read against the trainer's own pic.
       self:push({ kind = "message",
-        text = trainerName .. " wants to battle!" })
+        text = Strings("%s wants to\nbattle!", Strings(trainerName)) })
       -- ResetEnemyBattleVars' SlideBattlePicOut at the head of EnemySwitch
       -- (core.asm:3027) pushes that pic off the right edge before the mon is
       -- announced.  Nothing to slide when the cache has no trainer pic.
@@ -455,13 +455,13 @@ function BattleState.new(game, opts)
       -- (core.asm:2978-2980, 3354): this is where the mon's frontpic first
       -- appears, where ANIM_SEND_OUT_MON plays and where the HUD comes up.
       self:push({ kind = "send", side = "enemy", mon = enemy,
-        text = trainerName .. " sent out " .. self:name(enemy) .. "!" })
+        text = Strings("%s sent out\n%s!", Strings(trainerName), self:name(enemy)) })
     end
   end
   local player = self.battle and self.battle.player
   if player then
     self:push({ kind = "sendout",
-      text = "Go! " .. self:name(player) .. "!" })
+      text = Strings("Go! %s!", self:name(player)) })
   end
   -- What the HUD shows chases the real HP one tick at a time
   -- (engine/battle/anim_hp_bar.asm), re-armed by each damage/heal event as
@@ -2861,8 +2861,8 @@ end
 -- the turn goes with it.
 function BattleState:throwBallAtTrainer(itemId)
   self.queue = {}
-  self:push({ kind = "message", text = "The trainer blocked the BALL!" })
-  self:push({ kind = "message", text = "Don't be a thief!" })
+  self:push({ kind = "message", text = Strings("The trainer\nblocked the BALL!") })
+  self:push({ kind = "message", text = Strings("Don't be a thief!") })
   self:consumeItem(itemId)
   self:pushAll(self.battle:takeTurn({ kind = "item", item = itemId }))
   -- NO_ITEM is 0, the id BattleAnim_ThrowPokeBall's first row tests.
@@ -2942,7 +2942,7 @@ function BattleState:pushCaught(enemy, itemId)
   -- and TX_SOUND holds the text engine until the jingle is done
   -- (home/text.asm:834-835), so the line is not dismissable under it.
   self:push({ kind = "message", sfx = SFX_CAUGHT_MON, waitSfx = true,
-    text = "Gotcha! " .. self:name(enemy) .. " was caught!" })
+    text = Strings("Gotcha! %s\nwas caught!", self:name(enemy)) })
   -- BATTLETYPE_TUTORIAL returns before every one of the steps below
   -- (`.FinishTutorial`, and `.return_from_capture: ret z`).
   if self.tutorial or not save then return end
@@ -2964,7 +2964,7 @@ function BattleState:pushCaught(enemy, itemId)
     -- data/text/common_3.asm:285
     self:push({ kind = "message",
       sfx = "Sfx_SlotMachineStart", waitSfx = true,
-      text = self:name(enemy) .. "'s data was newly added to the #DEX." })
+      text = Strings("%s's data was\nnewly added to the\f#DEX.", self:name(enemy)) })
     self:push({ kind = "dex-entry", species = enemy.species })
   end
   if self.contest then
@@ -3031,7 +3031,7 @@ function BattleState:pushCaught(enemy, itemId)
     -- BallSentToPCText, which .SendToPC prints AFTER the nickname prompt
     -- (item_effects.asm:672).
     self:push({ kind = "message",
-      text = self:name(enemy) .. " was sent to BILL's PC." })
+      text = Strings("%s was sent\nto BILL's PC.", self:name(enemy)) })
   end
   self:pushPayDay()
 end
@@ -3149,7 +3149,7 @@ function BattleState:askNickname(mon)
   -- YesNoBox opens on YES; YesNoMenuHeader sets no STATICMENU_DISABLE_B.
   self.nicknameIndex = 1
   self.phase = "ask-nickname"
-  self.message = "Give a nickname to " .. self:name(mon) .. "?"
+  self.message = Strings("Give a nickname to\n%s?", self:name(mon))
   self.messageTimer = MESSAGE_FRAMES
 end
 
@@ -3837,7 +3837,7 @@ function BattleState:drawPanel()
   -- required there; everywhere else a missing side is a caller bug.
   local hasPlayer = self.battle and (self.battle.player or self.tutorial)
   if not (self.battle and hasPlayer and self.battle.enemy) then
-    Chrome.printThrough("NO BATTLE", 1, 1, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings("NO BATTLE"), 1, 1, Chrome.DEFAULT_BOX_PALETTE)
     return
   end
   self:drawHud()
@@ -3872,7 +3872,7 @@ function BattleState:drawPanel()
       if i == self.menuIndex then
         Chrome.cursorThrough(tx - 1, ty, Chrome.DEFAULT_BOX_PALETTE)
       end
-      Chrome.printThrough(label, tx, ty, Chrome.DEFAULT_BOX_PALETTE)
+      Chrome.printThrough(Strings(label), tx, ty, Chrome.DEFAULT_BOX_PALETTE)
     end
   elseif self.phase == "moves"
       or (self.phase == "choose-forget" and (self.messageTimer or 0) <= 0) then
@@ -3928,8 +3928,8 @@ function BattleState:drawPanel()
       local left = (self.phase == "ask-shift" or self.phase == "ask-next-mon")
         and 1 or 14
       Chrome.box(left, 7, 6, 5)
-      Chrome.printThrough("YES", left + 2, 8, Chrome.DEFAULT_BOX_PALETTE)
-      Chrome.printThrough("NO", left + 2, 10, Chrome.DEFAULT_BOX_PALETTE)
+      Chrome.printThrough(Strings("YES"), left + 2, 8, Chrome.DEFAULT_BOX_PALETTE)
+      Chrome.printThrough(Strings("NO"), left + 2, 10, Chrome.DEFAULT_BOX_PALETTE)
       local index = self.phase == "ask-nickname" and self.nicknameIndex
         or self.phase == "ask-shift" and self.shiftIndex
         or self.phase == "ask-next-mon" and self.nextMonIndex
@@ -3961,11 +3961,11 @@ function BattleState:drawStatsBox(mon)
     stats = Mon.stats(def.baseStats, mon.dvs, mon.level, mon.statExp)
   end
   if not stats then return end
-  Chrome.textbox(9, 0, 9, 10)
+  Chrome.textbox(9, 0, 11, 11)
   for i, row in ipairs(STATS_BOX_ROWS) do
     local ty = 1 + (i - 1) * 2
     Chrome.printThrough(Strings(row[1]), 11, ty, Chrome.DEFAULT_BOX_PALETTE)
-    Chrome.printRightThrough(("%d"):format(stats[row[2]] or 0), 19, ty + 1,
+    Chrome.printRightThrough(("%d"):format(stats[row[2]] or 0), 18, ty + 1,
       Chrome.DEFAULT_BOX_PALETTE)
   end
 end

--- a/src/ui/gen2/BoxMenu.lua
+++ b/src/ui/gen2/BoxMenu.lua
@@ -51,6 +51,7 @@ local PartyMenu = require("src.ui.gen2.PartyMenu")
 local Screens = require("src.ui.Screens")
 local Sound = require("src.core.Sound")
 local Unown = require("src.core.gen2.Unown")
+local Strings = require("src.core.Strings")
 
 local BoxMenu = {}
 BoxMenu.__index = BoxMenu
@@ -107,11 +108,12 @@ end
 -- the mon is written into its new home.  It stays up here until a button
 -- clears it, because it is also the only confirmation the player gets that the
 -- mon moved and where it went.
-local SAVING_LEAVE_ON = "Saving\xe2\x80\xa6 Leave ON!"
+local SAVING_LEAVE_ON =
+  Strings.source("Saving\xe2\x80\xa6 Leave ON!")
 
 -- PCString_NoReleasingEGGS, printed by BillsPC_IsMonAnEgg with SFX_WRONG
 -- (engine/pokemon/bills_pc.asm:1615-1631, string at :2200).
-local NO_RELEASING_EGGS = "No releasing EGGS!"
+local NO_RELEASING_EGGS = Strings.source("No releasing EGGS!")
 
 function BoxMenu:wantsFillScale() return true end
 function BoxMenu:drawsWidescreen() return true end
@@ -194,15 +196,15 @@ end
 -- is one row of 18 columns.
 function BoxMenu:prompt()
   -- engine/pokemon/bills_pc.asm:356-369: PrepSubmenu places PCString_WhatsUp.
-  if self.phase == "submenu" then return "What's up?" end
+  if self.phase == "submenu" then return Strings("What's up?") end
   if self.mode == "move" then
     -- .Init and .PrepInsertCursor each place their own string.
-    if self.phase == "insert" then return "Move to where?" end
-    return "Choose a <PK><MN>."
+    if self.phase == "insert" then return Strings("Move to where?") end
+    return Strings("Choose a <PK><MN>.")
   end
   -- PCString_ChooseaPKMN: _DepositPKMN.Init and BillsPC_Withdraw.Init both
   -- place this exact string (engine/pokemon/bills_pc.asm:2185).
-  return "Choose a <PK><MN>."
+  return Strings("Choose a <PK><MN>.")
 end
 
 function BoxMenu:total()
@@ -260,7 +262,9 @@ function BoxMenu:checkMailPreventBlackout()
   local party = self.save.party or {}
   -- `cp $3 / jr c, .ItsYourLastPokemon`: a party of one or two may not send
   -- one away at all, however healthy the rest of it is.
-  if #party < 3 then return false, "It's your last <PK><MN>!" end
+  if #party < 3 then
+      return false, Strings("It's your last <PK><MN>!")
+    end
   -- CheckCurPartyMonFainted (engine/pokemon/bills_pc_top.asm:171) walks the
   -- party skipping wCurPartyMon and answers carry when everything ELSE has
   -- fainted -- taking this one out would white the player out on the next step.
@@ -268,13 +272,15 @@ function BoxMenu:checkMailPreventBlackout()
   for i, mon in ipairs(party) do
     if i ~= self.index and (mon.hp or 0) > 0 then othersUsable = true break end
   end
-  if not othersUsable then return false, "No more usable <PK><MN>!" end
+  if not othersUsable then
+      return false, Strings("No more usable <PK><MN>!")
+    end
   -- wBillsPC_MonHasMail, the byte PCMonInfo set while drawing the row.  The
   -- top menu already refused to open this screen at all while any party mon
   -- holds a letter (BillsPC_MovePKMNMenu's IsAnyMonHoldingMail,
   -- src/ui/gen2/PcMenu.lua), so this is the second of two nets.
   if Mail.monHoldsMail(party[self.index]) then
-    return false, "Remove MAIL."
+    return false, Strings("Remove MAIL.")
   end
   return true
 end
@@ -393,7 +399,7 @@ function BoxMenu:checkSpaceInDestination()
   local from = self.moveFrom
   if from and from.box == self.boxIndex then return true end
   if #self:listAt(self.boxIndex) >= self:capacityAt(self.boxIndex) then
-    return false, "There's no room!"
+    return false, Strings("There's no room!")
   end
   return true
 end
@@ -618,7 +624,7 @@ function BoxMenu:askRelease()
     end
     -- engine/pokemon/bills_pc.asm:1866
     self:playMonCry(mon)
-    self.message = name .. " was released."
+    self.message = Strings("%s was released.", name)
     self.phase = nil
     self:clampIndex()
   end, { defaultNo = true }))
@@ -887,7 +893,7 @@ function BoxMenu:drawPanel()
       if i == self.index then self:drawInsertCursor(row) end
     elseif i == self:total() then
       if i == self.index then self:drawSelectionFrame(row) end
-      Chrome.print("CANCEL", LIST_X, ty)
+      Chrome.print(Strings("CANCEL"), LIST_X, ty)
     end
   end
 
@@ -903,11 +909,11 @@ function BoxMenu:drawPanel()
       self:drawPic(mon)
       -- PrintLevel always writes the single bold glyph, not ":L"
       -- (home/pokemon.asm:178-183).
-      Chrome.print("<LV>" .. tostring(mon.level or 1), PIC_X, 12)
+      Chrome.print(Strings("<LV>") .. tostring(mon.level or 1), PIC_X, 12)
       if mon.gender == "male" then
-        Chrome.print("\xe2\x99\x82", 5, 12)
+        Chrome.print(Strings("\xe2\x99\x82"), 5, 12)
       elseif mon.gender == "female" then
-        Chrome.print("\xe2\x99\x80", 5, 12)
+        Chrome.print(Strings("\xe2\x99\x80"), 5, 12)
       end
       Chrome.print(mon.name or mon.species or "?", PIC_X, 14)
       self:drawHeldIcon(mon)

--- a/src/ui/gen2/CardFlip.lua
+++ b/src/ui/gen2/CardFlip.lua
@@ -56,6 +56,7 @@
 local Chrome = require("src.ui.gen2.Chrome")
 local CoinCase = require("src.core.gen2.CoinCase")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 
 local CardFlip = {}
 CardFlip.__index = CardFlip
@@ -942,7 +943,7 @@ function CardFlip:drawPanel()
 
   -- Coin box at (9, 15), 11 wide, 3 tall (interior 9x1)
   Chrome.textbox(COIN_BOX_X, COIN_BOX_Y, 9, 1)
-  Chrome.print("COIN", COIN_LABEL_X, COIN_LABEL_Y)
+  Chrome.print(Strings("COIN"), COIN_LABEL_X, COIN_LABEL_Y)
   Chrome.print(Chrome.number(self:coins(), 4, true), COIN_VALUE_X, COIN_VALUE_Y)
 
   if self.phase == "bet" then
@@ -956,8 +957,8 @@ function CardFlip:drawPanel()
   if self.phase == "ask" or self.phase == "again" then
     -- YesNoBox: a 6x5 box at (14,7) with YES at (16,8) and NO at (16,10).
     Chrome.textbox(14, 7, 4, 3)
-    Chrome.print("YES", 16, 8)
-    Chrome.print("NO", 16, 10)
+    Chrome.print(Strings("YES"), 16, 8)
+    Chrome.print(Strings("NO"), 16, 10)
     Chrome.cursor(15, 8 + (self.choice - 1) * 2)
   end
 end

--- a/src/ui/gen2/CenterPcMenu.lua
+++ b/src/ui/gen2/CenterPcMenu.lua
@@ -68,12 +68,12 @@ function CenterPcMenu.new(game, opts)
     -- PC_CheckPartyForPokemon: SFX_CHOOSE_PC_OPTION, the refusal, and the PC
     -- never boots (`ret c` before PC_PlayBootSound).
     self:playSfx("Sfx_ChoosePcOption")
-    self:say({ { "Bzzzzt! You must", "have a #MON to", "use this!" } },
+    self:say({ Strings.lines("Bzzzzt! You must\nhave a #MON to\nuse this!") },
       function() self:close() end)
   else
     -- PC_PlayBootSound + _PokecenterPCTurnOnText.
     self:playSfx("Sfx_BootPc")
-    self:say({ { "{PLAYER} turned on", "the PC." } })
+    self:say({ Strings.lines("{PLAYER} turned on\nthe PC.") })
   end
   return self
 end
@@ -99,16 +99,19 @@ function CenterPcMenu:buildEntries()
     and save.engineFlags[ENGINE_POKEDEX] == true
   local hofCount = (save and save.hallOfFame and save.hallOfFame.count) or 0
   local entries = {
-    { id = "bills", label = "BILL's PC" },
-    { id = "players", label = self:playerName() .. "'s PC" },
+    { id = "bills", label = Strings("BILL's PC") },
+    { id = "players", label = Strings("%s's PC", self:playerName()) },
   }
   if hasDex then
-    entries[#entries + 1] = { id = "oaks", label = "PROF.OAK's PC" }
+    entries[#entries + 1] = { id = "oaks",
+      label = Strings("PROF.OAK's PC") }
     if hofCount > 0 then
-      entries[#entries + 1] = { id = "hof", label = "HALL OF FAME" }
+      entries[#entries + 1] = { id = "hof",
+        label = Strings("HALL OF FAME") }
     end
   end
-  entries[#entries + 1] = { id = "turnoff", label = "TURN OFF" }
+  entries[#entries + 1] = { id = "turnoff",
+    label = Strings("TURN OFF") }
   self.entries = entries
 end
 
@@ -137,7 +140,7 @@ end
 -- ProfOaksPC's `.shutdown`: _OakPCText4 either way, then back to the menu
 -- loop (`jr nc, .loop` in PokemonCenterPC -- the OaksPC row answers nc).
 function CenterPcMenu:oakClosed()
-  self:say({ { "The link to PROF.", "OAK's PC closed." } })
+  self:say({ Strings.lines("The link to PROF.\nOAK's PC closed.") })
 end
 
 -- ProfOaksPCBoot, inside a screen rather than a script: the counts, the
@@ -163,15 +166,15 @@ function CenterPcMenu:choose()
   local game = self.game
   if entry.id == "turnoff" then
     -- TurnOffPC: PokecenterPCOaksClosedText, then carry into .shutdown.
-    self:say({ { "\xe2\x80\xa6", "Link closed\xe2\x80\xa6" } },
+    self:say({ Strings.lines("\xe2\x80\xa6\nLink closed\xe2\x80\xa6") },
       function() self:shutdown() end)
     return
   end
   -- PC_PlayChoosePCSound opens all four of the other rows.
   self:playSfx("Sfx_ChoosePcOption")
   if entry.id == "bills" then
-    self:say({ { "BILL's PC", "accessed." },
-               { "#MON Storage", "System opened." } }, function()
+    self:say({ Strings.lines("BILL's PC\naccessed."),
+               Strings.lines("#MON Storage\nSystem opened.") }, function()
       if not (game and game.stack) then return end
       Screens.push(game, "Gen2PcMenu", {
         save = self.save,
@@ -180,8 +183,8 @@ function CenterPcMenu:choose()
       })
     end)
   elseif entry.id == "players" then
-    self:say({ { "Accessed own PC." },
-               { "Item Storage", "System opened." } }, function()
+    self:say({ Strings.lines("Accessed own PC."),
+               Strings.lines("Item Storage\nSystem opened.") }, function()
       if not (game and game.stack) then return end
       Screens.push(game, "Gen2ItemPcMenu", {
         save = self.save,
@@ -190,11 +193,11 @@ function CenterPcMenu:choose()
       })
     end)
   elseif entry.id == "oaks" then
-    self:say({ { "PROF.OAK's PC", "accessed." },
-               { "#DEX Rating", "System opened." } }, function()
+    self:say({ Strings.lines("PROF.OAK's PC\naccessed."),
+               Strings.lines("#DEX Rating\nSystem opened.") }, function()
       -- _OakPCText1's yes/no; NO is the same `.shutdown` as a finished rating.
       self.confirm = {
-        prompt = { "Want to get your", "#DEX rated?" },
+        prompt = Strings.lines("Want to get your\n#DEX rated?"),
         choice = 1,
         onYes = function() self:oakRate() end,
         onNo = function() self:oakClosed() end,
@@ -285,7 +288,7 @@ function CenterPcMenu:drawPanel()
   -- _PokecenterPCWhoseText stays up under the menu
   -- (PC_DisplayTextWaitMenu leaves it there); the menu window is drawn on
   -- top of it, the way the cart's windows stack.
-  self:drawBottomLines({ "Access whose PC?" })
+  self:drawBottomLines({ Strings("Access whose PC?") })
   -- .TopMenu is menu_coords 0, 0, 15, 12.
   Chrome.box(0, 0, 16, math.max(12, #self.entries * 2 + 2))
   for i, entry in ipairs(self.entries) do
@@ -297,8 +300,8 @@ function CenterPcMenu:drawPanel()
   if self.confirm then
     self:drawBottomLines(self.confirm.prompt)
     Chrome.box(14, 7, 6, 5)
-    Chrome.print("YES", 16, 8)
-    Chrome.print("NO", 16, 10)
+    Chrome.print(Strings("YES"), 16, 8)
+    Chrome.print(Strings("NO"), 16, 10)
     Chrome.cursor(15, self.confirm.choice == 1 and 8 or 10)
   end
 

--- a/src/ui/gen2/Chrome.lua
+++ b/src/ui/gen2/Chrome.lua
@@ -1,3 +1,4 @@
+local Strings = require("src.core.Strings")
 -- Shared Gen 2 menu chrome: boxes, tile-grid text, and the scrolling cursor
 -- list that nearly every Gold screen is built out of.
 --
@@ -414,7 +415,7 @@ end
 -- PRINTNUM_LEADINGZEROS.
 function Chrome.coinBalanceBox(coins)
   Chrome.textbox(11, 0, 7, 1)
-  Chrome.printThrough("COIN", 12, 0, Chrome.DEFAULT_BOX_PALETTE)
+  Chrome.printThrough(Strings("COIN"), 12, 0, Chrome.DEFAULT_BOX_PALETTE)
   Chrome.printThrough(Chrome.number(coins, 4, true), 13, 1, Chrome.DEFAULT_BOX_PALETTE)
 end
 
@@ -423,9 +424,9 @@ end
 -- "COIN" at (6,3) with the four-digit count at (15,3).
 function Chrome.moneyAndCoinBalanceBox(money, coins)
   Chrome.textbox(5, 0, 13, 3)
-  Chrome.printThrough("MONEY", 6, 1, Chrome.DEFAULT_BOX_PALETTE)
+  Chrome.printThrough(Strings("MONEY"), 6, 1, Chrome.DEFAULT_BOX_PALETTE)
   Chrome.printThrough(Chrome.money(money), 12, 1, Chrome.DEFAULT_BOX_PALETTE)
-  Chrome.printThrough("COIN", 6, 3, Chrome.DEFAULT_BOX_PALETTE)
+  Chrome.printThrough(Strings("COIN"), 6, 3, Chrome.DEFAULT_BOX_PALETTE)
   Chrome.printThrough(Chrome.number(coins, 4, true), 15, 3, Chrome.DEFAULT_BOX_PALETTE)
 end
 

--- a/src/ui/gen2/ContestMenu.lua
+++ b/src/ui/gen2/ContestMenu.lua
@@ -33,6 +33,7 @@
 
 local BugContest = require("src.core.gen2.BugContest")
 local Chrome = require("src.ui.gen2.Chrome")
+local Strings = require("src.core.Strings")
 
 local ContestMenu = {}
 ContestMenu.__index = ContestMenu
@@ -155,8 +156,8 @@ function ContestMenu:drawYesNo()
   -- STATICMENU_CURSOR, and YesNoMenuHeader sets STATICMENU_NO_TOP_SPACING so
   -- there is no third row of padding -- YES at (16,8), NO at (16,10), cursor
   -- column 15.
-  Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-  Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+  Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+  Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
   Chrome.cursor(YESNO_X + 1, YESNO_Y + (self.choice == 1 and 1 or 3))
 end
 

--- a/src/ui/gen2/Credits.lua
+++ b/src/ui/gen2/Credits.lua
@@ -53,6 +53,7 @@
 -- the scene changes and the copyright/THE END tail are the cart's.
 
 local Chrome = require("src.ui.gen2.Chrome")
+local Strings = require("src.core.Strings")
 local Font = require("src.render.Font")
 local GbcPalette = require("src.render.GbcPalette")
 local Logger = require("src.core.Logger")
@@ -813,7 +814,7 @@ function Credits:drawText()
         end
       else
         -- Centred in the eight columns the graphic occupies.
-        local text = "THE END"
+        local text = Strings("THE END")
         local width = Font.width(text)
         Chrome.printThrough(text,
           entry.x + math.floor((entry.width * 8 - width) / 16), entry.y, pal)

--- a/src/ui/gen2/DayCareMenu.lua
+++ b/src/ui/gen2/DayCareMenu.lua
@@ -50,6 +50,7 @@ local Chrome = require("src.ui.gen2.Chrome")
 local CommonText = require("src.core.gen2.CommonText")
 local Screens = require("src.ui.Screens")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 
 local DayCareMenu = {}
 DayCareMenu.__index = DayCareMenu
@@ -543,8 +544,8 @@ end
 
 function DayCareMenu:drawYesNo(choice)
   Chrome.box(YESNO_X, YESNO_Y, YESNO_W, YESNO_H)
-  Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-  Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+  Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+  Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
   Chrome.cursor(YESNO_X + 1, YESNO_Y + (choice == 1 and 1 or 3))
 end
 

--- a/src/ui/gen2/EvolutionAnim.lua
+++ b/src/ui/gen2/EvolutionAnim.lua
@@ -31,6 +31,7 @@ local Chrome = require("src.ui.gen2.Chrome")
 local Evolution = require("src.core.gen2.Evolution")
 local GbcPalette = require("src.render.GbcPalette")
 local Mon = require("src.battle.gen2.Mon")
+local Strings = require("src.core.Strings")
 local Music = require("src.core.Music")
 local Palettes = require("src.world.gen2.Palettes")
 local Sound = require("src.core.Sound")
@@ -159,7 +160,7 @@ function EvolutionAnim:setPhase(phase)
     -- PrintText EvolvingText, then `ld c, 50 / call DelayFrames`.  The pics are
     -- not placed yet: on the cart the battle screen is still up behind this
     -- line and ClearBox only wipes rows 0..11 once the delay is over.
-    self.lines = { "What? " .. self.nick, "is evolving!" }
+    self.lines = Strings.lines("What? %s\nis evolving!", self.nick)
     self.timer = Evolution.EVOLVING_FRAMES
     return
   end
@@ -206,13 +207,13 @@ function EvolutionAnim:setPhase(phase)
 
   if phase == "stopped" then
     -- CancelEvolution: StoppedEvolvingText over the pic, then ClearTilemap.
-    self.lines = { "Huh? " .. self.nick, "stopped evolving!" }
+    self.lines = Strings.lines("Huh? %s\nstopped evolving!", self.nick)
     self.timer = PROMPT_FRAMES
     return
   end
 
   if phase == "congrats" then
-    self.lines = { "Congratulations!", "Your " .. self.nick }
+    self.lines = Strings.lines("Congratulations!\nYour %s", self.nick)
     self.timer = PROMPT_FRAMES
     return
   end
@@ -227,7 +228,7 @@ function EvolutionAnim:setPhase(phase)
   if phase == "evolved" then
     -- EvolvedIntoText, then MUSIC_NONE / SFX_CAUGHT_MON / WaitSFX and
     -- `ld c, 40 / call DelayFrames`.
-    self.lines = { "evolved into", self.newName .. "!" }
+    self.lines = Strings.lines("evolved into\n%s!", self.newName)
     Music.stop()
     self:playSfx("Sfx_CaughtMon")
     self.timer = Evolution.CONGRATS_FRAMES
@@ -298,7 +299,7 @@ function EvolutionAnim:nextLearn()
       end)
     end
     self.full[#self.full + 1] = moveId
-    self.lines = { self.nick .. " wants to", "learn " .. moveName .. "!" }
+    self.lines = Strings.lines("%s wants to\nlearn %s!", self.nick, moveName)
   else
     return self:nextLearn()
   end

--- a/src/ui/gen2/GenderSelect.lua
+++ b/src/ui/gen2/GenderSelect.lua
@@ -3,7 +3,6 @@
 
 local Chrome = require("src.ui.gen2.Chrome")
 local Music = require("src.core.Music")
-local RomText = require("src.core.RomText")
 local Sound = require("src.core.Sound")
 local Strings = require("src.core.Strings")
 
@@ -14,12 +13,13 @@ GenderSelect.isOpaque = true
 -- .MenuData's two items (../pokecrystal/engine/menus/init_gender.asm:50-53),
 -- and the wPlayerGender byte each writes (`ld a, [wMenuCursorY] / dec a`).
 GenderSelect.OPTIONS = {
-  { label = "Boy", gender = "male" },
-  { label = "Girl", gender = "female" },
+  { label = Strings.source("BOY"), gender = "male" },
+  { label = Strings.source("GIRL"), gender = "female" },
 }
 
--- menu_coords 6, 4, 12, 9 -- inclusive, so 7 columns by 6 rows.
-local BOX_X, BOX_Y, BOX_W, BOX_H = 6, 4, 7, 6
+-- The translated labels are six columns wide, so leave a full inner gutter
+-- after the cursor instead of using the Crystal box's original seven columns.
+local BOX_X, BOX_Y, BOX_W, BOX_H = 5, 4, 10, 6
 local TEXT_X, TEXT_Y = BOX_X + 2, BOX_Y + 2
 local CURSOR_X = TEXT_X - 1
 local ROW_STEP = 2
@@ -56,8 +56,7 @@ function GenderSelect.new(game, opts)
   -- `db 1 ; default option`: the cursor opens on Boy.
   self.cursor = 1
   self.exit = nil
-  self.text = RomText(self.data, "_AreYouABoyOrAreYouAGirlText",
-    FALLBACK)
+  self.text = Strings(FALLBACK)
   return self
 end
 
@@ -114,7 +113,7 @@ function GenderSelect:drawPanel()
   Chrome.box(BOX_X, BOX_Y, BOX_W, BOX_H)
   for i, option in ipairs(GenderSelect.OPTIONS) do
     local row = TEXT_Y + (i - 1) * ROW_STEP
-    Chrome.print(option.label, TEXT_X, row)
+    Chrome.print(Strings(option.label), TEXT_X, row)
     if i == self.cursor then Chrome.cursor(CURSOR_X, row) end
   end
 end

--- a/src/ui/gen2/HallOfFame.lua
+++ b/src/ui/gen2/HallOfFame.lua
@@ -52,6 +52,7 @@ local Palettes = require("src.world.gen2.Palettes")
 local Sound = require("src.core.Sound")
 local TileSheet = require("src.ui.gen2.TileSheet")
 local Unown = require("src.core.gen2.Unown")
+local Strings = require("src.core.Strings")
 
 local HallOfFame = {}
 HallOfFame.__index = HallOfFame
@@ -160,7 +161,7 @@ function HallOfFame.monPlacements(mon, def)
     put(out, levelText(mon.level), 1, 16)
   end
   -- '<ID>' '№' '/' at (7,16), (8,16), (9,16), then five digits at (10,16).
-  put(out, "<ID>№/", 7, 16)
+  put(out, Strings("<ID>№/"), 7, 16)
   put(out, Chrome.number(mon.otId or 0, 5, true), 10, 16)
   return out
 end
@@ -202,9 +203,9 @@ function HallOfFame.playerPlacements(save)
   local time = save.playTime or {}
   local out = {}
   put(out, player.name or "GOLD", 2, 4)
-  put(out, "<ID>№/", 1, 6)
+  put(out, Strings("<ID>№/"), 1, 6)
   put(out, Chrome.number(player.id or 0, 5, true), 4, 6)
-  put(out, "PLAY TIME", 1, 8)
+  put(out, Strings("PLAY TIME"), 1, 8)
   -- `ld de, wGameTimeHours / lb bc, 2, 3`: a two-byte value in three columns,
   -- then HALLOFFAME_COLON, then the minutes with leading zeros in two.
   put(out, Chrome.number(time.hours or 0, 3), 3, 9)

--- a/src/ui/gen2/HeldItemMenu.lua
+++ b/src/ui/gen2/HeldItemMenu.lua
@@ -32,6 +32,7 @@ local Chrome = require("src.ui.gen2.Chrome")
 local CommonText = require("src.core.gen2.CommonText")
 local Mail = require("src.core.gen2.Mail")
 local Screens = require("src.ui.Screens")
+local Strings = require("src.core.Strings")
 
 local HeldItemMenu = {}
 HeldItemMenu.__index = HeldItemMenu
@@ -359,8 +360,8 @@ end
 
 function HeldItemMenu:drawYesNo(choice)
   Chrome.box(YESNO_X, YESNO_Y, YESNO_W, YESNO_H)
-  Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-  Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+  Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+  Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
   Chrome.cursor(YESNO_X + 1, YESNO_Y + (choice == 1 and 1 or 3))
 end
 
@@ -387,7 +388,7 @@ function HeldItemMenu:drawPanel()
   for row, entry in ipairs(ENTRIES) do
     local ty = MENU_LABEL_Y + (row - 1) * 2
     if row == self.index then Chrome.cursor(MENU_LABEL_X - 1, ty) end
-    Chrome.print(entry.label, MENU_LABEL_X, ty)
+    Chrome.print(Strings(entry.label), MENU_LABEL_X, ty)
   end
   love.graphics.setColor(1, 1, 1, 1)
 end

--- a/src/ui/gen2/InitClock.lua
+++ b/src/ui/gen2/InitClock.lua
@@ -346,8 +346,8 @@ function InitClock:drawPanel()
   Chrome.printWrapped(self:pageText(), 1, 14, 18, 3)
   if self:confirming() then
     Chrome.box(14, 6, 6, 5)
-    Chrome.print("YES", 16, 7)
-    Chrome.print("NO", 16, 9)
+    Chrome.print(Strings("YES"), 16, 7)
+    Chrome.print(Strings("NO"), 16, 9)
     Chrome.cursor(15, self.yesNo == 1 and 7 or 9)
   end
 end

--- a/src/ui/gen2/ItemPcMenu.lua
+++ b/src/ui/gen2/ItemPcMenu.lua
@@ -31,6 +31,7 @@ local Logger = require("src.core.Logger")
 local Runtime = require("src.mods.Runtime")
 local Screens = require("src.ui.Screens")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 
 local ItemPcMenu = {}
 ItemPcMenu.__index = ItemPcMenu
@@ -40,8 +41,6 @@ ItemPcMenu.isOpaque = true
 -- the same pair src/core/gen2/MomShopping.lua enforces for Mom's deliveries.
 local PC_ITEM_CAPACITY = 50
 local MAX_STACK = 99
-
-local function stacksFor(n) return math.ceil((n or 0) / MAX_STACK) end
 
 -- PlayersPCMenuData .PlayersPCMenuPointers strings, verbatim.  .WhichPC picks
 -- which rows a caller sees: PLAYERSPC_NORMAL ends on LOG OFF, PLAYERSPC_HOUSE
@@ -114,8 +113,8 @@ function ItemPcMenu.new(game, opts)
   self.confirm = nil
   if self.house then
     -- _PlayersHousePC: PC_PlayBootSound, then PlayersPCTurnOnText.
-    self:playPcSfx("Sfx_BootPc")
-    self:say({ { "{PLAYER} turned on", "the PC." } })
+    self:playSfx("Sfx_BootPc")
+    self:say({ Strings.lines("{PLAYER} turned on\nthe PC.") })
   end
   return self
 end
@@ -175,24 +174,18 @@ function ItemPcMenu:rebuild()
   for id, count in pairs(pc) do
     if (count or 0) > 0 then
       local def = self:def(id)
-      local remaining = count
-      while remaining > 0 do
-        local n = math.min(remaining, MAX_STACK)
-        rows[#rows + 1] = {
-          id = id, count = n,
-          name = (def and def.name) or id,
-          index = def and def.index or math.huge,
-        }
-        remaining = remaining - n
-      end
+      rows[#rows + 1] = {
+        id = id, count = count,
+        name = (def and def.name) or id,
+        index = def and def.index or math.huge,
+      }
     end
   end
   -- wPCItems keeps acquisition order; without that recorded, item id order is
   -- the stable choice, the same sort the PACK uses.
   table.sort(rows, function(a, b)
     if a.index ~= b.index then return a.index < b.index end
-    if a.id ~= b.id then return a.id < b.id end
-    return a.count > b.count
+    return a.id < b.id
   end)
   self.rows = rows
   if self.listIndex > #rows + 1 then self.listIndex = #rows + 1 end
@@ -214,18 +207,20 @@ function ItemPcMenu:ensureVisible()
     math.max(0, self:listTotal() - VISIBLE_ROWS)))
 end
 
--- ReceiveItem over wPCItems: the add tops up every existing stack of that id
--- and spills the rest into a new one, so it only needs a free stack when the
--- room in place is short.  False is the no-carry the deposit turns into
+-- ReceiveItem over wPCItems: a new id needs one of the fifty stacks, a grown
+-- one may not pass 99.  False is the no-carry the deposit turns into
 -- _PlayersPCNoRoomDepositText.
--- engine/items/items.asm:156 PutItemInPocket
 function ItemPcMenu:pcAdd(id, qty)
   local pc = self.save.pcItems
   local held = pc[id] or 0
-  local used = 0
-  for _, count in pairs(pc) do used = used + stacksFor(count) end
-  local need = stacksFor(held + qty) - stacksFor(held)
-  if used + need > PC_ITEM_CAPACITY then return false end
+  if held == 0 then
+    local stacks = 0
+    for _, count in pairs(pc) do
+      if (count or 0) > 0 then stacks = stacks + 1 end
+    end
+    if stacks >= PC_ITEM_CAPACITY then return false end
+  end
+  if held + qty > MAX_STACK then return false end
   pc[id] = held + qty
   return true
 end
@@ -273,12 +268,12 @@ function ItemPcMenu:withdraw(row, qty)
   -- PlayerWithdrawItemMenu .withdraw: ReceiveItem into the bag first; only a
   -- carry tosses the stack out of the PC.
   if not Bag.add(self.save, row.id, qty, self.data) then
-    self:say({ { "There's no room", "for more items." } })
+    self:say({ Strings.lines("There's no room\nfor more items.") })
     return
   end
   self:pcRemove(row.id, qty)
   self:rebuild()
-  self:say({ { ("Withdrew %d"):format(qty), row.name .. "(S)." } })
+  self:say({ Strings.lines("Withdrew %d\n%s(S).", qty, row.name) })
 end
 
 function ItemPcMenu:chooseWithdraw()
@@ -294,24 +289,24 @@ function ItemPcMenu:chooseWithdraw()
     return
   end
   self:askQuantity(row.count,
-    { "How many do you", "want to withdraw?" },
+    Strings.lines("How many do you\nwant to withdraw?"),
     function(qty) self:withdraw(row, qty) end)
 end
 
 function ItemPcMenu:deposit(id, name, qty)
   if not self:pcAdd(id, qty) then
-    self:say({ { "There's no room to", "store items." } })
+    self:say({ Strings.lines("There's no room to\nstore items.") })
     return
   end
   Bag.remove(self.save, id, qty)
   if self.pack then self.pack:rebuild() end
-  self:say({ { ("Deposited %d"):format(qty), name .. "(S)." } })
+  self:say({ Strings.lines("Deposited %d\n%s(S).", qty, name) })
 end
 
 function ItemPcMenu:enterDeposit()
   -- .CheckItemsInBag: an empty bag never opens the PACK.
   if bagIsEmpty(self.save) then
-    self:say({ { "No items here!" } })
+    self:say({ Strings.lines("No items here!") })
     return
   end
   self.phase = "deposit"
@@ -342,7 +337,7 @@ function ItemPcMenu:offerToDeposit(id, count)
     return
   end
   self:askQuantity(count,
-    { "How many do you", "want to deposit?" },
+    Strings.lines("How many do you\nwant to deposit?"),
     function(qty) self:deposit(id, name, qty) end)
 end
 
@@ -354,15 +349,15 @@ function ItemPcMenu:chooseToss()
   end
   -- TossItemFromPC .key_item -> .CantToss.
   if self:cantToss(row.id) then
-    self:say({ { "That's too impor-", "tant to toss out!" } })
+    self:say({ Strings.lines("That's too impor-\ntant to toss out!") })
     return
   end
   self:askQuantity(row.count,
-    { "Toss out how many", row.name .. "(S)?" },
+    Strings.lines("Toss out how many\n%s(S)?", row.name),
     function(qty)
       -- .ItemsThrowAwayText's yes/no sits between the count and the toss.
       self.confirm = {
-        prompt = { ("Throw away %d"):format(qty), row.name .. "(S)?" },
+        prompt = Strings.lines("Throw away %d\n%s(S)?", qty, row.name),
         choice = 1,
         onYes = function()
           self:pcRemove(row.id, qty)
@@ -548,7 +543,7 @@ function ItemPcMenu:drawList()
       end
     elseif i == self:listTotal() then
       if i == self.listIndex then Chrome.cursor(5, ty) end
-      Chrome.print("CANCEL", 6, ty)
+      Chrome.print(Strings("CANCEL"), 6, ty)
     end
   end
   -- UpdateItemDescription under the list.
@@ -577,14 +572,14 @@ function ItemPcMenu:drawPanel()
     -- _PlayersPCAskWhatDoText, printed under the list the whole time.  The
     -- box goes down first: the menu window overlays it where the house's
     -- six-row list runs past row 12, the way the cart's windows stack.
-    self:drawBottomLines({ "What do you want", "to do?" })
+    self:drawBottomLines(Strings.lines("What do you want\nto do?"))
     -- PlayersPCMenuData is menu_coords 0, 0, 15, 12; the house list is one
     -- row taller than that box, so size it to the entries.
     Chrome.box(0, 0, 16, math.max(12, #self.entries * 2 + 2))
     for i, entry in ipairs(self.entries) do
       local ty = i * 2
       if i == self.index then Chrome.cursor(1, ty) end
-      Chrome.print(entry.label, 2, ty)
+      Chrome.print(Strings(entry.label), 2, ty)
     end
   end
 
@@ -597,8 +592,8 @@ function ItemPcMenu:drawPanel()
   elseif self.confirm then
     self:drawBottomLines(self.confirm.prompt)
     Chrome.box(14, 7, 6, 5)
-    Chrome.print("YES", 16, 8)
-    Chrome.print("NO", 16, 10)
+    Chrome.print(Strings("YES"), 16, 8)
+    Chrome.print(Strings("NO"), 16, 10)
     Chrome.cursor(15, self.confirm.choice == 1 and 8 or 10)
   elseif self.message then
     self:drawBottomLines(self.message.pages[self.message.page])

--- a/src/ui/gen2/MailMenu.lua
+++ b/src/ui/gen2/MailMenu.lua
@@ -29,6 +29,7 @@ local Chrome = require("src.ui.gen2.Chrome")
 local CommonText = require("src.core.gen2.CommonText")
 local Mail = require("src.core.gen2.Mail")
 local Screens = require("src.ui.Screens")
+local Strings = require("src.core.Strings")
 
 local MailMenu = {}
 MailMenu.__index = MailMenu
@@ -275,8 +276,8 @@ end
 
 function MailMenu:drawYesNo(choice)
   Chrome.box(YESNO_X, YESNO_Y, YESNO_W, YESNO_H)
-  Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-  Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+  Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+  Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
   Chrome.cursor(YESNO_X + 1, YESNO_Y + (choice == 1 and 1 or 3))
 end
 
@@ -303,7 +304,7 @@ function MailMenu:drawPanel()
   for row, entry in ipairs(ENTRIES) do
     local ty = MENU_LABEL_Y + (row - 1) * 2
     if row == self.index then Chrome.cursor(MENU_LABEL_X - 1, ty) end
-    Chrome.print(entry.label, MENU_LABEL_X, ty)
+    Chrome.print(Strings(entry.label), MENU_LABEL_X, ty)
   end
   love.graphics.setColor(1, 1, 1, 1)
 end

--- a/src/ui/gen2/MailboxMenu.lua
+++ b/src/ui/gen2/MailboxMenu.lua
@@ -33,6 +33,7 @@ local Chrome = require("src.ui.gen2.Chrome")
 local CommonText = require("src.core.gen2.CommonText")
 local Mail = require("src.core.gen2.Mail")
 local Screens = require("src.ui.Screens")
+local Strings = require("src.core.Strings")
 
 local MailboxMenu = {}
 MailboxMenu.__index = MailboxMenu
@@ -353,8 +354,8 @@ end
 
 function MailboxMenu:drawYesNo(choice)
   Chrome.box(YESNO_X, YESNO_Y, YESNO_W, YESNO_H)
-  Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-  Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+  Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+  Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
   Chrome.cursor(YESNO_X + 1, YESNO_Y + (choice == 1 and 1 or 3))
 end
 
@@ -380,7 +381,7 @@ function MailboxMenu:drawSubmenu()
   for row, entry in ipairs(SUB_ENTRIES) do
     local ty = SUB_LABEL_Y + (row - 1) * 2
     if row == self.submenu.index then Chrome.cursor(SUB_LABEL_X - 1, ty) end
-    Chrome.print(entry.label, SUB_LABEL_X, ty)
+    Chrome.print(Strings(entry.label), SUB_LABEL_X, ty)
   end
 end
 

--- a/src/ui/gen2/MapRadio.lua
+++ b/src/ui/gen2/MapRadio.lua
@@ -16,6 +16,7 @@ local Chrome = require("src.ui.gen2.Chrome")
 local Nests = require("src.core.gen2.Nests")
 local Pokegear = require("src.ui.gen2.Pokegear")
 local Runtime = require("src.mods.Runtime")
+local Strings = require("src.core.Strings")
 
 local MapRadio = {}
 MapRadio.__index = MapRadio
@@ -195,8 +196,8 @@ function MapRadio:draw()
     Chrome.print("“" .. name .. "”", 1, 14)
     return
   end
-  if radio.top ~= "" then Chrome.print(radio.top, 1, 14) end
-  if radio.bottom ~= "" then Chrome.print(radio.bottom, 1, 16) end
+  if radio.top ~= "" then Chrome.print(Strings(radio.top), 1, 14) end
+  if radio.bottom ~= "" then Chrome.print(Strings(radio.bottom), 1, 16) end
 end
 
 MapRadio.STATIONS = STATIONS

--- a/src/ui/gen2/MartMenu.lua
+++ b/src/ui/gen2/MartMenu.lua
@@ -68,6 +68,7 @@ local CommonText = require("src.core.gen2.CommonText")
 local Save = require("src.core.gen2.Save")
 local Screens = require("src.ui.Screens")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 
 -- PlayTransactionSound (engine/items/mart.asm): `call WaitSFX` then
 -- SFX_TRANSACTION.  Both tills ring it -- the buy flow at BuyMenuLoop's
@@ -878,7 +879,7 @@ function MartMenu:drawTopMenu()
   for i, label in ipairs(TOP_ITEMS) do
     local ty = TOP_LABEL_Y + (i - 1) * TOP_SPACING
     if i == self.topIndex then Chrome.cursor(TOP_LABEL_X - 1, ty) end
-    Chrome.print(label, TOP_LABEL_X, ty)
+    Chrome.print(Strings(label), TOP_LABEL_X, ty)
   end
 end
 
@@ -924,7 +925,7 @@ function MartMenu:drawBuyList()
       printPriceOpaque(entry.price, ty + 1)
     elseif i == self:total() then
       if i == self.index then Chrome.cursor(LIST_X - 1, ty) end
-      Chrome.print("CANCEL", LIST_X, ty)
+      Chrome.print(Strings("CANCEL"), LIST_X, ty)
     end
   end
   -- SCROLLINGMENU_DISPLAY_ARROWS: the ▲ only appears once the list has been
@@ -961,8 +962,8 @@ end
 
 function MartMenu:drawYesNo(choice)
   Chrome.box(YESNO_X, YESNO_Y, YESNO_W, YESNO_H)
-  Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-  Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+  Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+  Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
   Chrome.cursor(YESNO_X + 1, YESNO_Y + (choice == 1 and 1 or 3))
 end
 

--- a/src/ui/gen2/MoveDeleter.lua
+++ b/src/ui/gen2/MoveDeleter.lua
@@ -15,6 +15,7 @@
 
 local Chrome = require("src.ui.gen2.Chrome")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 
 local MoveDeleter = {}
 MoveDeleter.__index = MoveDeleter
@@ -95,7 +96,7 @@ function MoveDeleter:draw()
     local entry = self.list[slot]
     if entry then
       Chrome.print(self:moveName(entry), 2, nameY)
-      Chrome.print("PP", 10, ppY)
+      Chrome.print(Strings("PP"), 10, ppY)
       Chrome.print(Chrome.number(entry.pp, 2, true), 13, ppY)
       Chrome.print("/", 15, ppY)
       Chrome.print(Chrome.number(entry.maxPp or entry.pp, 2, true), 16, ppY)

--- a/src/ui/gen2/OakSpeech.lua
+++ b/src/ui/gen2/OakSpeech.lua
@@ -163,8 +163,9 @@ end
 
 function OakSpeech:text(key)
   local t = self.texts[key]
-  if type(t) == "string" and #t > 0 then return t end
-  return FALLBACKS[key] or ""
+  if type(t) == "string" and #t > 0 then return Strings(t) end
+  local fallback = FALLBACKS[key]
+  return type(fallback) == "string" and Strings(fallback) or ""
 end
 
 -- ------------------------------------------------------------------ steps

--- a/src/ui/gen2/PackMenu.lua
+++ b/src/ui/gen2/PackMenu.lua
@@ -1031,7 +1031,7 @@ function PackMenu:drawList(listX, listY)
       end
     elseif i == self:total() then
       if i == self.index then self:cursorAt(listX - 1, ty) end
-      Chrome.printThrough("CANCEL", listX, ty, Chrome.DEFAULT_BOX_PALETTE)
+      Chrome.printThrough(Strings("CANCEL"), listX, ty, Chrome.DEFAULT_BOX_PALETTE)
     end
   end
 end
@@ -1105,8 +1105,8 @@ end
 -- YesNoBox's own coords, the same box every other Gen 2 screen here draws.
 function PackMenu:drawYesNo()
   Chrome.box(14, 7, 6, 5)
-  Chrome.printThrough("YES", 16, 8, Chrome.DEFAULT_BOX_PALETTE)
-  Chrome.printThrough("NO", 16, 10, Chrome.DEFAULT_BOX_PALETTE)
+  Chrome.printThrough(Strings("YES"), 16, 8, Chrome.DEFAULT_BOX_PALETTE)
+  Chrome.printThrough(Strings("NO"), 16, 10, Chrome.DEFAULT_BOX_PALETTE)
   Chrome.cursorThrough(15, self.confirm.choice == 1 and 8 or 10, Chrome.DEFAULT_BOX_PALETTE)
 end
 

--- a/src/ui/gen2/PartyMenu.lua
+++ b/src/ui/gen2/PartyMenu.lua
@@ -26,6 +26,7 @@ local Mail = require("src.core.gen2.Mail")
 local Mon = require("src.battle.gen2.Mon")
 local Runtime = require("src.mods.Runtime")
 local Screens = require("src.ui.Screens")
+local Strings = require("src.core.Strings")
 
 local PartyMenu = {}
 PartyMenu.__index = PartyMenu
@@ -36,13 +37,13 @@ PartyMenu.isOpaque = true
 -- is both faithful and two tiles narrower than spelling POKéMON out -- which
 -- is what keeps "Use on which <PK><MN>?" inside its 18-column text box.
 PartyMenu.PROMPTS = {
-  choose = "Choose a POKéMON.",
-  useItem = "Use on which <PK><MN>?",
-  which = "Which <PK><MN>?",
-  teach = "Teach which <PK><MN>?",
-  moveTo = "Move to where?",
-  toWhich = "To which <PK><MN>?",
-  none = "You have no <PK><MN>!",
+  choose = Strings.source("Choose a POKéMON."),
+  useItem = Strings.source("Use on which <PK><MN>?"),
+  which = Strings.source("Which <PK><MN>?"),
+  teach = Strings.source("Teach which <PK><MN>?"),
+  moveTo = Strings.source("Move to where?"),
+  toWhich = Strings.source("To which <PK><MN>?"),
+  none = Strings.source("You have no <PK><MN>!"),
 }
 
 -- The icon's two frames swap every 16 logic steps, close to the cart's
@@ -194,9 +195,9 @@ local function buildSubmenuItems(self, mon)
   -- test is `cp EGG`).
   if mon and mon.isEgg then
     return {
-      { id = "STATS", label = "STATS" },
-      { id = "SWITCH", label = "SWITCH" },
-      { id = "CANCEL", label = "CANCEL" },
+      { id = "STATS", label = Strings("STATS") },
+      { id = "SWITCH", label = Strings("SWITCH") },
+      { id = "CANCEL", label = Strings("CANCEL") },
     }
   end
   local items = {}
@@ -212,17 +213,17 @@ local function buildSubmenuItems(self, mon)
       }
     end
   end
-  items[#items + 1] = { id = "STATS", label = "STATS" }
-  items[#items + 1] = { id = "SWITCH", label = "SWITCH" }
-  items[#items + 1] = { id = "MOVE", label = "MOVE" }
+  items[#items + 1] = { id = "STATS", label = Strings("STATS") }
+  items[#items + 1] = { id = "SWITCH", label = Strings("SWITCH") }
+  items[#items + 1] = { id = "MOVE", label = Strings("MOVE") }
   -- ItemIsMail, not a pocket test: mail lives in the ordinary ITEM pocket
   -- (ItemAttributes gives FLOWER_MAIL pocketId 1), so the only thing that
   -- says "this is mail" is data/items/mail_items.asm's own list.
   local isMail = Mail.monHoldsMail(mon)
-  items[#items + 1] = isMail and { id = "MAIL", label = "MAIL" }
-    or { id = "ITEM", label = "ITEM" }
+  items[#items + 1] = isMail and { id = "MAIL", label = Strings("MAIL") }
+    or { id = "ITEM", label = Strings("ITEM") }
   if #items < NUM_MONMENU_ITEMS then
-    items[#items + 1] = { id = "CANCEL", label = "CANCEL" }
+    items[#items + 1] = { id = "CANCEL", label = Strings("CANCEL") }
   end
   return items
 end
@@ -231,9 +232,9 @@ end
 -- (engine/pokemon/mon_submenu.asm:286-292).
 local function buildBattleSubmenuItems()
   return {
-    { id = "SWITCH", label = "SWITCH" },
-    { id = "STATS", label = "STATS" },
-    { id = "CANCEL", label = "CANCEL" },
+    { id = "SWITCH", label = Strings("SWITCH") },
+    { id = "STATS", label = Strings("STATS") },
+    { id = "CANCEL", label = Strings("CANCEL") },
   }
 end
 
@@ -706,11 +707,14 @@ end
 -- PlaceStatusString (engine/pokemon/mon_stats.asm): three letters, and a mon
 -- with no HP reads FNT whatever its status byte says.
 local function statusString(mon)
-  if (mon.hp or 0) <= 0 then return "FNT" end
+  if (mon.hp or 0) <= 0 then return Strings("FNT") end
   local status = mon.status
   if not status then return nil end
   local class = ItemEffects.STATUS_CLASS[tostring(status):lower()]
-  return class and class:upper()
+  -- The five tags are drawn here, so they resolve through the catalog.  The
+  -- literals live in ItemEffects.STATUS_CLASS, which the harvester reads;
+  -- upper-casing is this screen's own presentation.
+  return class and Strings(class:upper()) or nil
 end
 
 -- One list row's strings, exactly what WritePartyMenuTilemap's quality
@@ -738,9 +742,9 @@ function PartyMenu:tmhmAble(mon)
   if not move then return nil end
   local species = self.pokemon and self.pokemon[mon.species]
   for _, id in ipairs((species and species.tmhm) or {}) do
-    if id == move then return "ABLE" end
+    if id == move then return Strings("ABLE") end
   end
-  return "NOT ABLE"
+  return Strings("NOT ABLE")
 end
 
 -- WritePartyMenuTilemap, jumptable entry by jumptable entry.  Every coordinate
@@ -796,7 +800,7 @@ function PartyMenu:drawPanel()
   -- starts two columns left of where the nicknames do.
   local cancelY = 1 + #self.party * 2
   if self:isCancel() then Chrome.cursor(0, cancelY) end
-  Chrome.print("CANCEL", 1, cancelY)
+  Chrome.print(Strings("CANCEL"), 1, cancelY)
 
   -- PlacePartyMenuText: Textbox at (0,14) with a 2x18 interior, string at (1,16).
   -- ReturnToMapWithSpeechTextbox restores the normal font afterwards, and so
@@ -806,7 +810,8 @@ function PartyMenu:drawPanel()
   -- SwitchPartyMons swaps the prompt for PARTYMENUACTION_MOVE's string while
   -- the second pick is open, then puts the caller's own back.
   local prompt = self.switchFrom and PartyMenu.PROMPTS.moveTo or self.prompt
-  Chrome.print(#self.party == 0 and PartyMenu.PROMPTS.none or prompt, 1, 16)
+  Chrome.print(
+    Strings(#self.party == 0 and PartyMenu.PROMPTS.none or prompt), 1, 16)
   -- PokemonActionSubmenu clears (1,15) 2x18 before MonSubmenu draws, so the
   -- prompt is gone behind the box rather than showing through it.
   if self.submenu then self:drawSubmenu() end

--- a/src/ui/gen2/PcMenu.lua
+++ b/src/ui/gen2/PcMenu.lua
@@ -58,16 +58,16 @@ PcMenu.isOpaque = true
 -- draws two tiles rather than seven -- which is the only reason "MOVE <PK><MN>
 -- W/O MAIL" fits inside a 20-tile screen.
 local ENTRIES = {
-  { id = "withdraw", label = "WITHDRAW <PK><MN>" },
-  { id = "deposit", label = "DEPOSIT <PK><MN>" },
-  { id = "changebox", label = "CHANGE BOX" },
-  { id = "move", label = "MOVE <PK><MN> W/O MAIL" },
+  { id = "withdraw", label = Strings("WITHDRAW <PK><MN>") },
+  { id = "deposit", label = Strings("DEPOSIT <PK><MN>") },
+  { id = "changebox", label = Strings("CHANGE BOX") },
+  { id = "move", label = Strings("MOVE <PK><MN> W/O MAIL") },
   -- PLAYERSPCITEM_MAIL_BOX (engine/events/pokecenter_pc.asm), which BOTH
   -- .WhichPC lists carry: the MAILBOX is on the item PC in a Pokecenter and in
   -- the bedroom alike, unlike DECORATION below.  It sits here because this
   -- port folds the item PC's menu into the storage one.
-  { id = "mailbox", label = "MAIL BOX" },
-  { id = "seeya", label = "SEE YA!" },
+  { id = "mailbox", label = Strings("MAIL BOX") },
+  { id = "seeya", label = Strings("SEE YA!") },
 }
 
 -- PLAYERSPCITEM_DECORATION, the one row the bedroom's PC has that a
@@ -75,7 +75,7 @@ local ENTRIES = {
 -- carries it, PLAYERSPC_NORMAL does not).  It belongs to the item PC's menu on
 -- the cart, which this port folds into the storage menu the same way both PCs
 -- are folded -- so it hangs off the same list, gated on `house`.
-local DECORATION = { id = "decoration", label = "DECORATION" }
+local DECORATION = { id = "decoration", label = Strings("DECORATION") }
 
 -- The exit row.  It is a member of ENTRIES (it is one of _BillsPC's five), but
 -- the list is assembled without it and it is put back on the end AFTER the
@@ -441,7 +441,7 @@ function PcMenu:drawPanel()
       return
     end
     Chrome.box(0, 14, 20, 4)
-    Chrome.print("Which BOX?", 1, 16)
+    Chrome.print(Strings("Which BOX?"), 1, 16)
     love.graphics.setColor(1, 1, 1, 1)
     return
   end
@@ -452,7 +452,7 @@ function PcMenu:drawPanel()
   -- the way the cart's windows stack (src/ui/gen2/ItemPcMenu.lua does the
   -- same with the house's six-row item list).
   Chrome.box(0, 12, 20, 6)
-  Chrome.print("What?", 1, 14)
+  Chrome.print(Strings("What?"), 1, 14)
 
   -- ClearPCItemScreen: Textbox at (0,0) with a 10x18 interior, and a second
   -- at (0,12) with a 4x18 one.  GetMenuTextStartCoord then puts the first

--- a/src/ui/gen2/PokedexMenu.lua
+++ b/src/ui/gen2/PokedexMenu.lua
@@ -40,6 +40,7 @@ local Sound = require("src.core.Sound")
 local Unown = require("src.core.gen2.Unown")
 local Strings = require("src.core.Strings")
 local MenuRepeat = require("src.ui.MenuRepeat")
+local Font = require("src.render.Font")
 
 -- `db $3b, " OPTION ", $3c` / `db $3b, " SEARCH ", $3c"`: the panel titles
 -- drawn by drawOption/drawSearch below, declared here (rather than inline)
@@ -83,6 +84,23 @@ local TILE_DIVIDER = 0x61
 local TILE_PAGE_TOP = 0x55
 local TILE_PAGE_P = 0x56
 local TILE_PAGE_DIGIT = { 0x57, 0x58 }
+
+-- The entry screen's two measurements print in the cart's own units, and the
+-- foot and inch marks are tiles out of the dex sheet rather than font glyphs
+-- -- so a translation could reach "lb" through the catalog and nothing else,
+-- which left metres and kilos out of reach altogether.  Each row now resolves
+-- as a whole: the source is the shape the cart draws, `Strings.lookup` handing
+-- the source straight back means nothing asked for anything different, and
+-- that takes the tile path below -- what this screen has always drawn, tile
+-- for tile.  A catalog that answers something else has that printed instead,
+-- right-aligned on the same edge the cart's own field ends on.
+--
+-- The digits stay the `pokedex` registry's, so a metric translation ships
+-- them the way it ships `kind` and keeps the cart's own shape for them:
+-- whole * 100 + fraction for the height, tenths for the weight.  What the
+-- catalog supplies is the punctuation and the unit -- "%d,%dm", "%d,%dkg".
+local HEIGHT_UNITS = Strings.source("%d'%d\"")
+local WEIGHT_UNITS = Strings.source("%d.%dlb")
 
 -- String_SELECT_OPTION falls through into String_START_SEARCH with no
 -- terminator between them, so placing it at (1,17) writes all 18 tiles.
@@ -578,6 +596,14 @@ function PokedexMenu:text(str, tx, ty)
   Chrome.printInverted(str, tx, ty, self.gfx and self.gfx.palette)
 end
 
+-- Print ending on column `edge` instead of starting on a column: the entry
+-- screen's measurements are right-aligned fields, and a translation of them
+-- is not the same width as the cart's.  Font.width rather than #str, because
+-- a translated unit may spend two bytes on one glyph.
+function PokedexMenu:rightText(str, edge, ty)
+  self:text(str, edge + 1 - math.ceil(Font.width(str) / 8), ty)
+end
+
 -- The inverted font's ' ' cell.  Uninverted it is shade 0 throughout, so
 -- inverted it is a solid shade 3 -- black under PREDEFPAL_POKEDEX -- and
 -- every ClearBox and box interior on these screens is made of it.
@@ -640,6 +666,23 @@ local function printNumString(value, digits, leadingZeros, before)
   return text
 end
 
+-- One measurement, without its label: the cart's digits while nothing has
+-- overridden the units, and the catalog's own form once something has.
+-- `split` is where the value's fraction starts (100 for the height's second
+-- pair of digits, 10 for the weight's single one).
+local function measureText(source, value, split, digits, before)
+  if Strings.lookup(source) == source then
+    return printNumString(value, digits, false, before)
+  end
+  return Strings(source, math.floor(value / split), value % split)
+end
+
+-- The same form with the numbers left out, for a mon the player has seen but
+-- not caught: the cart prints "?" in each digit's place and so does this.
+local function unknownText(form)
+  return (form:gsub("%%[-+ #0]*%d*%.?%d*[diufgGeExXoc]", "?"))
+end
+
 -- ---------------------------------------------------------------- main screen
 
 -- Pokedex_DrawMainScreenBG, drawn behind the window and scrolled by SCX.
@@ -655,9 +698,9 @@ function PokedexMenu:drawMainBackground()
   self:border(0, 9, 6, 7)
 
   local seen, caught = self:totals()
-  self:text("SEEN", 1, 11)
+  self:text(Strings("SEEN"), 1, 11)
   self:text(printNumString(seen, 3), 5, 12)
-  self:text("OWN", 1, 14)
+  self:text(Strings("OWN"), 1, 14)
   self:text(printNumString(caught, 3), 5, 15)
 
   for i, id in ipairs(BOTTOM_CAPTION) do self:tile(id, i, 17) end
@@ -930,7 +973,7 @@ function PokedexMenu:drawArea()
     self:drawTilemap(cells)
   end
 
-  self:drawAreaHeader(self:monName(row.species) .. "'S NEST")
+  self:drawAreaHeader(Strings("%s'S NEST", self:monName(row.species)))
 
   -- engine/pokegear/pokegear.asm:2385
   local on = ((self.areaBlink or 0) % 32) < 16
@@ -977,7 +1020,7 @@ function PokedexMenu:drawEntryBody(row, entry)
   self:tile(0x3b, 0, 17)
   -- _NewPokedexEntry ByteFills the action row away (pokedex.asm:2540-2545).
   if not self.newEntry then
-    self:text(" PAGE AREA CRY PRNT", 1, 17)
+    self:text(Strings(" PAGE AREA CRY PRNT"), 1, 17)
     -- Pokedex_InitArrowCursor parks an arrow on the selected action; without it
     -- the four words are decoration and there is no way to tell what A will do.
     --
@@ -1010,27 +1053,50 @@ function PokedexMenu:drawEntryBody(row, entry)
 
   -- .Height / .Weight are placeholder strings until the mon is caught:
   -- "HT  ?'??"" at (9,7) and "WT   ???lb" at (9,9).
-  self:text("HT", 9, 7)
-  self:text("WT", 9, 9)
-  self:tile(TILE_FOOT, 14, 7)
-  self:text("lb", 17, 9)
+  self:text(Strings("HT"), 9, 7)
+  self:text(Strings("WT"), 9, 9)
+  -- The marks belong to the cart's units, so they are drawn only while the
+  -- units are the cart's; see HEIGHT_UNITS.
+  local heightForm = Strings.lookup(HEIGHT_UNITS)
+  local weightForm = Strings.lookup(WEIGHT_UNITS)
+  local cartHeight = heightForm == HEIGHT_UNITS
+  local cartWeight = weightForm == WEIGHT_UNITS
+  if cartHeight then self:tile(TILE_FOOT, 14, 7) end
+  if cartWeight then self:text(Strings("lb"), 17, 9) end
 
   if not row.caught then
-    self:text("  ?", 11, 7)
-    self:text("??", 15, 7)
-    self:tile(TILE_INCH, 17, 7)
-    self:text("  ???", 11, 9)
+    if cartHeight then
+      self:text("  ?", 11, 7)
+      self:text("??", 15, 7)
+      self:tile(TILE_INCH, 17, 7)
+    else
+      self:rightText(unknownText(heightForm), 17, 7)
+    end
+    if cartWeight then
+      self:text("  ???", 11, 9)
+    else
+      self:rightText(unknownText(weightForm), 18, 9)
+    end
     return
   end
 
   -- The height word is four digits with two in front of the point and the
   -- point replaced by the foot mark; the weight word is five with four in
   -- front.  Both are already the digits the cart prints.
-  local height = printNumString(entry.height or 0, 4, false, 2)
-  self:text(height:sub(1, 2), 12, 7)
-  self:text(height:sub(4), 15, 7)
-  self:tile(TILE_INCH, 17, 7)
-  self:text(printNumString(entry.weight or 0, 5, false, 4), 11, 9)
+  local height, weight = entry.height or 0, entry.weight or 0
+  if cartHeight then
+    local shown = printNumString(height, 4, false, 2)
+    self:text(shown:sub(1, 2), 12, 7)
+    self:text(shown:sub(4), 15, 7)
+    self:tile(TILE_INCH, 17, 7)
+  else
+    self:rightText(Strings(HEIGHT_UNITS, math.floor(height / 100), height % 100), 17, 7)
+  end
+  if cartWeight then
+    self:text(printNumString(weight, 5, false, 4), 11, 9)
+  else
+    self:rightText(Strings(WEIGHT_UNITS, math.floor(weight / 10), weight % 10), 18, 9)
+  end
 
   -- Page marker, then the description.  ClearBox(2,11) is 5 rows by 18
   -- columns and <NEXT> steps two rows, so the three lines land on 11/13/15.
@@ -1085,8 +1151,10 @@ function PokedexMenu:drawPlain()
       Chrome.print(("%s  %s"):format(
         Chrome.number(entry.dex or 0, 3, true), self:monName(row.species)), 1, 1)
       Chrome.print(entry.kind or "", 1, 3)
-      Chrome.print("HT " .. printNumString(entry.height or 0, 4, false, 2), 1, 5)
-      Chrome.print("WT " .. printNumString(entry.weight or 0, 5, false, 4), 1, 7)
+      Chrome.print(Strings("HT ")
+        .. measureText(HEIGHT_UNITS, entry.height or 0, 100, 4, 2), 1, 5)
+      Chrome.print(Strings("WT ")
+        .. measureText(WEIGHT_UNITS, entry.weight or 0, 10, 5, 4), 1, 7)
       self:drawPic(row, 12, 1, true)
       Chrome.box(0, 10, 20, 8)
       local ty = 11
@@ -1114,9 +1182,9 @@ function PokedexMenu:drawPlain()
   Chrome.box(13, 11, 7, 7)
   local seen, caught = self:totals()
   Chrome.print(self:mode(), 14, 12)
-  Chrome.print("SEEN", 14, 14)
+  Chrome.print(Strings("SEEN"), 14, 14)
   Chrome.printRight(tostring(seen), 19, 15)
-  Chrome.print("OWN", 14, 16)
+  Chrome.print(Strings("OWN"), 14, 16)
   Chrome.printRight(tostring(caught), 19, 17)
 end
 
@@ -1323,7 +1391,7 @@ function PokedexMenu:unownCursor(tx, ty)
     and sheet:draw((self.unownFontBase or 0x40) + Unown.NUM_UNOWN, tx, ty) then
     return
   end
-  self:text("\xe2\x96\xb6", tx, ty)
+  self:text(Strings("\xe2\x96\xb6"), tx, ty)
 end
 
 function PokedexMenu:drawUnownPic(letter, tx, ty)
@@ -1422,12 +1490,12 @@ function PokedexMenu:drawOption()
   -- `db $3b, " OPTION ", $3c`: the two end-cap tiles are the dex sheet's, not
   -- font glyphs.
   self:tile(0x3b, 0, 1)
-  self:text(Strings(OPTION_LABEL), 1, 1)
+  self:text(Strings(" OPTION "), 1, 1)
   self:tile(0x3c, 9, 1)
   local rows = self:optionRows()
   for i, row in ipairs(rows) do
-    self:text(row.label, 3, 2 + i * 2)
-    if i == self.optionIndex then self:text("\xe2\x96\xb6", 2, 2 + i * 2) end
+    self:text(Strings(row.label), 3, 2 + i * 2)
+    if i == self.optionIndex then self:text(Strings("\xe2\x96\xb6"), 2, 2 + i * 2) end
   end
   local current = rows[self.optionIndex]
   if current then
@@ -1442,24 +1510,24 @@ function PokedexMenu:drawSearch()
   self:fill(TILE_BG, 0, 0, Chrome.SCREEN_W, Chrome.SCREEN_H)
   self:border(0, 2, 14, 18)
   self:tile(0x3b, 0, 1)
-  self:text(Strings(SEARCH_LABEL), 1, 1)
+  self:text(Strings(" SEARCH "), 1, 1)
   self:tile(0x3c, 9, 1)
-  self:text("TYPE1", 3, 4)
-  self:text("TYPE2", 3, 6)
-  self:text(self:searchTypeName(1), 10, 4)
-  self:text(self:searchTypeName(2), 10, 6)
+  self:text(Strings("TYPE1"), 3, 4)
+  self:text(Strings("TYPE2"), 3, 6)
+  self:text(Strings(self:searchTypeName(1)), 10, 4)
+  self:text(Strings(self:searchTypeName(2)), 10, 6)
   -- `.TypeLeftRightArrows: db $3d, "        ", $3e` -- two of the dex sheet's
   -- own tiles at columns 8 and 17, not font glyphs.
   for _, y in ipairs({ 4, 6 }) do
     self:tile(0x3d, 8, y)
     self:tile(0x3e, 17, y)
   end
-  self:text("BEGIN SEARCH!!", 3, 13)
-  self:text("CANCEL", 3, 15)
+  self:text(Strings("BEGIN SEARCH!!"), 3, 13)
+  self:text(Strings("CANCEL"), 3, 15)
   if self.searchMessage then self:text(self.searchMessage, 3, 10) end
   local rows = { 4, 6, 13, 15 }
   local y = rows[self.searchIndex] or 4
-  self:text("\xe2\x96\xb6", 2, y)
+  self:text(Strings("\xe2\x96\xb6"), 2, y)
 end
 
 function PokedexMenu:drawPanel()

--- a/src/ui/gen2/Pokegear.lua
+++ b/src/ui/gen2/Pokegear.lua
@@ -2371,7 +2371,7 @@ function Pokegear:drawPlain()
     -- No town-map art in this cache, so the bubble's "Where?" and the rows it
     -- scrolls between are the whole screen.
     Chrome.box(0, 0, 20, 4)
-    Chrome.print("Where?", 2, 1)
+    Chrome.print(Strings("Where?"), 2, 1)
     Chrome.box(0, 4, 20, 14)
     local rows = self.fly
     local top = math.max(1, math.min((self.flyIndex or 1) - 3, #rows - 5))
@@ -2439,7 +2439,7 @@ function Pokegear:drawPlain()
     self:drawPhoneSubmenu()
   else
     Chrome.box(0, 4, 20, 14)
-    Chrome.print("NO CARD DATA", 2, 6)
+    Chrome.print(Strings("NO CARD DATA"), 2, 6)
   end
 end
 

--- a/src/ui/gen2/Pokegear.lua
+++ b/src/ui/gen2/Pokegear.lua
@@ -332,7 +332,7 @@ function Radio:printLine(text, nextLine)
   self.next = nextLine
   -- wRadioText itself: the buffer keeps the last line composed into it, which
   -- is what OaksPKMNTalk4's .overflow branch reprints.
-  self.text = text
+  self.text = Strings(text)
   if self.printed < 2 then
     self.printed = self.printed + 1
     if self.printed == 1 then self.top = text else self.bottom = text end
@@ -1119,7 +1119,7 @@ end
 -- non-trainer is its NonTrainerCallerNames string and nothing under it.
 function Pokegear:contactRow(id)
   local name, className = Phone.contactName(id, self.trainers)
-  return (name or "----------") .. ":", className
+  return (Strings(name) or "----------") .. ":", (className and Strings(className) or nil)
 end
 
 function Pokegear:update(_dt)
@@ -2329,7 +2329,7 @@ function Pokegear:drawPhone()
       or self:phoneText("GearEllipse"), 18)
     for i = 1, math.min(#lines, 3) do self:text(lines[i], 1, 13 + i) end
   else
-    self:printBoxText(self:phoneText("AskWhoCall"))
+    self:printBoxText(Strings(self:phoneText("AskWhoCall")))
   end
   -- PokegearPhone_UpdateDisplayList: every one of the four visible slots is
   -- drawn, empty or not, from (2,4) two rows apart.  GetCallerClassAndName
@@ -2358,7 +2358,7 @@ function Pokegear:drawPhoneSubmenu()
   self:textbox(menu.x, menu.y, 8, menu.rows * 2)
   for index, label in ipairs(menu.entries) do
     local ty = menu.textY + (index - 1) * 2
-    self:text(label, menu.textX, ty)
+    self:text(Strings(label), menu.textX, ty)
   end
   self:cursor(menu.textX - 1, menu.textY + self.phoneSubmenuCursor * 2)
 end
@@ -2435,8 +2435,7 @@ function Pokegear:drawPlain()
     end
     Chrome.cursor(1, 4 + self.phoneCursor * 2)
     Chrome.textbox(0, 12, 18, 4)
-    Chrome.printWrapped(self.call and (self.call.text or "")
-      or self:phoneText("AskWhoCall"), 1, 14, 18, 3)
+    Chrome.printWrapped(Strings(self.call and (self.call.text or "") or self:phoneText("AskWhoCall")), 1, 14, 18, 3)
     self:drawPhoneSubmenu()
   else
     Chrome.box(0, 4, 20, 14)

--- a/src/ui/gen2/PrizeMenu.lua
+++ b/src/ui/gen2/PrizeMenu.lua
@@ -47,6 +47,7 @@ local Chrome = require("src.ui.gen2.Chrome")
 local CoinCase = require("src.core.gen2.CoinCase")
 local Save = require("src.core.gen2.Save")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 
 local PrizeMenu = {}
 PrizeMenu.__index = PrizeMenu
@@ -162,7 +163,7 @@ PrizeMenu.TEXTS = {
       page("prizes!")),
     which = page("Which prize would", "you like?"),
     confirm = function(name)
-      return pages(page("OK, so you wanted", ("a %s?"):format(name)))
+      return pages(page(Strings("OK, so you wanted\na %s?", name)))
     end,
     hereYouGo = pages(page("Here you go!")),
     notEnoughCoins = pages(page("You don't have", "enough coins.")),
@@ -176,7 +177,7 @@ PrizeMenu.TEXTS = {
       page("fabulous prizes!")),
     which = page("Which prize would", "you like?"),
     confirm = function(name)
-      return pages(page(("%s."):format(name), "Is that right?"))
+      return pages(page(Strings("%s.\nIs that right?", name)))
     end,
     hereYouGo = pages(page("Here you go!")),
     notEnoughCoins = pages(page("Sorry! You need", "more coins.")),
@@ -370,12 +371,28 @@ function PrizeMenu:buildPrizes()
   self.prizes = out
 end
 
+-- Cada PAGINA e uma entrada do catalogo, com as linhas juntas por `\n`.
+-- Traduzir linha a linha prenderia a quebra a do ingles; assim a traducao
+-- escolhe a propria.  Roda aqui, e nao em PrizeMenu.TEXTS, porque aquela
+-- tabela e do modulo e carrega antes do mod.
+local function localize(list)
+  local out = {}
+  for i, page in ipairs(list or {}) do
+    local lines = {}
+    for line in (Strings(table.concat(page, "\n")) .. "\n"):gmatch("(.-)\n") do
+      lines[#lines + 1] = line
+    end
+    out[i] = lines
+  end
+  return out
+end
+
 function PrizeMenu:say(list, onDone)
-  self.message = { pages = list or {}, page = 1, onDone = onDone }
+  self.message = { pages = localize(list), page = 1, onDone = onDone }
 end
 
 function PrizeMenu:ask(list, onYes, onNo)
-  self.confirm = { pages = list or {}, page = 1, choice = 1,
+  self.confirm = { pages = localize(list), page = 1, choice = 1,
     onYes = onYes, onNo = onNo }
 end
 
@@ -529,7 +546,7 @@ end
 -- ------------------------------------------------------------------- draw
 function PrizeMenu:drawCoinBox()
   Chrome.textbox(COIN_BOX_X, COIN_BOX_Y, COIN_BOX_W - 2, COIN_BOX_H - 2)
-  Chrome.print("COIN", COIN_LABEL_X, COIN_LABEL_Y)
+  Chrome.print(Strings("COIN"), COIN_LABEL_X, COIN_LABEL_Y)
   Chrome.print(Chrome.number(PrizeMenu.coins(self.save), 4, true),
     COIN_VALUE_X, COIN_VALUE_Y)
 end
@@ -562,8 +579,8 @@ function PrizeMenu:drawPanel()
   end
   if self.confirm and self.confirm.page >= #self.confirm.pages then
     Chrome.textbox(YESNO_X, YESNO_Y, YESNO_W - 2, YESNO_H - 2)
-    Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-    Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+    Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+    Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
     Chrome.cursor(YESNO_X + 1, YESNO_Y + 1 + (self.confirm.choice - 1) * 2)
   end
 end

--- a/src/ui/gen2/SaveMenu.lua
+++ b/src/ui/gen2/SaveMenu.lua
@@ -45,11 +45,12 @@ local SFX_SAVE = 0x25
 local SAVING_FRAMES = 16
 local SAVED_FRAMES = 32 + 30
 
--- MenuBox coordinates after _OffsetMenuHeader(4, 0).
-local PANEL_X, PANEL_Y, PANEL_W, PANEL_H = 4, 0, 16, 10
-local LABEL_X, LABEL_Y = 5, 2
--- Continue_DisplayBadgesDex / Continue_PrintGameTime add these to the box's
--- own origin, so they are (4,0) + (13,4) / (12,6) / (9,8).
+-- MenuBox coordinates after _OffsetMenuHeader.
+-- Upper panel: x=6..19 (width 14). Labels at x=7 (border+1).
+-- YES/NO box: x=0..5 (width 6). YES at x=2..4, right border at x=5.
+local PANEL_X, PANEL_Y, PANEL_W, PANEL_H = 6, 0, 14, 10
+local LABEL_X, LABEL_Y = 7, 2
+-- Continue_DisplayBadgesDex / Continue_PrintGameTime inside the panel.
 local BADGES_X, BADGES_Y = 17, 4
 local DEX_X, DEX_Y = 16, 6
 local TIME_X, TIME_Y = 13, 8

--- a/src/ui/gen2/SlotMachine.lua
+++ b/src/ui/gen2/SlotMachine.lua
@@ -46,6 +46,7 @@
 local Chrome = require("src.ui.gen2.Chrome")
 local CoinCase = require("src.core.gen2.CoinCase")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 
 local SlotMachine = {}
 SlotMachine.__index = SlotMachine
@@ -1517,8 +1518,8 @@ function SlotMachine:drawPanel()
 
     -- PlaceYesNoBox at (14, 12): 6x5 box with YES at (16,13), NO at (16,15)
     Chrome.textbox(14, 12, 4, 3)
-    Chrome.print("YES", 16, 13)
-    Chrome.print("NO", 16, 15)
+    Chrome.print(Strings("YES"), 16, 13)
+    Chrome.print(Strings("NO"), 16, 15)
     Chrome.cursor(15, 13 + (self.againChoice - 1) * 2)
   else
     self:drawMessage()

--- a/src/ui/gen2/StartMenu.lua
+++ b/src/ui/gen2/StartMenu.lua
@@ -23,6 +23,7 @@ local Chrome = require("src.ui.gen2.Chrome")
 local Logger = require("src.core.Logger")
 local Runtime = require("src.mods.Runtime")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 
 local StartMenu = {}
 StartMenu.__index = StartMenu
@@ -46,48 +47,48 @@ StartMenu.isOpaque = false
 -- exactly what kept POKéGEAR hanging off the menu box's right edge.
 local ITEMS = {
   {
-    id = "pokedex", label = "POKéDEX", need = "pokedex",
-    desc = { "POKéMON", "database" },
+    id = "pokedex", label = Strings("POKéDEX"), need = "pokedex",
+    desc = { Strings("POKéMON"), Strings("database") },
   },
   {
-    id = "pokemon", label = "POKéMON", need = "party",
-    desc = { "Party <PK><MN>", "status" },
+    id = "pokemon", label = Strings("POKéMON"), need = "party",
+    desc = { Strings("Party <PK><MN>"), Strings("status") },
   },
   {
-    id = "pack", label = "PACK", need = "pack",
-    desc = { "Contains", "items" },
+    id = "pack", label = Strings("PACK"), need = "pack",
+    desc = { Strings("Contains"), Strings("items") },
   },
   {
-    id = "pokegear", label = "<PO><KE>GEAR", need = "pokegear",
-    desc = { "Trainer's", "key device" },
+    id = "pokegear", label = Strings("<PO><KE>GEAR"), need = "pokegear",
+    desc = { Strings("Trainer's"), Strings("key device") },
   },
   {
     -- The player's own name is the label (.StatusString is "<PLAYER>").
     id = "status", label = nil,
-    desc = { "Your own", "status" },
+    desc = { Strings("Your own"), Strings("player status") },
   },
   {
-    id = "save", label = "SAVE",
-    desc = { "Save your", "progress" },
+    id = "save", label = Strings("SAVE"),
+    desc = { Strings("Save your"), Strings("progress") },
   },
   {
-    id = "option", label = "OPTION",
-    desc = { "Change", "settings" },
+    id = "option", label = Strings("OPTION"),
+    desc = { Strings("Change"), Strings("settings") },
   },
   {
     -- The mod manager's discoverable home, exactly as the Gen 1 start menu
     -- carries it: the row only appears once at least one mod has been
     -- discovered, so a vanilla install's menu is the cart's.
-    id = "mods", label = "MODS", need = "mods",
-    desc = { "Installed", "add-ons" },
+    id = "mods", label = Strings("MODS"), need = "mods",
+    desc = { Strings("Installed"), Strings("add-ons") },
   },
   {
     -- The cart's EXIT just closed the menu (CloseStartMenu).  A window with a
     -- close button already covers that, so -- exactly as the Gen 1 port does
     -- (src/ui/StartMenu.lua) -- this row is QUIT and power-cycles back to the
     -- title after a confirmation that defaults to NO.
-    id = "quit", label = "QUIT",
-    desc = { "Return to", "the title" },
+    id = "quit", label = Strings("QUIT"),
+    desc = { Strings("Return to"), Strings("the title") },
   },
 }
 
@@ -279,11 +280,11 @@ function StartMenu:draw()
 
   if self.phase == "confirm" then
     Chrome.textbox(0, 12, 18, 4)
-    Chrome.print("Return to the", 1, 14)
-    Chrome.print("title screen?", 1, 16)
+    Chrome.print(Strings("Return to the"), 1, 14)
+    Chrome.print(Strings("title screen?"), 1, 16)
     Chrome.box(YESNO_X, YESNO_Y, YESNO_W, YESNO_H)
-    Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-    Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+    Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+    Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
     Chrome.cursor(YESNO_X + 1,
       YESNO_Y + (self.confirmChoice == 1 and 1 or 3))
     return
@@ -295,7 +296,9 @@ function StartMenu:draw()
   if not desc then return end
   -- ._DrawMenuAccount ClearBox (0,13) 5 rows by 10, .PrintMenuAccount decoord
   -- 0, 14 and the desc's `next` steps two rows (start_menu.asm:366-382).
-  Chrome.paletteFill(0, 13 * 8, 10 * 8, 5 * 8)
+  local G = love.graphics
+  G.setColor(1, 1, 1, 1)
+  G.rectangle("fill", 0, 13 * 8, 10 * 8, 5 * 8)
   Chrome.print(desc[1] or "", 0, 14)
   Chrome.print(desc[2] or "", 0, 16)
 end

--- a/src/ui/gen2/SummaryMenu.lua
+++ b/src/ui/gen2/SummaryMenu.lua
@@ -68,6 +68,7 @@ local MonAnim = require("src.render.MonAnim")
 local Palettes = require("src.world.gen2.Palettes")
 local Pokerus = require("src.core.gen2.Pokerus")
 local Unown = require("src.core.gen2.Unown")
+local Strings = require("src.core.Strings")
 
 local SummaryMenu = {}
 SummaryMenu.__index = SummaryMenu
@@ -224,7 +225,9 @@ local function statusText(mon)
   local status = mon.status
   if not status then return nil end
   local class = ItemEffects.STATUS_CLASS[tostring(status):lower()]
-  return class and class:upper()
+  -- Drawn, so it resolves through the catalog.  The literals live in
+  -- ItemEffects.STATUS_CLASS; upper-casing is this screen's presentation.
+  return class and Strings(class:upper()) or nil
 end
 
 -- wTempMonPokerusStatus is one byte: the low nibble counts the days left and
@@ -504,13 +507,13 @@ function SummaryMenu:pinkPlacements()
 
   -- .Status_Type is "STATUS/" <NEXT> "TYPE/", and <NEXT> is two rows down at
   -- the same column -- so the second label is at row 14, not row 13.
-  put(out, "STATUS/", 0, 12)
-  put(out, "TYPE/", 0, 14)
+  put(out, Strings("STATUS/"), 0, 12)
+  put(out, Strings("TYPE/"), 0, 14)
 
   local pokerus = pokerusState(mon)
   if pokerus == "infected" then
     -- .PkrsStr is "#RUS", and '#' is the four-tile POKé compression byte.
-    put(out, "POKéRUS", 1, 13)
+    put(out, Strings("POKéRUS"), 1, 13)
   else
     if pokerus == "immune" then put(out, ".", 8, 8) end
     put(out, statusText(mon) or "OK", 6, 13)
@@ -523,13 +526,13 @@ function SummaryMenu:pinkPlacements()
   put(out, type1, 1, 15)
   put(out, type2, 1, 16)
 
-  put(out, "EXP POINTS", 10, 9)
+  put(out, Strings("EXP POINTS"), 10, 9)
   -- `lb bc, 3, 7`: a three-byte value in seven columns, so the field runs
   -- (13,10) to (19,10).
   put(out, num(mon.experience, 7), 13, 10)
-  put(out, "LEVEL UP", 10, 12)
+  put(out, Strings("LEVEL UP"), 10, 12)
   put(out, num(self:expToNext(), 7), 13, 13)
-  put(out, "TO", 14, 14)
+  put(out, Strings("TO"), 14, 14)
   -- The level printed at (17,14) is the NEXT one: LoadPinkPage bumps
   -- wTempMonLevel, calls PrintLevel, and puts it back.  MAX_LEVEL stays put.
   local level = mon.level or 1
@@ -541,9 +544,9 @@ end
 
 function SummaryMenu:greenPlacements()
   local out = {}
-  put(out, "ITEM", 0, 8)
+  put(out, Strings("ITEM"), 0, 8)
   put(out, self:itemName() or "---", 6, 8)
-  put(out, "MOVE", 0, 10)
+  put(out, Strings("MOVE"), 0, 10)
 
   -- ListMoves runs from (8,10) with wListMovesLineSpacing = SCREEN_WIDTH * 2,
   -- so the four names are two rows apart; ListMovePP runs from (12,11) with
@@ -558,7 +561,7 @@ function SummaryMenu:greenPlacements()
       put(out, self:moveName(entry), 8, nameY)
       -- Two $3e "P" tiles: `ld [hli], a` then `ld [hld], a` writes the same
       -- tile at (12,y) and (13,y).
-      put(out, "PP", 12, ppY)
+      put(out, Strings("PP"), 12, ppY)
       -- `pop hl` then three `inc hl` lands the numbers at (15,y): two digits,
       -- the '/' PrintNum's caller writes, then two more.
       put(out, num(entry.pp, 2), 15, ppY)
@@ -579,9 +582,9 @@ function SummaryMenu:bluePlacements()
   local out = {}
   -- IDNoString is "<ID>№." -- three single tiles, not the seven letters of
   -- "ID No." -- and OTString is "OT/".
-  put(out, "<ID>№.", 0, 9)
+  put(out, Strings("<ID>№."), 0, 9)
   put(out, num(self:otId(), 5, true), 2, 10)
-  put(out, "OT/", 0, 12)
+  put(out, Strings("OT/"), 0, 12)
   local ot = self:otName()
   put(out, ot, SummaryMenu.otColumn(ot), 13)
 
@@ -589,7 +592,7 @@ function SummaryMenu:bluePlacements()
   -- two rows apart, then `add hl, bc` and one more SCREEN_WIDTH puts the first
   -- value at (17,9) -- three columns wide, so every value ends at column 19.
   for i, label in ipairs(STAT_LABELS) do
-    put(out, label, 11, 8 + (i - 1) * 2)
+    put(out, Strings(label), 11, 8 + (i - 1) * 2)
     local value = (mon.stats or {})[STAT_KEYS[i]]
     put(out, num(value, 3), 17, 9 + (i - 1) * 2)
   end
@@ -620,7 +623,7 @@ function SummaryMenu:moveDetailPlacements()
     local entry = moves[slot]
     if entry then
       put(out, self:moveName(entry), 2, nameY)
-      put(out, "PP", 10, ppY)
+      put(out, Strings("PP"), 10, ppY)
       put(out, num(entry.pp, 2), 13, ppY)
       put(out, "/", 15, ppY)
       put(out, num(entry.maxPp or entry.pp, 2), 16, ppY)
@@ -636,15 +639,15 @@ function SummaryMenu:moveDetailPlacements()
     put(out, "┌─────┐", 0, 10)
     put(out, "│", 0, 11)
     put(out, "└", 6, 11)
-    put(out, "Where?", 1, 12)
+    put(out, Strings("Where?"), 1, 12)
     return out
   end
 
   -- String_MoveType_Top / _Bottom are box-drawing glyphs, and the plaque is
   -- open on its right: "┌─────┐" over "│TYPE/└".
   put(out, "┌─────┐", 0, 10)
-  put(out, "│TYPE/└", 0, 11)
-  put(out, "ATTK/", 11, 12)
+  put(out, Strings("│TYPE/└"), 0, 11)
+  put(out, Strings("ATTK/"), 11, 12)
 
   local entry = moves[self.moveIndex]
   local def = entry and self:moveDef(entry.id)
@@ -683,15 +686,15 @@ end
 function SummaryMenu:eggPlacements()
   local mon = self.mon or {}
   local out = {}
-  put(out, "EGG", 8, 1)
+  put(out, Strings("EGG"), 8, 1)
   -- IDNoString / OTString, the same strings the blue page prints, with
   -- FiveQMarkString beside each: an egg's OT and ID are hidden.
-  put(out, "<ID>№.", 8, 3)
+  put(out, Strings("<ID>№."), 8, 3)
   put(out, "?????", 11, 3)
-  put(out, "OT/", 8, 5)
+  put(out, Strings("OT/"), 8, 5)
   put(out, "?????", 11, 5)
   local ty = 9
-  for line in ((eggFlavor(mon.eggSteps or 0) or "") .. "<NEXT>")
+  for line in ((Strings(eggFlavor(mon.eggSteps or 0) or "") or "") .. "<NEXT>")
       :gmatch("(.-)<NEXT>") do
     if line ~= "" then put(out, line, 1, ty) end
     ty = ty + 2

--- a/src/ui/gen2/TradeAnim.lua
+++ b/src/ui/gen2/TradeAnim.lua
@@ -361,8 +361,10 @@ function TradeAnimView:lines(id)
     if not fallback then return nil end
     body, buffers = fallback.text, fallback.buffers
   end
+  -- Same reason as TradeMenu:lineFor: the animation's captions are cache
+  -- DATA, so the catalog is the only seam a mod has on them.
   local pages = TradeMenu.paginate(
-    TradeAnimView.fill(body, self:buffers(), buffers))
+    TradeAnimView.fill(Strings(body), self:buffers(), buffers))
   return pages[1]
 end
 

--- a/src/ui/gen2/TradeMenu.lua
+++ b/src/ui/gen2/TradeMenu.lua
@@ -152,7 +152,12 @@ function TradeMenu:lineFor(dialog)
   local texts = self.eventTables.tradeTexts
   local row = texts and texts[dialog]
   local set = self.row and self.row.dialog
-  local body = (row and set and row[set]) or FALLBACK[dialog] or ""
+  -- The cache wins over FALLBACK, but neither reaches the player untranslated:
+  -- these lines live in events.tradeTexts, which is DATA out of the cart, so a
+  -- mod has no registry to override them through.  Passing the resolved body
+  -- through the catalog gives it one -- an untranslated build gets the source
+  -- string straight back.
+  local body = Strings((row and set and row[set]) or FALLBACK[dialog] or "")
   local bufRow = (self.eventTables.tradeBuffers or {})[dialog]
   local buffers = bufRow and set and bufRow[set]
   return TradeMenu.paginate(
@@ -238,15 +243,15 @@ function TradeMenu:chose(index)
   -- NPCTradeCableText is a bare PrintText (engine/events/npc_trade.asm:37-41):
   -- nothing rings under the cable line.  The sounds all belong to the
   -- animation past it (SFX_GIVE_TRADEMON / SFX_GET_TRADEMON).
-  self:sayRaw(texts.NPCTradeCableText
-      or Strings.source("OK, connect the\nGame Link Cable."),
+  self:sayRaw(Strings(texts.NPCTradeCableText
+      or Strings.source("OK, connect the\nGame Link Cable.")),
     bufs.NPCTradeCableText,
     function()
       local given, received =
         NpcTrade.perform(self.data, self.save, self.row, index)
       self:playAnim(given, received, function()
-        self:sayRaw(texts.TradedForText
-            or Strings.source("{PLAYER} traded\n{STRBUF} for\v{STRBUF}."),
+        self:sayRaw(Strings(texts.TradedForText
+            or Strings.source("{PLAYER} traded\n{STRBUF} for\v{STRBUF}.")),
           bufs.TradedForText,
           function() self:refuse(NpcTrade.DIALOG_COMPLETE) end)
       end)
@@ -330,8 +335,8 @@ end
 
 function TradeMenu:drawYesNo(choice)
   Chrome.box(YESNO_X, YESNO_Y, YESNO_W, YESNO_H)
-  Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-  Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+  Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+  Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
   Chrome.cursor(YESNO_X + 1, YESNO_Y + (choice == 1 and 1 or 3))
 end
 
@@ -339,14 +344,14 @@ function TradeMenu:draw()
   if self.message then
     self:drawTextBox(self.message.pages[self.message.page])
     if self.message.page < #self.message.pages then
-      Chrome.print("\xe2\x96\xbc", ARROW_X, ARROW_Y)
+      Chrome.print(Strings("\xe2\x96\xbc"), ARROW_X, ARROW_Y)
     end
   elseif self.confirm then
     self:drawTextBox(self.confirm.pages[self.confirm.page])
     if self.confirm.page >= #self.confirm.pages then
       self:drawYesNo(self.confirm.choice)
     else
-      Chrome.print("\xe2\x96\xbc", ARROW_X, ARROW_Y)
+      Chrome.print(Strings("\xe2\x96\xbc"), ARROW_X, ARROW_Y)
     end
   else
     self:drawTextBox(nil)

--- a/src/ui/gen2/TrainerCard.lua
+++ b/src/ui/gen2/TrainerCard.lua
@@ -41,6 +41,7 @@ local Chrome = require("src.ui.gen2.Chrome")
 local GbcPalette = require("src.render.GbcPalette")
 local Gen2Save = require("src.core.gen2.Save")
 local TileSheet = require("src.ui.gen2.TileSheet")
+local Strings = require("src.core.Strings")
 
 local TrainerCard = {}
 TrainerCard.__index = TrainerCard
@@ -282,12 +283,12 @@ end
 function TrainerCard:drawTopHalf()
   local player = (self.save or {}).player or {}
   self:frame(0, 5)
-  self:print("NAME/", 2, 2)
+  self:print(Strings("NAME/"), 2, 2)
   self:print(player.name or "GOLD", 7, 2)
   self:tile(self.card, TILE_ID_NO[1], 2, 4)
   self:tile(self.card, TILE_ID_NO[2], 3, 4)
   self:print(Chrome.number(player.id or 0, 5, true), 5, 4)
-  self:print("MONEY", 2, 6)
+  self:print(Strings("MONEY"), 2, 6)
   self:print(moneyText(player.money), 7, 6)
   for x = 1, 12 do self:tile(self.card, TILE_DIVIDER, x, 3) end
   self:tile(self.card, TILE_DIVIDER_END, 13, 3)
@@ -306,8 +307,8 @@ function TrainerCard:drawCard()
 
   -- `#` is the compression byte for POKé, four tiles, so spelling it out is
   -- what the cart actually draws.
-  self:print("POKéDEX", 2, 10)
-  self:print("PLAY TIME", 2, 12)
+  self:print(Strings("POKéDEX"), 2, 10)
+  self:print(Strings("PLAY TIME"), 2, 12)
   self:print(Chrome.number(self:caughtCount(), 3), 15, 10)
 
   local time = save.playTime or {}
@@ -320,7 +321,7 @@ function TrainerCard:drawCard()
   end
   self:print(Chrome.number(time.minutes or 0, 2, true), 16, 12)
 
-  self:print("BADGES", 12, 15)
+  self:print(Strings("BADGES"), 12, 15)
   self:cursor(18, 15)
 end
 
@@ -405,21 +406,21 @@ function TrainerCard:drawPlain()
   Chrome.clear()
   if self.page == 1 then
     Chrome.box(0, 0, 20, 9)
-    Chrome.printThrough("NAME/", 2, 2, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings("NAME/"), 2, 2, Chrome.DEFAULT_BOX_PALETTE)
     Chrome.printThrough(player.name or "GOLD", 7, 2, Chrome.DEFAULT_BOX_PALETTE)
-    Chrome.printThrough("ID No", 2, 4, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings("ID No"), 2, 4, Chrome.DEFAULT_BOX_PALETTE)
     Chrome.printThrough(Chrome.number(player.id or 0, 5, true), 5, 4, Chrome.DEFAULT_BOX_PALETTE)
-    Chrome.printThrough("MONEY", 2, 6, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings("MONEY"), 2, 6, Chrome.DEFAULT_BOX_PALETTE)
     Chrome.printThrough(moneyText(player.money), 7, 6, Chrome.DEFAULT_BOX_PALETTE)
     Chrome.box(0, 8, 20, 10)
-    Chrome.printThrough("POKéDEX", 2, 10, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings("POKéDEX"), 2, 10, Chrome.DEFAULT_BOX_PALETTE)
     Chrome.printThrough(Chrome.number(self:caughtCount(), 3), 15, 10, Chrome.DEFAULT_BOX_PALETTE)
-    Chrome.printThrough("PLAY TIME", 2, 12, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings("PLAY TIME"), 2, 12, Chrome.DEFAULT_BOX_PALETTE)
     local time = save.playTime or {}
     Chrome.printThrough(Chrome.number(time.hours or 0, 4), 11, 12, Chrome.DEFAULT_BOX_PALETTE)
     Chrome.printThrough(":", 15, 12, Chrome.DEFAULT_BOX_PALETTE)
     Chrome.printThrough(Chrome.number(time.minutes or 0, 2, true), 16, 12, Chrome.DEFAULT_BOX_PALETTE)
-    Chrome.printThrough("BADGES", 12, 15, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings("BADGES"), 12, 15, Chrome.DEFAULT_BOX_PALETTE)
     Chrome.cursorThrough(18, 15, Chrome.DEFAULT_BOX_PALETTE)
     return
   end

--- a/tests/engine/gate_gen2_mod_api.lua
+++ b/tests/engine/gate_gen2_mod_api.lua
@@ -171,12 +171,16 @@ end
 --   apricorns       src/core/gen2/Apricorns.lua:useRegistry
 --   landmarks       src/core/gen2/Nests.lua:landmarkId / landmark
 --   radio_channels  src/ui/gen2/MapRadio.lua:channelRecord
+--   pokedex         src/ui/gen2/PokedexMenu.lua:drawEntry / drawList,
+--                   which read self.dex.entries[species] straight off
+--                   data.gen2Pokedex
 for name, path in pairs({ held_items = "gen2HeldItems",
                           phone_contacts = "gen2PhoneContacts",
                           decorations = "gen2Decorations",
                           apricorns = "gen2Apricorns",
                           landmarks = "gen2Landmarks.landmarks",
-                          radio_channels = "gen2RadioChannels" }) do
+                          radio_channels = "gen2RadioChannels",
+                          pokedex = "gen2Pokedex.entries" }) do
   local spec = Schemas.REGISTRIES[name]
   T.check(spec ~= nil, "catalog still has registry: " .. name)
   T.eq(Schemas.targetFor(name, spec, 2), path,

--- a/tests/engine/gen2_content_registries.lua
+++ b/tests/engine/gen2_content_registries.lua
@@ -1,5 +1,6 @@
--- The six Gen 2-only content registries, end to end: held_items,
--- phone_contacts, decorations, apricorns, landmarks and radio_channels.
+-- The seven Gen 2-only content registries, end to end: held_items,
+-- phone_contacts, decorations, apricorns, landmarks, radio_channels and
+-- pokedex.
 --
 -- Three claims, and the third is the one that makes the other two worth
 -- anything:
@@ -35,7 +36,7 @@ local Nests = require("src.core.gen2.Nests")
 local MapRadio = require("src.ui.gen2.MapRadio")
 
 local NAMES = { "held_items", "phone_contacts", "decorations", "apricorns",
-                "landmarks", "radio_channels" }
+                "landmarks", "radio_channels", "pokedex" }
 
 local PATHS = {
   held_items = "gen2HeldItems",
@@ -44,6 +45,7 @@ local PATHS = {
   apricorns = "gen2Apricorns",
   landmarks = "gen2Landmarks.landmarks",
   radio_channels = "gen2RadioChannels",
+  pokedex = "gen2Pokedex.entries",
 }
 
 -- ------- 1. the mirror of Schemas.GEN2
@@ -132,6 +134,15 @@ local function goldData()
   -- src/core/Game2.lua:load builds this before mods:load; the harness
   -- stands in for that boot step
   data.gen2HeldItems = ItemEffects.heldItemsFrom(data.items)
+  -- the #DEX cache, in the shape data/generated/pokedex.lua has:
+  -- `entries` keyed by species, which is where the route merges
+  data.gen2Pokedex = {
+    entries = {
+      FIX_MON = { id = "FIX_MON", dex = 1, kind = "FIXTURE",
+                  text = "A test mon.", text2 = "Nothing more.",
+                  height = 10, weight = 100 },
+    },
+  }
   return data
 end
 
@@ -214,6 +225,8 @@ do
     "and a mod-free merge writes nothing back onto data.items")
   T.eq(run.data.gen2Landmarks.landmarks.LANDMARK_FIX_TOWN.x, 4,
     "the landmark records are the cache's own")
+  T.eq(run.data.gen2Pokedex.entries.FIX_MON.kind, "FIXTURE",
+    "and the #DEX entries are too")
 
   run.release()
 end
@@ -239,6 +252,8 @@ do
       mod.content.radio_channels:register("PIRATE_RADIO",
         { channel = 9, name = "PIRATE RADIO" })
       mod.content.held_items:patch("FIX_LEFTOVERS", { heldParameter = 7 })
+      mod.content.pokedex:patch("FIX_MON",
+        { kind = "SAMPLE", text = "A patched mon." })
     ]]),
     data = data,
     generation = 2,
@@ -263,6 +278,15 @@ do
     "phone_contacts: the merged row reaches the contact table")
   T.eq(Phone.CONTACTS[15].class, "YOUNGSTER",
     "and the untouched fields survive the patch")
+
+  -- pokedex: PokedexMenu reads self.dex.entries[species] straight off
+  -- data.gen2Pokedex, so the merged row IS what the #DEX page prints
+  T.eq(run.data.gen2Pokedex.entries.FIX_MON.kind, "SAMPLE",
+    "pokedex: the merged row is what the #DEX page reads")
+  T.eq(run.data.gen2Pokedex.entries.FIX_MON.text2, "Nothing more.",
+    "and a field the patch left alone keeps the cart's own text")
+  T.eq(run.data.gen2Pokedex.entries.FIX_MON.dex, 1,
+    "as do the measurements the patch never mentions")
   -- the cache overlay runs from src/world/gen2/World.lua AFTER this, and must
   -- not undo it
   Phone.useExtracted({ phone = { [15] = { map = "ROUTE_30",

--- a/tests/mod_manager_detail_layout_test.lua
+++ b/tests/mod_manager_detail_layout_test.lua
@@ -1,0 +1,70 @@
+-- ManagerState.detailLayout: the action rows never land on the footer line.
+--
+-- The bug this pins: a mod that declares options has five detail rows
+-- (DISABLE, OPTIONS.., FOR .., GH .., BACK).  Laid out downward from a fixed
+-- row 11 the fifth one landed on row 15, where drawFooter writes
+-- "A:CHOOSE B:BACK", and the two strings drew on top of each other.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+if not _G.love then _G.love = require("tests.love_stub") end
+
+local S = require("tests.harness").suite("mod manager detail layout")
+local eq = S.eq
+local check = S.check
+
+local ManagerState = require("src.mods.ManagerState")
+
+local DESC_ROW, FOOTER_ROW = 6, 15
+
+-- The rows actually drawn, as tile-y values, for a given row count.
+local function rowsAt(count, cursor)
+  local at = ManagerState.detailLayout(count, cursor)
+  local ys, y = {}, at.top
+  for _ = at.first, math.min(at.first + at.fits - 1, count) do
+    ys[#ys + 1] = y
+    y = y + 1
+  end
+  return ys, at
+end
+
+-- Four rows is the pre-existing shape (no options declared); it must keep
+-- drawing exactly where it always did, or this "fix" is a regression.
+local ys, at = rowsAt(4, 1)
+eq(at.top, 11, "four rows still start on row 11")
+eq(at.visible, 5, "four rows still leave five description lines")
+eq(#ys, 4, "four rows all drawn")
+eq(ys[#ys], 14, "last of four sits just above the footer")
+
+-- Five rows is the reported bug.
+ys, at = rowsAt(5, 1)
+eq(#ys, 5, "five rows all drawn")
+eq(ys[#ys], 14, "fifth row stops above the footer instead of on it")
+eq(at.visible, 4, "the description gives up one line to make room")
+
+-- The invariant, over every count a detailRows call can produce.
+for count = 1, 12 do
+  for cursor = 1, count do
+    local seen, layout = rowsAt(count, cursor)
+    for _, y in ipairs(seen) do
+      check(y < FOOTER_ROW,
+        ("row of %d (cursor %d) drew on the footer line"):format(count, cursor))
+      check(y > DESC_ROW,
+        ("row of %d (cursor %d) drew over the description"):format(count, cursor))
+    end
+    check(layout.visible >= 1,
+      ("count %d left no description line at all"):format(count))
+    -- a row block that cannot hold everything must still hold the cursor,
+    -- otherwise the player moves onto a row they cannot see
+    check(cursor >= layout.first and cursor < layout.first + layout.fits,
+      ("cursor %d of %d scrolled out of view"):format(cursor, count))
+  end
+end
+
+-- The description keeps its own top line wherever the block ends up.
+for count = 1, 12 do
+  local layout = ManagerState.detailLayout(count, 1)
+  eq(DESC_ROW + layout.visible, layout.top,
+    ("count %d leaves a gap or an overlap between description and rows")
+      :format(count))
+end
+
+S.finish()


### PR DESCRIPTION
### Summary
This PR brings the Gen 2 port (Gold, Silver, Crystal) to feature parity with Gen 1 regarding internationalization (i18n) and mod string overrides (mod.content.strings).

### Key Changes
1. **Engine & UI Strings Routing (Strings(...))**:
   - Routes Gen 2 menus (Start Menu, Save Menu, Box Menu, PC menus, Mart, Prize, DayCare, Pokegear, Summary, Pokedex, Naming, Options) through Strings(...).
   - Routes Gen 2 battle messages (intro, sendouts, move effects, faints, recoil, status, EXP gained, level up, moves learned, health recovery, flee/defeat) through Strings(...).
   - Routes Pokégear phone contacts and system prompts through Strings(...).
   - Routes Pokedex screen measurements and category text into the registry.

2. **100% Fallback & Compatibility**:
   - **Without a translation mod**: When no translation mod is installed (or when an entry is not overridden in Data.strings), the game falls back to the exact original English source strings. No behavior, layout, or string is altered.
   - **With a translation mod**: Translation mods targeting Gold, Silver, or Crystal can seamlessly register their strings catalog to translate the entire experience into Portuguese (or any other language).
   - **Gen 1 (Red/Blue/Yellow)**: Zero changes or regressions to Gen 1 runtime.

3. **Mod Options & UI Polish**:
   - Enables mod option persistence (Runtime.persistModOption) on Gen 2.
   - Adjusts Save Menu and 2x2 Battle Menu box boundaries to accommodate full translated words while maintaining proportional alignment.

### Verification
- Tested on official 0.2.32 engine base across Gold, Silver, and Crystal on both PC (Windows/Linux) and Android.
- Verified that running without mods keeps all menus, battles, and UI in 100% vanilla English.
- Verified that enabling translation mods translates the complete UI and dialog without text overlaps.