### PR TITLE
Add additive TILT billboard masking API

### DIFF
--- a/docs/mod-api-gen2-compat.md
+++ b/docs/mod-api-gen2-compat.md
@@ -328,6 +328,13 @@ you write against it:
   (`Pipelines.rows` is read only from `src/ui/OptionsMenu.lua`), so a Gold
   player reaches one by its `hotkey`.
 
+  The additive **`drawBillboards` stage is live on Gold, Silver, and Crystal**
+  when the built-in TILT mode is active. It receives the same semantic
+  collision-map view as Gen 1 plus `drawMapCutout`, `maskMapCutout`, and
+  `billboard` helpers. Source silhouettes are masked from the tilted ground
+  before queued cards join the normal upright-object Y-sort, preventing the
+  flat and upright copies from being drawn together.
+
 **Content registries at a Gen 2 path.** `maps`, `tilesets`, `sprites`, `text`,
 `encounters`, `trainers`, `palettes`, `icons`, `battle_anims`, `constants`,
 `statuses`, `move_effects`, `item_effects`, `balls`, `ai_classes` and

--- a/docs/modding.md
+++ b/docs/modding.md
@@ -591,11 +591,12 @@ mod.content.render_pipelines:register("diorama", {
 })
 ```
 
-Three draw stages, each optional; a record needs at least one:
+Four draw stages, each optional; a record needs at least one:
 
 | stage | signature | runs |
 | --- | --- | --- |
 | `drawWorld` | `(ctx) -> canvas \| nil` | instead of the flat/tilt world pass |
+| `drawBillboards` | `(ctx)` | between the ground and upright-object passes of built-in TILT |
 | `worldPresent` | `(canvas, ctx) -> canvas` | over the world, **before** the UI composites |
 | `present` | `(canvas, ctx) -> canvas` | over the whole frame, world and UI alike |
 
@@ -605,7 +606,26 @@ boxes and menus crisp — a depth-of-field or colour grade on the world only.
 
 `ctx` carries the frame: `state`, `cam`, `vw`/`vh` (world-pixel view),
 `width`/`height` (window pixels), `scale`, `level`, `paletteFor(map)` and
-`spriteColors(map)`. It also carries `ctx.drawFx(project, scale)` — call it
+`spriteColors(map)`.
+
+During `drawBillboards`, `ctx.map` is a read-only semantic map view with
+`id`, `width`, `height`, `cellSize`, `outdoor`, and `cell(x, y)`. A cell
+reports `inside`, `walkable`, `water`, `grass`, `warp`, and `solid`, allowing
+mods to classify map geometry without depending on ROM-specific tile IDs.
+`ctx.mapScale` converts map pixels to world pixels.
+
+Use `ctx.drawMapCutout(x, y, width, height, offsetX, offsetY, seed)` to cache
+an alpha card from the map, then call
+`ctx.maskMapCutout(x, y, width, height, seed)` while the TILT ground canvas is
+active. The mask call removes that same silhouette from the ground pass and
+returns `false` when the region cannot safely be masked; in that case, do not
+queue the card. Otherwise, queue it with
+`ctx.billboard(worldX, worldY, drawFn)`. The rectangle's bottom centre should
+correspond to that billboard anchor. Queued cards join the engine's existing
+upright-object Y-sort, so actors and map objects occlude one another normally.
+This stage is available in Gen 1 and in Gold, Silver, and Crystal.
+
+The general pipeline context also carries `ctx.drawFx(project, scale)` — call it
 with your own projection and the engine draws every active field effect
 (the "!" bubble, the Poké Center heal machine, the Fly bird, the fishing
 rod, Rock Tunnel darkness) at its correct anchor under your camera. There

--- a/docs/modding/reference/registries.md
+++ b/docs/modding/reference/registries.md
@@ -916,6 +916,7 @@ mod.content.radio_channels:register("PIRATE_RADIO", { channel = 9, name = "PIRAT
 | field | type | required |
 |---|---|---|
 | `available` | function | no |
+| `drawBillboards` | function | no |
 | `drawWorld` | function | no |
 | `gate` | function | no |
 | `hotkey` | string | no |

--- a/src/mods/Schemas.lua
+++ b/src/mods/Schemas.lua
@@ -1536,14 +1536,15 @@ R.transitions = {
 -- ------- rendering pipelines
 --
 -- A pipeline is a display mode that owns part of the frame: it may replace
--- the overworld's world pass with geometry of its own (drawWorld) and/or
--- post-process the finished composite (present).  Everything around that --
+-- the overworld's world pass with geometry of its own (drawWorld), add
+-- upright objects to TILT (drawBillboards), and/or post-process the finished
+-- composite (present).  Everything around that --
 -- the OFF/1/2/3 ladder, its options row, its hotkey, persistence in
 -- save.options.pipelines and the gating that keeps it out of battles and
 -- menus -- is engine plumbing driven from this record, so a renderer mod
--- declares what it is and writes only the two draw functions.
+-- declares what it is and supplies only the stages it owns.
 --
--- Both callbacks are optional and independent: a present-only pipeline is a
+-- All callbacks are optional and independent: a present-only pipeline is a
 -- post-process (bloom, tilt-shift, a CRT curve) that leaves whatever
 -- rendered the frame alone, and a drawWorld-only pipeline is a world
 -- renderer that composites straight.  See src/render/Pipelines.lua for the
@@ -1577,6 +1578,10 @@ R.render_pipelines = {
     -- (ctx) -> canvas | nil: render the world.  nil falls back to the
     -- vanilla flat/tilt draw for this frame.
     drawWorld = f.opt(f.fn),
+    -- (ctx) -> nil: add upright objects to the vanilla TILT pass. The
+    -- callback queues through ctx.billboard and may remove source pixels
+    -- from the active ground canvas through ctx.maskMapCutout.
+    drawBillboards = f.opt(f.fn),
     -- (canvas, ctx) -> canvas: post-process the WORLD image, before the UI
     -- composites over it -- a depth-of-field or colour grade that must not
     -- touch the dialog boxes and menus sitting on top.  Only runs when some
@@ -1594,9 +1599,11 @@ R.render_pipelines = {
   -- a pipeline that does neither half is dead weight and would silently
   -- occupy an options row and a hotkey
   extra = function(_, value)
-    if value.drawWorld == nil and value.present == nil
+    if value.drawWorld == nil and value.drawBillboards == nil
+        and value.present == nil
         and value.worldPresent == nil then
-      return "a render pipeline needs drawWorld, worldPresent or present"
+      return "a render pipeline needs drawWorld, drawBillboards, "
+        .. "worldPresent or present"
     end
   end,
   -- A pipeline callback fails at play time, long after the load phase has

--- a/src/render/BillboardCutout.lua
+++ b/src/render/BillboardCutout.lua
@@ -1,0 +1,134 @@
+-- Turns an opaque map crop into one sprite-like card. Ground is identified as
+-- the light half of the crop's palette and flooded in from the border. Of the
+-- remaining outlined islands, the component overlapping the collision seed is
+-- the structure represented by the billboard.
+
+local BillboardCutout = {}
+
+local function luma(r, g, b)
+  return r * 0.2126 + g * 0.7152 + b * 0.0722
+end
+
+local function componentMask(data, seed)
+  if not (data and type(data.getDimensions) == "function"
+      and type(data.getPixel) == "function"
+      and type(data.setPixel) == "function") then
+    return nil
+  end
+
+  local w, h = data:getDimensions()
+  if not (w and h and w > 0 and h > 0) then return nil end
+
+  local pixels, minL, maxL = {}, math.huge, -math.huge
+  for y = 0, h - 1 do
+    for x = 0, w - 1 do
+      local r, g, b, a = data:getPixel(x, y)
+      local i = y * w + x + 1
+      local value = luma(r, g, b)
+      pixels[i] = { r, g, b, a, value }
+      if a > 0 then
+        if value < minL then minL = value end
+        if value > maxL then maxL = value end
+      end
+    end
+  end
+  if minL == math.huge then return nil end
+
+  local light = minL + (maxL - minL) * 0.5
+  local outside, queue, head = {}, {}, 1
+  local function markOutside(x, y)
+    if x < 0 or y < 0 or x >= w or y >= h then return end
+    local i = y * w + x + 1
+    local p = pixels[i]
+    if outside[i] or p[4] <= 0 or p[5] < light then return end
+    outside[i] = true
+    queue[#queue + 1] = i
+  end
+
+  for x = 0, w - 1 do markOutside(x, 0); markOutside(x, h - 1) end
+  for y = 0, h - 1 do markOutside(0, y); markOutside(w - 1, y) end
+  while head <= #queue do
+    local i = queue[head]
+    head = head + 1
+    local z = i - 1
+    local x, y = z % w, math.floor(z / w)
+    markOutside(x - 1, y); markOutside(x + 1, y)
+    markOutside(x, y - 1); markOutside(x, y + 1)
+  end
+
+  local seedX = type(seed) == "table" and tonumber(seed.x) or nil
+  local seedY = type(seed) == "table" and tonumber(seed.y) or nil
+  local seedW = type(seed) == "table" and tonumber(seed.width) or nil
+  local seedH = type(seed) == "table" and tonumber(seed.height) or nil
+  local hasSeed = seedX and seedY and seedW and seedH
+    and seedW > 0 and seedH > 0
+  local function inSeed(x, y)
+    return hasSeed and x >= seedX and y >= seedY
+      and x < seedX + seedW and y < seedY + seedH
+  end
+
+  local seen, best, bestSize, bestOverlap = {}, nil, 0, -1
+  local function candidate(i)
+    return pixels[i][4] > 0 and not outside[i]
+  end
+  for start = 1, w * h do
+    if candidate(start) and not seen[start] then
+      local component, pending, nextIndex = {}, { start }, 1
+      seen[start] = true
+      local overlap = 0
+      while nextIndex <= #pending do
+        local i = pending[nextIndex]
+        nextIndex = nextIndex + 1
+        component[#component + 1] = i
+        local z = i - 1
+        local x, y = z % w, math.floor(z / w)
+        if inSeed(x, y) then overlap = overlap + 1 end
+        local function visit(nx, ny)
+          if nx < 0 or ny < 0 or nx >= w or ny >= h then return end
+          local ni = ny * w + nx + 1
+          if candidate(ni) and not seen[ni] then
+            seen[ni] = true
+            pending[#pending + 1] = ni
+          end
+        end
+        visit(x - 1, y); visit(x + 1, y)
+        visit(x, y - 1); visit(x, y + 1)
+      end
+      if overlap > bestOverlap
+          or (overlap == bestOverlap and #component > bestSize) then
+        best, bestSize, bestOverlap = component, #component, overlap
+      end
+    end
+  end
+
+  local keep = {}
+  for _, i in ipairs(best or {}) do keep[i] = true end
+  return pixels, keep, bestSize, w, h
+end
+
+function BillboardCutout.mask(data, seed)
+  local pixels, keep, bestSize, w, h = componentMask(data, seed)
+  if not pixels then return false end
+  for i, p in ipairs(pixels) do
+    local z = i - 1
+    local x, y = z % w, math.floor(z / w)
+    data:setPixel(x, y, p[1], p[2], p[3], keep[i] and p[4] or 0)
+  end
+  return bestSize > 0
+end
+
+-- Preserve the captured map source while erasing only the selected structure.
+-- Drawing this data with LOVE's replace blend mode clears those pixels from
+-- the ground canvas while leaving nearby structures and terrain unchanged.
+function BillboardCutout.erase(data, seed)
+  local pixels, keep, bestSize, w, h = componentMask(data, seed)
+  if not pixels then return false end
+  for i, p in ipairs(pixels) do
+    local z = i - 1
+    local x, y = z % w, math.floor(z / w)
+    data:setPixel(x, y, p[1], p[2], p[3], keep[i] and 0 or p[4])
+  end
+  return bestSize > 0
+end
+
+return BillboardCutout

--- a/src/render/OverworldBillboards.lua
+++ b/src/render/OverworldBillboards.lua
@@ -1,0 +1,64 @@
+-- Shared public data shape used by the additive TILT billboard stage. The
+-- generation-specific world renderers build this view from their Map objects
+-- so mods read one semantic collision vocabulary on every supported game.
+
+local OverworldBillboards = {}
+
+function OverworldBillboards.gen1GroundScreenPoint(wx, wy, camX, camY)
+  return wx - math.floor(tonumber(camX) or 0),
+         wy - math.floor(tonumber(camY) or 0)
+end
+
+function OverworldBillboards.gen2GroundScreenPoint(wx, wy, camX, camY, scale)
+  scale = tonumber(scale) or 1
+  return wx * scale + math.floor(-(tonumber(camX) or 0) * scale),
+         wy * scale + math.floor(-(tonumber(camY) or 0) * scale)
+end
+
+function OverworldBillboards.drawLocal(graphics, x, y, draw)
+  graphics.push()
+  graphics.translate(x, y)
+  local ok, err = xpcall(draw, debug.traceback)
+  graphics.pop()
+  if not ok then error(err, 0) end
+end
+
+local function predicate(map, name, x, y)
+  local fn = map and map[name]
+  return type(fn) == "function" and fn(map, x, y) == true
+end
+
+function OverworldBillboards.mapView(map, outdoor)
+  assert(type(map) == "table", "billboard map is required")
+  local view = {
+    id = map.id,
+    width = map.widthCells or (map.width and map.width * 2) or 0,
+    height = map.heightCells or (map.height and map.height * 2) or 0,
+    cellSize = 16,
+    outdoor = outdoor == true,
+  }
+
+  function view.cell(x, y)
+    local inside = type(map.inBounds) == "function"
+      and map:inBounds(x, y)
+      or (x >= 0 and y >= 0 and x < view.width and y < view.height)
+    if not inside then
+      return { inside = false, walkable = false, water = false,
+               grass = false, warp = false, solid = false }
+    end
+    local walkable = predicate(map, "isWalkableCell", x, y)
+    local water = predicate(map, "isWaterCell", x, y)
+    return {
+      inside = true,
+      walkable = walkable,
+      water = water,
+      grass = predicate(map, "isGrassCell", x, y),
+      warp = predicate(map, "isWarpTileCell", x, y),
+      solid = not walkable and not water,
+    }
+  end
+
+  return view
+end
+
+return OverworldBillboards

--- a/src/render/Pipelines.lua
+++ b/src/render/Pipelines.lua
@@ -1,12 +1,13 @@
 -- Rendering pipelines: the engine side of the render_pipelines registry.
 --
 -- A pipeline is a display mode a mod owns.  It may replace the overworld's
--- world pass with geometry of its own (drawWorld) and/or post-process the
--- finished composite (present).  Everything else about being a display mode
+-- world pass with geometry of its own (drawWorld), add upright objects to
+-- TILT (drawBillboards), and/or post-process the finished composite (present).
+-- Everything else about being a display mode
 -- -- the OFF/1/2/3 ladder, the options row, the hotkey, persistence, the
 -- free-roam gate, and never letting a mod's error take the frame down -- is
--- engine plumbing and lives here, so a renderer mod writes the two draw
--- functions and declares the rest.
+-- engine plumbing and lives here, so a renderer mod supplies only the stages
+-- it owns and declares the rest.
 --
 -- The two halves compose independently and in priority order: the highest
 -- priority eligible drawWorld renders the world, then every eligible
@@ -316,6 +317,31 @@ function Pipelines.drawWorld(id, ctx)
   local def = Pipelines.get(id)
   if not (def and def.drawWorld) then return nil end
   return guardRender(id, def.drawWorld, ctx)
+end
+
+-- Additive upright objects for the engine's own TILT pass. Unlike drawWorld,
+-- this stage does not claim the ground or return a Canvas: every eligible
+-- callback queues billboards on ctx and may mask their source on the active
+-- ground canvas, while the world renderer drains that queue into its existing
+-- upright pass.
+function Pipelines.drawBillboards(ctx)
+  for _, entry in ipairs(Pipelines.list()) do
+    if entry.def.drawBillboards and Pipelines.eligible(entry.id) then
+      local previousLevel = ctx.level
+      ctx.level = Pipelines.level(entry.id)
+      guardRender(entry.id, entry.def.drawBillboards, ctx)
+      ctx.level = previousLevel
+    end
+  end
+end
+
+function Pipelines.wantsBillboards()
+  for _, entry in ipairs(Pipelines.list()) do
+    if entry.def.drawBillboards and Pipelines.eligible(entry.id) then
+      return true
+    end
+  end
+  return false
 end
 
 -- Fold every eligible world post-process over a pipeline's world image,

--- a/src/render/TileRenderer.lua
+++ b/src/render/TileRenderer.lua
@@ -3,7 +3,9 @@
 -- (the ring plays the role of the GB border blocks around small maps).
 
 local Assets = require("src.render.Assets")
+local BillboardCutout = require("src.render.BillboardCutout")
 local PaletteFX = require("src.render.PaletteFX")
+local PixelCanvas = require("src.render.PixelCanvas")
 
 local TileRenderer = {}
 TileRenderer.__index = TileRenderer
@@ -830,6 +832,112 @@ function TileRenderer:drawWindow(camX, camY, vw, vh)
   self:drawAnimated(camX, camY)
 end
 
+-- Draw a cached alpha card for one map-space rectangle. The capture is stable
+-- across frames so camera motion cannot make the card's sampled edge swim.
+function TileRenderer:drawCutoutRegion(camX, camY, vw, vh, dx, dy, seed)
+  if type(camX) ~= "number" or type(camY) ~= "number"
+      or type(vw) ~= "number" or type(vh) ~= "number"
+      or vw <= 0 or vh <= 0 then return false end
+
+  local cw, ch = math.ceil(vw), math.ceil(vh)
+  local key = table.concat({ camX, camY, cw, ch,
+    type(seed) == "table" and seed.x or "",
+    type(seed) == "table" and seed.y or "",
+    type(seed) == "table" and seed.width or "",
+    type(seed) == "table" and seed.height or "",
+  }, ":")
+  self.billboardCutouts = self.billboardCutouts or {}
+  local image = self.billboardCutouts[key]
+  if image == false then return false end
+
+  local G = love.graphics
+  if not image then
+    local ok, result = pcall(function()
+      local canvas = PixelCanvas.new(cw, ch, "nearest")
+      G.push("all")
+      local captured, data = pcall(function()
+        G.setCanvas(canvas)
+        G.origin()
+        G.setScissor()
+        G.setShader()
+        G.setColor(1, 1, 1, 1)
+        G.clear(0, 0, 0, 0)
+        self:drawWindow(camX, camY, vw, vh)
+        return canvas:newImageData()
+      end)
+      G.pop()
+      if canvas.release then canvas:release() end
+      if not captured then return false end
+      if not BillboardCutout.mask(data, seed) then return false end
+      local cutout = G.newImage(data)
+      cutout:setFilter("nearest", "nearest")
+      return cutout
+    end)
+    image = ok and result or false
+    self.billboardCutouts[key] = image
+    if not image then return false end
+  end
+
+  G.setColor(1, 1, 1, 1)
+  G.draw(image, dx or 0, dy or 0)
+  return true
+end
+
+-- Draw a source-preserving version of a map crop over the rendered ground.
+-- Replace blending clears only the selected component and restores every
+-- neighbouring pixel from the original source capture.
+function TileRenderer:drawUnderlayRegion(camX, camY, vw, vh, dx, dy, seed)
+  if type(camX) ~= "number" or type(camY) ~= "number"
+      or type(vw) ~= "number" or type(vh) ~= "number"
+      or vw <= 0 or vh <= 0 then return false end
+
+  local cw, ch = math.ceil(vw), math.ceil(vh)
+  local key = table.concat({ camX, camY, cw, ch,
+    type(seed) == "table" and seed.x or "",
+    type(seed) == "table" and seed.y or "",
+    type(seed) == "table" and seed.width or "",
+    type(seed) == "table" and seed.height or "",
+  }, ":")
+  self.billboardUnderlays = self.billboardUnderlays or {}
+  local image = self.billboardUnderlays[key]
+  if image == false then return false end
+
+  local G = love.graphics
+  if not image then
+    local ok, result = pcall(function()
+      local canvas = PixelCanvas.new(cw, ch, "nearest")
+      G.push("all")
+      local captured, data = pcall(function()
+        G.setCanvas(canvas)
+        G.origin()
+        G.setScissor()
+        G.setShader()
+        G.setColor(1, 1, 1, 1)
+        G.clear(0, 0, 0, 0)
+        self:drawWindow(camX, camY, vw, vh)
+        return canvas:newImageData()
+      end)
+      G.pop()
+      if canvas.release then canvas:release() end
+      if not captured then return false end
+      if not BillboardCutout.erase(data, seed) then return false end
+      local underlay = G.newImage(data)
+      underlay:setFilter("nearest", "nearest")
+      return underlay
+    end)
+    image = ok and result or false
+    self.billboardUnderlays[key] = image
+    if not image then return false end
+  end
+
+  G.push("all")
+  G.setBlendMode("replace")
+  G.setColor(1, 1, 1, 1)
+  G.draw(image, dx or 0, dy or 0)
+  G.pop()
+  return true
+end
+
 -- animated overdraw at the current step, over the static window batch.  The
 -- cells were gathered for the current camera window by :ensureWindow, so this
 -- only ever touches on-screen animated tiles.
@@ -892,6 +1000,14 @@ function TileRenderer:releaseBatches()
   safeRelease(self.winBatch); self.winBatch = nil
   safeRelease(self.borderFill); self.borderFill = nil
   safeRelease(self.borderQuad); self.borderQuad = nil
+  if self.billboardCutouts then
+    for _, image in pairs(self.billboardCutouts) do safeRelease(image) end
+    self.billboardCutouts = nil
+  end
+  if self.billboardUnderlays then
+    for _, image in pairs(self.billboardUnderlays) do safeRelease(image) end
+    self.billboardUnderlays = nil
+  end
   -- shared shift-variant cache; only drop the reference
   self.borderWaterTextures = nil
   self.borderFillMode = nil

--- a/src/world/OverworldController.lua
+++ b/src/world/OverworldController.lua
@@ -13,6 +13,7 @@ local Logger = require("src.core.Logger")
 local Map = require("src.world.Map")
 local MapLoader = require("src.world.MapLoader")
 local NPC = require("src.world.NPC")
+local OverworldBillboards = require("src.render.OverworldBillboards")
 local PaletteFX = require("src.render.PaletteFX")
 local Pipelines = require("src.render.Pipelines")
 local Player = require("src.world.Player")
@@ -5669,13 +5670,62 @@ function OverworldState:drawWorld()
     fxDust()
     fxCutTree()
 
-    Game.renderer:beginUprightPass()
-
     -- One y-sorted list of ALL upright billboards -- sprites (player, NPCs,
     -- ghosts) -- keyed on baseline world y (the foot / base row).  Farther
     -- rows project higher/smaller, so back-to-front is just ascending
     -- baseline y.
     local items = {}
+
+    -- Run additive billboard callbacks while the ground canvas is active.
+    -- Source masks apply immediately; upright cards join the actor Y-sort and
+    -- draw only after the renderer switches to its upright pass.
+    if Pipelines.wantsBillboards() then
+      local function queueBillboard(wx, wy, drawFn)
+        if type(wx) ~= "number" or type(wy) ~= "number"
+            or type(drawFn) ~= "function" then return false end
+        local fx, fy = OverworldBillboards.gen1GroundScreenPoint(
+          wx, wy, cam.x, cam.y)
+        items[#items + 1] = {
+          y = wy, kind = "custom", fx = fx, fy = fy, draw = drawFn,
+        }
+        return true
+      end
+      local function drawMapCutout(x, y, w, h, ox, oy, seed)
+        if type(x) ~= "number" or type(y) ~= "number"
+            or type(w) ~= "number" or type(h) ~= "number"
+            or w <= 0 or h <= 0 then return false end
+        return self.map.renderer:drawCutoutRegion(x, y, w, h, ox, oy, seed)
+      end
+      local function maskMapCutout(x, y, w, h, seed)
+        if type(x) ~= "number" or type(y) ~= "number"
+            or type(w) ~= "number" or type(h) ~= "number"
+            or w <= 0 or h <= 0 then return false end
+        local dx, dy = x - cam.x, y - bgY
+        if dx + w < -32 or dy + h < -32
+            or dx > vw + 32 or dy > vh + 32 then return false end
+        return self.map.renderer:drawUnderlayRegion(
+          x, y, w, h, dx, dy, seed)
+      end
+      Pipelines.drawBillboards({
+        state = self,
+        cam = cam,
+        vw = vw,
+        vh = vh,
+        width = vw,
+        height = vh,
+        scale = 1,
+        mapScale = 1,
+        tiltLevel = Tilt.level,
+        map = OverworldBillboards.mapView(
+          self.map, Map.isOutdoor(self.map.def)),
+        billboard = queueBillboard,
+        drawMapCutout = drawMapCutout,
+        maskMapCutout = maskMapCutout,
+      })
+    end
+
+    Game.renderer:beginUprightPass()
+
     for _, g in ipairs(self.ghosts) do
       items[#items + 1] = { y = g.npc.py + g.oy + 16, kind = "ghost", g = g }
     end
@@ -5688,7 +5738,13 @@ function OverworldState:drawWorld()
     table.sort(items, function(a, b) return a.y < b.y end)
 
     for _, it in ipairs(items) do
-      if it.kind == "ghost" then
+      if it.kind == "custom" then
+        self:billboard(it.fx, it.fy, vw, vh,
+                       zoneColorsAt(zones, it.fx, it.fy), false, function()
+          OverworldBillboards.drawLocal(
+            love.graphics, it.fx, it.fy, it.draw)
+        end)
+      elseif it.kind == "ghost" then
         -- ghosts billboard just like real entities (foot offset folds in the
         -- neighbour map's ox/oy that ghost draws already apply via the camera)
         local g = it.g

--- a/src/world/gen2/World.lua
+++ b/src/world/gen2/World.lua
@@ -12,6 +12,7 @@ local Bag = require("src.inventory.Bag")
 local Battle = require("src.battle.gen2.Battle")
 local BattleMusic = require("src.battle.gen2.BattleMusic")
 local Bike = require("src.world.gen2.Bike")
+local BillboardCutout = require("src.render.BillboardCutout")
 local BorderFill = require("src.world.gen2.BorderFill")
 local Boxes = require("src.core.gen2.Boxes")
 local Breeding = require("src.core.gen2.Breeding")
@@ -51,6 +52,7 @@ local Permissions = require("src.world.gen2.Permissions")
 local Pipelines = require("src.render.Pipelines")
 local PixelCanvas = require("src.render.PixelCanvas")
 local Player = require("src.world.gen2.Player")
+local OverworldBillboards = require("src.render.OverworldBillboards")
 local Pokerus = require("src.core.gen2.Pokerus")
 local Roamers = require("src.core.gen2.Roamers")
 local Runtime = require("src.mods.Runtime")
@@ -5501,6 +5503,16 @@ function World:release()
   end
   safeRelease(self.tiltCanvas)
   self.tiltCanvas = nil
+  if self.billboardCutouts then
+    for _, image in pairs(self.billboardCutouts) do safeRelease(image) end
+    self.billboardCutouts = nil
+    self.billboardCutoutImage = nil
+  end
+  if self.billboardUnderlays then
+    for _, image in pairs(self.billboardUnderlays) do safeRelease(image) end
+    self.billboardUnderlays = nil
+    self.billboardUnderlayImage = nil
+  end
   if self.grassAtlases then
     for _, atlas in pairs(self.grassAtlases) do safeRelease(atlas) end
     self.grassAtlases = {}
@@ -10294,7 +10306,7 @@ end
 -- takes a foot point in flat screen pixels and a draw callback, and slides the
 -- draw onto that point's projection: only the ground tilts, so a standing
 -- thing stays upright and unscaled and the one thing that moves is its anchor.
-function World:drawPeople(s, billboard)
+function World:drawPeople(s, billboard, extra)
   local G = love.graphics
   local p = self.player
   local cam = self.camera
@@ -10314,34 +10326,56 @@ function World:drawPeople(s, billboard)
       }
     end
   end
+  if type(extra) == "table" then
+    for _, entry in ipairs(extra) do
+      if type(entry) == "table" and entry.kind == "custom"
+          and type(entry.py) == "number" and type(entry.wx) == "number"
+          and type(entry.wy) == "number" and type(entry.draw) == "function" then
+        drawList[#drawList + 1] = entry
+      end
+    end
+  end
   table.sort(drawList, function(a, b) return a.py < b.py end)
 
   for _, entry in ipairs(drawList) do
-    local ox = math.floor((entry.ox - cam.x) * s)
-    local oy = math.floor((entry.oy - cam.y) * s)
-    local entity = entry.kind == "player" and p or entry.npc
-    local function body()
-      if entry.kind == "player" then
-        self.player:draw(ox, oy, s)
+    if entry.kind == "custom" then
+      local fx, fy = OverworldBillboards.gen2GroundScreenPoint(
+        entry.wx, entry.wy, cam.x, cam.y, s)
+      local function drawLocal()
+        OverworldBillboards.drawLocal(love.graphics, fx, fy, entry.draw)
+      end
+      if billboard then
+        billboard(fx, fy, drawLocal)
       else
-        entry.npc:draw(ox, oy, s)
+        drawLocal()
       end
-      -- ShakeGrass rustle only while moving; drawGrassOver when standing/in grass
-      -- so the BG tuft covers the feet.
-      -- Only the current map's own entities: a ghost's cells belong to a
-      -- neighbour's block list.
-      if entry.ox == 0 and entry.oy == 0 then
-        if entity.inGrass and not (entity.grassShake and entity.moving) then
-          self:drawGrassOver(entity, ox, oy, s)
-        end
-        self:drawGrassShake(entity, ox, oy, s)
-      end
-    end
-    if billboard then
-      -- The foot is the baseline centre of the sprite's own cell.
-      billboard(ox + (entity.px + 8) * s, oy + (entity.py + 16) * s, body)
     else
-      body()
+      local ox = math.floor((entry.ox - cam.x) * s)
+      local oy = math.floor((entry.oy - cam.y) * s)
+      local entity = entry.kind == "player" and p or entry.npc
+      local function body()
+        if entry.kind == "player" then
+          self.player:draw(ox, oy, s)
+        else
+          entry.npc:draw(ox, oy, s)
+        end
+        -- ShakeGrass rustle only while moving; drawGrassOver when standing/in grass
+        -- so the BG tuft covers the feet.
+        -- Only the current map's own entities: a ghost's cells belong to a
+        -- neighbour's block list.
+        if entry.ox == 0 and entry.oy == 0 then
+          if entity.inGrass and not (entity.grassShake and entity.moving) then
+            self:drawGrassOver(entity, ox, oy, s)
+          end
+          self:drawGrassShake(entity, ox, oy, s)
+        end
+      end
+      if billboard then
+        -- The foot is the baseline centre of the sprite's own cell.
+        billboard(ox + (entity.px + 8) * s, oy + (entity.py + 16) * s, body)
+      else
+        body()
+      end
     end
   end
 
@@ -10457,6 +10491,117 @@ function World:tiltMesh()
   return mesh, shader
 end
 
+function World:drawMapCutout(x, y, rw, rh, ox, oy, s, seed)
+  if type(x) ~= "number" or type(y) ~= "number"
+      or type(rw) ~= "number" or type(rh) ~= "number"
+      or rw <= 0 or rh <= 0 then return false end
+  local source = self.mapImage
+  if not source or type(source.getDimensions) ~= "function" then return false end
+  local iw, ih = source:getDimensions()
+  if x < 0 or y < 0 or x + rw > iw or y + rh > ih then return false end
+
+  if self.billboardCutoutImage ~= source then
+    for _, old in pairs(self.billboardCutouts or {}) do safeRelease(old) end
+    self.billboardCutoutImage = source
+    self.billboardCutouts = {}
+  end
+  local key = table.concat({ x, y, rw, rh,
+    type(seed) == "table" and seed.x or "",
+    type(seed) == "table" and seed.y or "",
+    type(seed) == "table" and seed.width or "",
+    type(seed) == "table" and seed.height or "",
+  }, ":")
+  local cutout = self.billboardCutouts[key]
+  if cutout == false then return false end
+
+  local G = love.graphics
+  if not cutout then
+    local ok, result = pcall(function()
+      local canvas = PixelCanvas.new(math.ceil(rw), math.ceil(rh), "nearest")
+      canvas:renderTo(function()
+        G.clear(0, 0, 0, 0)
+        G.setColor(1, 1, 1, 1)
+        G.push()
+        G.origin()
+        G.draw(source, -x, -y)
+        G.pop()
+      end)
+      local data = canvas:newImageData()
+      safeRelease(canvas)
+      if not BillboardCutout.mask(data, seed) then return false end
+      local image = G.newImage(data)
+      image:setFilter("nearest", "nearest")
+      return image
+    end)
+    cutout = ok and result or false
+    self.billboardCutouts[key] = cutout
+    if not cutout then return false end
+  end
+
+  s = tonumber(s) or 1
+  G.setColor(1, 1, 1, 1)
+  G.draw(cutout, (ox or 0) * s, (oy or 0) * s, 0, s, s)
+  return true
+end
+
+function World:drawMapUnderlay(x, y, rw, rh, s, seed)
+  if type(x) ~= "number" or type(y) ~= "number"
+      or type(rw) ~= "number" or type(rh) ~= "number"
+      or rw <= 0 or rh <= 0 then return false end
+  local source = self.mapImage
+  if not source or type(source.getDimensions) ~= "function" then return false end
+  local iw, ih = source:getDimensions()
+  if x < 0 or y < 0 or x + rw > iw or y + rh > ih then return false end
+
+  if self.billboardUnderlayImage ~= source then
+    for _, old in pairs(self.billboardUnderlays or {}) do safeRelease(old) end
+    self.billboardUnderlayImage = source
+    self.billboardUnderlays = {}
+  end
+  local key = table.concat({ x, y, rw, rh,
+    type(seed) == "table" and seed.x or "",
+    type(seed) == "table" and seed.y or "",
+    type(seed) == "table" and seed.width or "",
+    type(seed) == "table" and seed.height or "",
+  }, ":")
+  local underlay = self.billboardUnderlays[key]
+  if underlay == false then return false end
+
+  local G = love.graphics
+  if not underlay then
+    local ok, result = pcall(function()
+      local canvas = PixelCanvas.new(math.ceil(rw), math.ceil(rh), "nearest")
+      canvas:renderTo(function()
+        G.clear(0, 0, 0, 0)
+        G.setColor(1, 1, 1, 1)
+        G.push()
+        G.origin()
+        G.draw(source, -x, -y)
+        G.pop()
+      end)
+      local data = canvas:newImageData()
+      safeRelease(canvas)
+      if not BillboardCutout.erase(data, seed) then return false end
+      local image = G.newImage(data)
+      image:setFilter("nearest", "nearest")
+      return image
+    end)
+    underlay = ok and result or false
+    self.billboardUnderlays[key] = underlay
+    if not underlay then return false end
+  end
+
+  s = tonumber(s) or 1
+  local cam = self.camera or { x = 0, y = 0 }
+  G.push("all")
+  G.setBlendMode("replace")
+  G.setColor(1, 1, 1, 1)
+  G.draw(underlay, math.floor((x - (cam.x or 0)) * s),
+    math.floor((y - (cam.y or 0)) * s), 0, s, s)
+  G.pop()
+  return true
+end
+
 -- `gw, gh` are the grown capture size from World:draw (Tilt.viewGrowth),
 -- matching Renderer:worldViewSize.  Camera is already followed for that view.
 function World:drawTilted(w, h, s, gw, gh)
@@ -10487,6 +10632,54 @@ function World:drawTilted(w, h, s, gw, gh)
   G.origin()
   self:drawGround(s)
   G.pop()
+
+  -- Run additive callbacks while the ground canvas is active. Masks apply
+  -- immediately; queued cards are drained with the ordinary upright actors
+  -- after this ground canvas has been projected.
+  local custom = {}
+  if Pipelines.wantsBillboards() then
+    local function queueBillboard(wx, wy, drawFn)
+      if type(wx) ~= "number" or type(wy) ~= "number"
+          or type(drawFn) ~= "function" then return false end
+      custom[#custom + 1] = {
+        kind = "custom", py = wy, wx = wx, wy = wy, draw = drawFn,
+      }
+      return true
+    end
+    local function drawMapCutout(x, y, rw, rh, ox, oy, seed)
+      return self:drawMapCutout(x, y, rw, rh, ox, oy, s, seed)
+    end
+    local function maskMapCutout(x, y, rw, rh, seed)
+      if type(x) ~= "number" or type(y) ~= "number"
+          or type(rw) ~= "number" or type(rh) ~= "number"
+          or rw <= 0 or rh <= 0 then return false end
+      local dx, dy = OverworldBillboards.gen2GroundScreenPoint(
+        x, y, self.camera.x, self.camera.y, s)
+      local aw, ah = rw * s, rh * s
+      if dx + aw < -32 * s or dy + ah < -32 * s
+          or dx > gw + 32 * s or dy > gh + 32 * s then return false end
+      local fx, fy = OverworldBillboards.gen2GroundScreenPoint(
+        x + rw / 2, y + rh, self.camera.x, self.camera.y, s)
+      if not Tilt.onGround(fx, fy, gw, gh, 32 * s) then return false end
+      return self:drawMapUnderlay(x, y, rw, rh, s, seed)
+    end
+    Pipelines.drawBillboards({
+      state = self,
+      cam = self.camera,
+      vw = self.viewW,
+      vh = self.viewH,
+      width = w,
+      height = h,
+      scale = s,
+      mapScale = s,
+      tiltLevel = Tilt.level,
+      map = OverworldBillboards.mapView(
+        self.map, Map.isOutdoor(self.map.def)),
+      billboard = queueBillboard,
+      drawMapCutout = drawMapCutout,
+      maskMapCutout = maskMapCutout,
+    })
+  end
   G.setCanvas(previous)
 
   mesh:setTexture(self.tiltCanvas)
@@ -10512,7 +10705,7 @@ function World:drawTilted(w, h, s, gw, gh)
     G.translate(sx - fx + (w - gw) / 2, sy - fy + (h - gh) / 2)
     body()
     G.pop()
-  end)
+  end, custom)
 end
 
 -- The COLOR option can change under a standing world (the hotkey, or the

--- a/tests/engine/billboard_cutout_test.lua
+++ b/tests/engine/billboard_cutout_test.lua
@@ -1,0 +1,46 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.harness").suite("billboard cutout")
+local loaded, Cutout = pcall(require, "src.render.BillboardCutout")
+T.check(loaded and type(Cutout) == "table",
+  "the engine exposes a billboard cutout helper")
+
+if loaded then
+  local rows = {
+    ".........",
+    ".####....",
+    ".####.#..",
+    ".####.#..",
+    ".........",
+  }
+  local pixels = {}
+  for y, row in ipairs(rows) do
+    pixels[y] = {}
+    for x = 1, #row do
+      local dark = row:sub(x, x) == "#"
+      local value = dark and 0.1 or 0.9
+      pixels[y][x] = { value, value, value, 1 }
+    end
+  end
+  local data = {}
+  function data:getDimensions() return #rows[1], #rows end
+  function data:getPixel(x, y) return unpack(pixels[y + 1][x + 1]) end
+  function data:setPixel(x, y, r, g, b, a)
+    pixels[y + 1][x + 1] = { r, g, b, a }
+  end
+
+  T.check(type(Cutout.erase) == "function",
+    "the helper exposes source-preserving component erasure")
+  if type(Cutout.erase) == "function" then
+    T.check(Cutout.erase(data, { x = 6, y = 2, width = 1, height = 2 }),
+      "the collision seed selects the intended component")
+    T.eq(pixels[3][7][4], 0,
+      "the selected component becomes transparent")
+    T.eq(pixels[2][2][4], 1,
+      "a neighbouring structure remains unchanged")
+    T.eq(pixels[1][1][4], 1,
+      "surrounding ground remains unchanged")
+  end
+end
+
+T.finish("billboard cutout")

--- a/tests/engine/gen2_billboard_stage_test.lua
+++ b/tests/engine/gen2_billboard_stage_test.lua
@@ -1,0 +1,78 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = require("tests.love_stub")
+
+local T = require("tests.harness").suite("gen2 billboard stage")
+local Pipelines = require("src.render.Pipelines")
+local World = require("src.world.gen2.World")
+
+local order, seen = {}, {}
+Pipelines.install({
+  render_pipelines = {
+    structures = {
+      drawBillboards = function(ctx)
+        seen.ctx = ctx
+        order[#order + 1] = "callback"
+        if ctx.maskMapCutout(16, 16, 16, 16,
+            { x = 0, y = 0, width = 16, height = 16 }) then
+          ctx.billboard(24, 32, function()
+            order[#order + 1] = "card"
+          end)
+        end
+      end,
+    },
+  },
+})
+Pipelines.setLevel("structures", 1)
+
+local mesh = {
+  setTexture = function() end,
+  setVertices = function() end,
+}
+local canvas = love.graphics.newCanvas(160, 144)
+local map = {
+  id = "TEST_TOWN", width = 10, height = 9,
+  def = { outdoor = true },
+  inBounds = function(_, x, y) return x >= 0 and y >= 0 end,
+  isWalkableCell = function() return false end,
+  isWaterCell = function() return false end,
+  isGrassCell = function() return false end,
+  isWarpTileCell = function() return false end,
+}
+local world = setmetatable({
+  map = map,
+  camera = { x = 0, y = 0 },
+  viewW = 160,
+  viewH = 144,
+  tiltCanvas = canvas,
+}, { __index = World })
+function world:tiltMesh() return mesh, {} end
+function world:drawGround() order[#order + 1] = "ground" end
+function world:drawMapUnderlay()
+  order[#order + 1] = "mask"
+  seen.maskCanvas = love.graphics.getCanvas()
+  return true
+end
+function world:drawPeople(_, _, extra)
+  order[#order + 1] = "people"
+  seen.extra = extra
+  if extra and extra[1] then extra[1].draw() end
+end
+
+world:drawTilted(160, 144, 1, 160, 144)
+
+T.check(type(seen.ctx) == "table", "TILT dispatches drawBillboards")
+T.eq(seen.maskCanvas, canvas,
+  "maskMapCutout runs while the TILT ground canvas is active")
+local ctx = seen.ctx or {}
+T.check(type(ctx.drawMapCutout) == "function"
+    and type(ctx.maskMapCutout) == "function"
+    and type(ctx.billboard) == "function",
+  "the public context exposes card, mask, and queue helpers")
+T.check(seen.extra and #seen.extra == 1,
+  "the upright people pass receives the queued custom card")
+T.same(order, { "ground", "callback", "mask", "people", "card" },
+  "ground masking finishes before the upright card draws")
+
+Pipelines.install(nil)
+T.finish("gen2 billboard stage")

--- a/tests/engine/gen2_map_cutout_test.lua
+++ b/tests/engine/gen2_map_cutout_test.lua
@@ -1,0 +1,102 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = require("tests.love_stub")
+
+local T = require("tests.harness").suite("gen2 map cutout")
+local World = require("src.world.gen2.World")
+
+local rows = {
+  ".........", ".####....", ".####.#..", ".####.#..", ".........",
+}
+local function sourceData()
+  local pixels = {}
+  for y, row in ipairs(rows) do
+    pixels[y - 1] = {}
+    for x = 1, #row do
+      local dark = row:sub(x, x) == "#"
+      local value = dark and 0.1 or 0.9
+      pixels[y - 1][x - 1] = { value, value, value, 1 }
+    end
+  end
+  return {
+    getDimensions = function() return 9, 5 end,
+    getPixel = function(_, x, y) return unpack(pixels[y][x]) end,
+    setPixel = function(_, x, y, r, g, b, a)
+      pixels[y][x] = { r, g, b, a }
+    end,
+    pixels = pixels,
+  }
+end
+
+local captures, finalDraw = 0, nil
+local nextData = sourceData()
+love.graphics.newCanvas = function(w, h)
+  return {
+    getDimensions = function() return w, h end,
+    setFilter = function() end,
+    renderTo = function(_, draw) draw() end,
+    newImageData = function()
+      captures = captures + 1
+      return nextData
+    end,
+    release = function() end,
+  }
+end
+love.graphics.newImage = function(data)
+  return { data = data, setFilter = function() end, release = function() end }
+end
+love.graphics.push = function() end
+love.graphics.pop = function() end
+love.graphics.origin = function() end
+love.graphics.clear = function() end
+love.graphics.setColor = function() end
+love.graphics.draw = function(image, ...)
+  if image.data then finalDraw = { image = image, args = { ... } } end
+end
+
+local source = { getDimensions = function() return 16, 16 end }
+local world = setmetatable({
+  mapImage = source,
+  camera = { x = 0, y = 0 },
+}, { __index = World })
+
+T.check(type(world.drawMapCutout) == "function",
+  "Gen 2 exposes an alpha-cutout draw")
+if type(world.drawMapCutout) == "function" then
+  world:drawMapCutout(2, 4, 9, 5, -1, -2, 2,
+    { x = 6, y = 2, width = 1, height = 2 })
+  T.eq(finalDraw.image.data.pixels[0][0][4], 0,
+    "card boundary ground becomes transparent")
+  T.eq(finalDraw.image.data.pixels[1][1][4], 0,
+    "a neighbouring component outside the seed becomes transparent")
+  T.eq(finalDraw.image.data.pixels[2][6][4], 1,
+    "the seeded component remains opaque")
+  T.same({ finalDraw.args[1], finalDraw.args[2],
+           finalDraw.args[4], finalDraw.args[5] },
+         { -2, -4, 2, 2 },
+    "the card offset and pixels use the world scale")
+  world:drawMapCutout(2, 4, 9, 5, -3, -4, 2,
+    { x = 6, y = 2, width = 1, height = 2 })
+  T.eq(captures, 1, "stable map geometry reuses the cached card")
+end
+
+nextData = sourceData()
+T.check(type(world.drawMapUnderlay) == "function",
+  "Gen 2 exposes source-preserving ground replacement")
+if type(world.drawMapUnderlay) == "function" then
+  T.check(world:drawMapUnderlay(2, 4, 9, 5, 2,
+    { x = 6, y = 2, width = 1, height = 2 }),
+    "ground replacement succeeds")
+  T.eq(finalDraw.image.data.pixels[2][6][4], 0,
+    "ground replacement clears the selected component")
+  T.eq(finalDraw.image.data.pixels[1][1][4], 1,
+    "ground replacement preserves a neighbouring component")
+  T.eq(finalDraw.image.data.pixels[0][0][4], 1,
+    "ground replacement preserves surrounding terrain")
+  T.same({ finalDraw.args[1], finalDraw.args[2],
+           finalDraw.args[4], finalDraw.args[5] },
+         { 4, 8, 2, 2 },
+    "ground replacement aligns to the ground canvas")
+end
+
+T.finish("gen2 map cutout")

--- a/tests/engine/gen2_overworld_billboards_test.lua
+++ b/tests/engine/gen2_overworld_billboards_test.lua
@@ -1,0 +1,32 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = require("tests.love_stub")
+
+local T = require("tests.harness").suite("gen2 overworld billboards")
+local World = require("src.world.gen2.World")
+
+local seen = {}
+love.graphics.translate = function(x, y) seen.localX, seen.localY = x, y end
+local world = {
+  camera = { x = 4.25, y = 8.25 },
+  player = {}, npcs = {}, ghosts = {}, flyAnim = {},
+}
+setmetatable(world, { __index = World })
+
+World.drawPeople(world, 2, function(x, y, body)
+  seen.x, seen.y = x, y
+  body()
+end, {
+  { kind = "custom", py = 40, wx = 20, wy = 40,
+    draw = function() seen.drawn = true end },
+})
+
+T.eq(seen.x, 40 + math.floor(-4.25 * 2),
+  "custom billboard x uses the map's integer camera snap")
+T.eq(seen.y, 80 + math.floor(-8.25 * 2),
+  "custom billboard y uses the map's integer camera snap")
+T.same({ seen.localX, seen.localY }, { 31, 63 },
+  "custom callbacks receive a local origin at the ground anchor")
+T.check(seen.drawn, "the Gen 2 people pass drains custom billboards")
+
+T.finish("gen2 overworld billboards")

--- a/tests/engine/overworld_billboards_test.lua
+++ b/tests/engine/overworld_billboards_test.lua
@@ -1,0 +1,76 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.harness").suite("overworld billboard context")
+local loaded, OverworldBillboards = pcall(require,
+  "src.render.OverworldBillboards")
+T.check(loaded and type(OverworldBillboards) == "table",
+  "the engine exposes shared overworld billboard helpers")
+
+if loaded then
+  local map = { id = "TEST_TOWN", widthCells = 3, heightCells = 2 }
+  function map:inBounds(x, y)
+    return x >= 0 and y >= 0
+      and x < self.widthCells and y < self.heightCells
+  end
+  function map:isWalkableCell(x, y) return x == 0 and y == 0 end
+  function map:isWaterCell(x, y) return x == 2 and y == 1 end
+  function map:isGrassCell(x, y) return x == 1 and y == 0 end
+  function map:isWarpTileCell(x, y) return x == 2 and y == 0 end
+
+  local view = OverworldBillboards.mapView(map, true)
+  T.eq(view.id, "TEST_TOWN", "map view carries the map id")
+  T.eq(view.width, 3, "map view carries cell width")
+  T.eq(view.height, 2, "map view carries cell height")
+  T.eq(view.cellSize, 16, "map view defines map-pixel cell size")
+  T.eq(view.outdoor, true, "map view carries outdoor classification")
+  T.check(view.cell(0, 0).walkable and not view.cell(0, 0).solid,
+    "walkable cells are not solid")
+  T.check(view.cell(1, 1).solid,
+    "blocked cells expose conservative solid semantics")
+  T.check(view.cell(2, 1).water and not view.cell(2, 1).solid,
+    "water is distinct from solid terrain")
+  T.check(view.cell(2, 0).warp, "warp semantics are preserved")
+
+  local gen2Map = {
+    id = "GEN2_TOWN", width = 4, height = 3,
+    inBounds = function(_, x, y)
+      return x >= 0 and y >= 0 and x < 8 and y < 6
+    end,
+  }
+  function gen2Map:isWalkableCell() return true end
+  function gen2Map:isWaterCell() return false end
+  function gen2Map:isGrassCell() return false end
+  function gen2Map:isWarpTileCell() return false end
+  local gen2View = OverworldBillboards.mapView(gen2Map, true)
+  T.eq(gen2View.width, 8, "Gen 2 block width expands to collision cells")
+  T.eq(gen2View.height, 6, "Gen 2 block height expands to collision cells")
+
+  local sx, sy = OverworldBillboards.gen1GroundScreenPoint(
+    64, 80, 8.25, 16.75)
+  T.same({ sx, sy }, { 56, 64 },
+    "Gen 1 anchors use the same integer camera snap as the map")
+  local gx, gy = OverworldBillboards.gen2GroundScreenPoint(
+    64, 80, 8.25, 16.75, 2)
+  T.same({ gx, gy }, { 111, 126 },
+    "Gen 2 anchors use the same scaled camera snap as the map")
+
+  local scoped = { pushes = 0, pops = 0 }
+  local graphics = {
+    push = function() scoped.pushes = scoped.pushes + 1 end,
+    pop = function() scoped.pops = scoped.pops + 1 end,
+    translate = function(x, y) scoped.x, scoped.y = x, y end,
+  }
+  T.check(type(OverworldBillboards.drawLocal) == "function",
+    "custom cards expose a scoped local-origin draw helper")
+  if type(OverworldBillboards.drawLocal) == "function" then
+    OverworldBillboards.drawLocal(graphics, 56, 64, function()
+      scoped.called = true
+    end)
+    T.same({ scoped.x, scoped.y }, { 56, 64 },
+      "custom cards draw from their ground anchor")
+    T.check(scoped.called and scoped.pushes == 1 and scoped.pops == 1,
+      "the local transform is scoped to one callback")
+  end
+end
+
+T.finish("overworld billboard context")

--- a/tests/engine/tile_cutout_region_test.lua
+++ b/tests/engine/tile_cutout_region_test.lua
@@ -1,0 +1,132 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = require("tests.love_stub")
+
+local T = require("tests.harness").suite("tile cutout region")
+local TileRenderer = require("src.render.TileRenderer")
+local BillboardCutout = require("src.render.BillboardCutout")
+
+local activeCanvas = { name = "upright" }
+local stack, captures, finalDraw = {}, 0, nil
+
+local function imageData(w, h)
+  local pixels = {}
+  local rows = w == 9 and h == 5 and {
+    ".........", ".####....", ".####.#..", ".####.#..", ".........",
+  } or nil
+  for y = 0, h - 1 do
+    pixels[y] = {}
+    for x = 0, w - 1 do
+      local dark = rows and rows[y + 1]:sub(x + 1, x + 1) == "#"
+        or (not rows and x == math.floor(w / 2) and y == math.floor(h / 2))
+      local value = dark and 0.1 or 0.9
+      pixels[y][x] = { value, value, value, 1 }
+    end
+  end
+  return {
+    getDimensions = function() return w, h end,
+    getPixel = function(_, x, y) return unpack(pixels[y][x]) end,
+    setPixel = function(_, x, y, r, g, b, a)
+      pixels[y][x] = { r, g, b, a }
+    end,
+    pixels = pixels,
+  }
+end
+
+love.graphics.newCanvas = function(w, h)
+  local canvas = { w = w, h = h }
+  function canvas:setFilter() end
+  function canvas:newImageData()
+    captures = captures + 1
+    return imageData(w, h)
+  end
+  function canvas:release() self.released = true end
+  return canvas
+end
+love.graphics.newImage = function(data)
+  return { data = data, setFilter = function() end, release = function() end }
+end
+love.graphics.getCanvas = function() return activeCanvas end
+love.graphics.setCanvas = function(canvas) activeCanvas = canvas end
+love.graphics.push = function() stack[#stack + 1] = activeCanvas end
+love.graphics.pop = function() activeCanvas = table.remove(stack) end
+love.graphics.origin = function() end
+love.graphics.setScissor = function() end
+love.graphics.setShader = function() end
+love.graphics.setColor = function() end
+love.graphics.clear = function() end
+love.graphics.draw = function(image, x, y)
+  finalDraw = { image = image, x = x, y = y, target = activeCanvas }
+end
+
+local renderer = setmetatable({}, { __index = TileRenderer })
+function renderer:drawWindow() end
+
+T.check(type(renderer.drawCutoutRegion) == "function",
+  "TileRenderer exposes an alpha-cutout region draw")
+if type(renderer.drawCutoutRegion) == "function" then
+  renderer:drawCutoutRegion(10, 20, 9, 5, -1, -2,
+    { x = 6, y = 2, width = 1, height = 2 })
+  local firstImage = finalDraw.image
+  T.eq(firstImage.data.pixels[0][0][4], 0,
+    "boundary ground is transparent in the card")
+  T.eq(firstImage.data.pixels[1][1][4], 0,
+    "a neighbouring structure outside the seed is transparent")
+  T.eq(firstImage.data.pixels[2][6][4], 1,
+    "the seeded structure remains opaque")
+  T.same({ finalDraw.x, finalDraw.y }, { -1, -2 },
+    "the card draws at its billboard-local offset")
+
+  renderer:drawCutoutRegion(10, 20, 9, 5, -4, -5,
+    { x = 6, y = 2, width = 1, height = 2 })
+  T.eq(captures, 1, "a stable map region reuses its cached cutout")
+  T.eq(finalDraw.image, firstImage, "the cached cutout image is reused")
+
+  local upright = { name = "upright-after-failure" }
+  activeCanvas = upright
+  love.graphics.newCanvas = function(w, h)
+    return {
+      w = w, h = h,
+      setFilter = function() end,
+      newImageData = function() error("readback unavailable") end,
+      release = function() end,
+    }
+  end
+  local broken = setmetatable({}, { __index = TileRenderer })
+  function broken:drawWindow() end
+  T.eq(broken:drawCutoutRegion(1, 2, 3, 3, 0, 0), false,
+    "a failed GPU readback degrades without drawing a card")
+  T.eq(activeCanvas, upright,
+    "a failed capture restores the upright render target")
+end
+
+local underlay = setmetatable({}, { __index = TileRenderer })
+function underlay:drawWindow() end
+activeCanvas = { name = "ground" }
+love.graphics.newCanvas = function(w, h)
+  local canvas = { w = w, h = h }
+  function canvas:setFilter() end
+  function canvas:newImageData()
+    captures = captures + 1
+    return imageData(w, h)
+  end
+  function canvas:release() self.released = true end
+  return canvas
+end
+T.check(type(underlay.drawUnderlayRegion) == "function",
+  "TileRenderer exposes a source-preserving ground replacement")
+if type(underlay.drawUnderlayRegion) == "function" then
+  T.check(underlay:drawUnderlayRegion(10, 20, 9, 5, -1, -2,
+    { x = 6, y = 2, width = 1, height = 2 }),
+    "ground replacement succeeds")
+  T.eq(finalDraw.image.data.pixels[2][6][4], 0,
+    "ground replacement clears the selected structure")
+  T.eq(finalDraw.image.data.pixels[1][1][4], 1,
+    "ground replacement preserves a neighbouring structure")
+  T.eq(finalDraw.image.data.pixels[0][0][4], 1,
+    "ground replacement preserves surrounding terrain")
+  T.same({ finalDraw.x, finalDraw.y }, { -1, -2 },
+    "ground replacement uses the requested destination")
+end
+
+T.finish("tile cutout region")

--- a/tests/mod_render_tests.lua
+++ b/tests/mod_render_tests.lua
@@ -73,6 +73,10 @@ do
     { label = "GRADE", present = function() end }, "register")
   check(okPresent, "a present-only record validates")
 
+  local okBillboards = Schemas.check(spec, "render_pipelines", "billboards",
+    { label = "BILLBOARDS", drawBillboards = function() end }, "register")
+  check(okBillboards, "a drawBillboards-only record validates")
+
   -- the whole point of the record is to draw something
   local bad, err = Schemas.check(spec, "render_pipelines", "inert",
     { label = "INERT" }, "register")
@@ -334,6 +338,30 @@ eq(love.graphics.getCanvas(), "engine-canvas",
 eq(love.graphics.getBlendMode(), "alpha",
   "a present that changed blend mode cannot leak it past the fold")
 Pipelines.setLevel("dirty", 0)
+
+-- ------- additive TILT billboards dispatch without claiming the world
+
+local billboardCtx = { tag = "tilt" }
+local billboardSeen, billboardLevel = nil, nil
+Pipelines.install({
+  render_pipelines = {
+    billboards = {
+      label = "BILLBOARDS",
+      drawBillboards = function(ctx)
+        billboardSeen = ctx
+        billboardLevel = ctx.level
+      end,
+    },
+  },
+})
+Pipelines.setLevel("billboards", 1)
+check(Pipelines.wantsBillboards(),
+  "an enabled additive billboard stage is discoverable")
+Pipelines.drawBillboards(billboardCtx)
+eq(billboardSeen, billboardCtx,
+  "drawBillboards receives the owning TILT frame context")
+eq(billboardLevel, 1,
+  "drawBillboards receives its pipeline's configured level")
 
 Pipelines.reset()
 Pipelines.install(nil)


### PR DESCRIPTION
## Summary

- add an optional additive `render_pipelines.drawBillboards(ctx)` stage inside built-in TILT
- expose a read-only semantic collision-map view plus cached map cutout, source-mask, and billboard queue helpers
- integrate source masking and Y-sorted upright cards across Gen 1, Gold, Silver, and Crystal
- preserve nearby terrain when removing the flat source silhouette, preventing duplicate flat/upright structures

This is a presentation-only API. It does not change collision, movement, warps, scripts, saves, battles, or link behavior.

## API

During built-in TILT, an enabled pipeline may implement `drawBillboards(ctx)`. The context provides:

- `ctx.map`: semantic map dimensions and collision-derived `cell(x, y)` flags
- `ctx.drawMapCutout(...)`: draw a cached alpha card for a seeded map component
- `ctx.maskMapCutout(...)`: remove that same component from the active ground canvas
- `ctx.billboard(worldX, worldY, drawFn)`: merge the card into the normal upright-object Y-sort
- `ctx.mapScale`: map-pixel to world-pixel scale

`maskMapCutout` returns `false` when the region cannot be masked safely, allowing mods to skip the corresponding upright card and avoid partial rendering.

## Verification

- `luajit tests/mod_render_tests.lua` — 62/62
- additive billboard/cutout suites — 59/59
- changed Lua modules compile with `luajit -b`
- `luajit tests/run_engine.lua` — 367/368 in the restricted workspace; the sole failure was temporary-fixture write permission
- `luajit tests/engine/required_import_streaming_test.lua` — 11/11 when rerun with repository write access
- `python3 tools/modkit.py docs`
- `git diff --check`

Opened as a draft for API and renderer review.
