### PR TITLE
fix(gen2): preserve caller identity for deferred phone calls

### DIFF
--- a/src/core/gen2/PhoneRing.lua
+++ b/src/core/gen2/PhoneRing.lua
@@ -100,6 +100,7 @@ function PhoneRing.script(call, name, className)
     })
   end
   local rows = {}
+  rows.phoneContact = call and call.contact
   if call and call.delay then
     rows[#rows + 1] = { op = "pause", frames = call.delay }
   end

--- a/src/world/gen2/World.lua
+++ b/src/world/gen2/World.lua
@@ -5040,7 +5040,11 @@ function World:runQueuedScript()
   if not script or self:busy() then return false end
   self.queuedScript = nil
   self.talkNpc = nil
-  return self.vm and self.vm:start(script) or false
+  local vm = self.vm
+  if vm and type(script) == "table" and script.phoneContact ~= nil then
+    vm.curPhoneCaller = script.phoneContact
+  end
+  return vm and vm:start(script) or false
 end
 
 -- Script_FishCastRod, then Script_NotEvenANibble or Script_GotABite.  Held as
@@ -6758,7 +6762,7 @@ function World:momTriesToBuy()
   local Phone = require("src.core.gen2.Phone")
   if self.vm then self.vm.curPhoneCaller = Phone.PHONECONTACT_MOM end
   self.queuedScript = require("src.core.gen2.PhoneRing").script(
-    { scriptKey = script },
+    { contact = Phone.PHONECONTACT_MOM, scriptKey = script },
     Phone.NON_TRAINER_NAMES[Phone.PHONECONTACT_MOM])
   -- A doll changes what stands in the bedroom, and the room is rebuilt from
   -- the flags on a MAP LOAD -- so nothing has to be dropped here, the same

--- a/tests/gen2_phone_call_test.lua
+++ b/tests/gen2_phone_call_test.lua
@@ -220,6 +220,21 @@ do
   check(pages[1]:find("MOM:", 1, true) ~= nil, "ringing as MOM")
   check(table.concat(pages, "|"):find("Click!", 1, true) ~= nil,
     "and hanging up on the Click!")
+
+  -- The defeated trainer's after-battle script may write wCurCaller again
+  -- before the deferred Mom call starts.  The queued call must restore its
+  -- own caller instead of showing that trainer above Mom's text.
+  vm.curPhoneCaller = 15
+  local startedAs
+  vm.start = function(self)
+    startedAs = self.curPhoneCaller
+    return true
+  end
+  fake.busy = function() return false end
+  fake.runQueuedScript = World.runQueuedScript
+  check(fake:runQueuedScript(), "the deferred Mom call starts")
+  eq(startedAs, Phone.PHONECONTACT_MOM,
+    "and restores MOM after a trainer overwrote wCurCaller")
 end
 
 -- ------------------------------------------------- against the cache

--- a/tests/gen2_phone_call_test.lua
+++ b/tests/gen2_phone_call_test.lua
@@ -221,9 +221,9 @@ do
   check(table.concat(pages, "|"):find("Click!", 1, true) ~= nil,
     "and hanging up on the Click!")
 
-  -- The defeated trainer's after-battle script may write wCurCaller again
+  -- wCurCaller is shared state and may still hold an earlier trainer contact
   -- before the deferred Mom call starts.  The queued call must restore its
-  -- own caller instead of showing that trainer above Mom's text.
+  -- own caller instead of showing that stale trainer above Mom's text.
   vm.curPhoneCaller = 15
   local startedAs
   vm.start = function(self)


### PR DESCRIPTION
## What this fixes

Mom can call after a trainer battle to say she bought something. That call waits until the current overworld script is finished. The shared caller value can still contain an earlier trainer contact, so the caller box may show that stale trainer even though Mom is speaking.

The stale trainer does not need to be the trainer from the immediately preceding battle, and the player does not need to have accepted that trainer's phone number.

## How it works

- Store the intended contact on a queued phone script.
- Restore that contact immediately before the queued script starts.
- Include Mom's contact in her shopping-call descriptor.

This only changes queued phone scripts that carry caller metadata. Ordinary queued scripts and existing direct phone calls keep their current behavior.

## Why this is safe

The metadata is additive. `runQueuedScript` behaves exactly as before unless the queued table contains `phoneContact`. There is no mod API or event-contract change.

## Testing

- Added a regression test that queues Mom's call, simulates a stale trainer caller value, and verifies that the call still starts as Mom: 48/48 checks passed.
- A/B tested on Android: the control build reliably showed the stale trainer name; the fixed build showed Mom.
- Gen 2 suite: 135/137 suites pass locally. The same two remaining failures reproduce on unchanged `dev` and are Windows-only path/shell assumptions (`/tmp` and Unix command output), unrelated to this change.
- Lua/JIT source-limit checks: 452/452 passed.
