### PR TITLE
fix present sync probing + fixedstep so display/vrr pacing doesnt lie

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1423,9 +1423,10 @@ function love.run()
     elseif cap == FrameCap.DISPLAY and not VSync.isOn() then
       cap = FrameCap.DEFAULT
     elseif cap == FrameCap.DISPLAY and PresentSync.needsSoftwareCap() then
-      -- Vsync is "on" but presents are ungated (driver no-op, VRR early
-      -- return, Gamescope/XWayland, etc.) and no platform wait is bound:
-      -- FrameCap is the thermal / pacing safety net on every OS.
+      -- Fallback cascade: probe failed / wait abandoned / sync non-
+      -- deterministic → FrameCap is the live pacing path on every OS.
+      -- (During an active probe we intentionally leave DISPLAY uncapped so
+      -- calibration is not grading our own limiter.)
       cap = FrameCap.DEFAULT
     end
 

--- a/main.lua
+++ b/main.lua
@@ -1423,8 +1423,9 @@ function love.run()
     elseif cap == FrameCap.DISPLAY and not VSync.isOn() then
       cap = FrameCap.DEFAULT
     elseif cap == FrameCap.DISPLAY and PresentSync.needsSoftwareCap() then
-      -- Vsync is "on" but presents are ungated (Gamescope/XWayland no-op)
-      -- and no GLX wait bound: FrameCap is the thermal safety net.
+      -- Vsync is "on" but presents are ungated (driver no-op, VRR early
+      -- return, Gamescope/XWayland, etc.) and no platform wait is bound:
+      -- FrameCap is the thermal / pacing safety net on every OS.
       cap = FrameCap.DEFAULT
     end
 

--- a/src/core/FixedStep.lua
+++ b/src/core/FixedStep.lua
@@ -62,7 +62,7 @@ end
 -- intended budget.
 FixedStep.maxAccum = MAX_ACCUM
 
-function FixedStep:update(dt)
+function FixedStep:update(dt, speed)
   -- A hitch's oversized dt lands on the frame AFTER discardCatchup was
   -- called (the hitch itself already ran inside the current step); absorb
   -- that one frame as a single step instead of the normal accumulator so
@@ -74,6 +74,12 @@ function FixedStep:update(dt)
     self.callback(self.STEP)
     return
   end
+  -- Snap/smooth against the wall-clock frame dt first.  Game speed is a
+  -- multiplier on how many logic steps that real frame buys — applying it
+  -- before refresh-period snap made 2–4X look like multi-period frames and
+  -- destabilized pacing under DISPLAY sync.
+  speed = tonumber(speed) or 1
+  if speed < 1 then speed = 1 end
   local period = self.refreshPeriod
   local snapped = false
   if period and dt > 0 then
@@ -104,7 +110,7 @@ function FixedStep:update(dt)
     local target = phaseOffset(period, self.STEP)
     self.accum = self.accum - self.accum % self.STEP + target
   end
-  self.accum = math.min(self.accum + dt, self.maxAccum or MAX_ACCUM)
+  self.accum = math.min(self.accum + dt * speed, self.maxAccum or MAX_ACCUM)
   while self.accum >= self.STEP - STEP_EPS do
     self.accum = self.accum - self.STEP
     self.callback(self.STEP)

--- a/src/core/FixedStep.lua
+++ b/src/core/FixedStep.lua
@@ -5,7 +5,12 @@
 local FixedStep = {}
 
 FixedStep.STEP = 1 / 60
-local MAX_ACCUM = 0.25 -- avoid spiral of death after a stall
+-- Hard ceiling on catch-up debt (seconds of logic time drained in one
+-- rendered frame).  0.25s = 15 GB steps.  Game:update may lower this for the
+-- current speed target but must never raise it: a hitch at high multipliers
+-- cannot dump unbounded steps and starve input / spiral the frame.
+FixedStep.MAX_ACCUM = 0.25
+local MAX_ACCUM = FixedStep.MAX_ACCUM
 local SMOOTH_FRAMES = 4
 local SMOOTH_MAX = 1 / 60 * 2.5
 local STEP_EPS = 1 / 60 * 0.02
@@ -55,12 +60,22 @@ function FixedStep:init(callback)
   self.phasedFor = nil
 end
 
--- The anti-spiral clamp doubles as a steps-per-frame ceiling (0.25s = 15
--- steps), which silently throttled the high fast-forward levels: at 100X
--- a 60fps frame wants ~100 steps. Game:update raises this to fit the
--- current speed target; a stall still cannot snowball past one frame's
--- intended budget.
+-- The anti-spiral clamp is the steps-per-frame ceiling.  Game:update sets
+-- maxAccum to the current speed's one-frame budget, hard-capped at MAX_ACCUM
+-- so high fast-forward cannot turn a hitch into input starvation.
 FixedStep.maxAccum = MAX_ACCUM
+
+-- Compute the live catch-up ceiling for a logic-speed multiplier.
+-- Always ≤ MAX_ACCUM; at least two steps so ordinary vsync wobble can recover.
+function FixedStep.catchupLimit(speed)
+  speed = tonumber(speed) or 1
+  if speed < 1 then speed = 1 end
+  local target = speed * FixedStep.STEP * 1.5
+  local floor = FixedStep.STEP * 2
+  if target < floor then target = floor end
+  if target > MAX_ACCUM then target = MAX_ACCUM end
+  return target
+end
 
 function FixedStep:update(dt, speed)
   -- A hitch's oversized dt lands on the frame AFTER discardCatchup was
@@ -80,6 +95,9 @@ function FixedStep:update(dt, speed)
   -- destabilized pacing under DISPLAY sync.
   speed = tonumber(speed) or 1
   if speed < 1 then speed = 1 end
+  -- Pathological wall-clock stalls: do not let dt alone exceed the catch-up
+  -- ceiling before speed is applied (speed amplify would just hit the clamp).
+  if dt > MAX_ACCUM then dt = MAX_ACCUM end
   local period = self.refreshPeriod
   local snapped = false
   if period and dt > 0 then

--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -399,7 +399,7 @@ function Game:update(dt)
   local speed = self:logicSpeed()
   local Sound = require("src.core.Sound")
   if Sound.setRate then Sound.setRate(speed) end
-  FixedStep.maxAccum = math.max(0.25, speed * FixedStep.STEP * 1.5)
+  FixedStep.maxAccum = FixedStep.catchupLimit(speed)
   FixedStep:update(dt, speed)
   local step = FixedStep.STEP
   self.audioAccum = math.min((self.audioAccum or 0) + dt, 0.25)

--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -400,7 +400,7 @@ function Game:update(dt)
   local Sound = require("src.core.Sound")
   if Sound.setRate then Sound.setRate(speed) end
   FixedStep.maxAccum = math.max(0.25, speed * FixedStep.STEP * 1.5)
-  FixedStep:update(dt * speed)
+  FixedStep:update(dt, speed)
   local step = FixedStep.STEP
   self.audioAccum = math.min((self.audioAccum or 0) + dt, 0.25)
   while self.audioAccum >= step do

--- a/src/core/Game2.lua
+++ b/src/core/Game2.lua
@@ -1268,12 +1268,12 @@ function Game2:update(dt)
   local Sound = require("src.core.Sound")
   if Sound.setRate then Sound.setRate(speed) end
   if self.phase == "boot" then
-    FixedStep.maxAccum = math.max(0.25, speed / 60 + 0.05)
+    FixedStep.maxAccum = FixedStep.catchupLimit(speed)
     FixedStep:update(dt, speed)
     return
   end
   if not self.world or not self.world.map then return end
-  FixedStep.maxAccum = math.max(0.25, speed / 60 + 0.05)
+  FixedStep.maxAccum = FixedStep.catchupLimit(speed)
   FixedStep:update(dt, speed)
 end
 

--- a/src/core/Game2.lua
+++ b/src/core/Game2.lua
@@ -1269,12 +1269,12 @@ function Game2:update(dt)
   if Sound.setRate then Sound.setRate(speed) end
   if self.phase == "boot" then
     FixedStep.maxAccum = math.max(0.25, speed / 60 + 0.05)
-    FixedStep:update(dt * speed)
+    FixedStep:update(dt, speed)
     return
   end
   if not self.world or not self.world.map then return end
   FixedStep.maxAccum = math.max(0.25, speed / 60 + 0.05)
-  FixedStep:update(dt * speed)
+  FixedStep:update(dt, speed)
 end
 
 -- The screen-pixels-per-GB-pixel scale the post passes need so their grid and

--- a/src/core/PresentProbe.lua
+++ b/src/core/PresentProbe.lua
@@ -1,14 +1,21 @@
 -- Present sync: on every platform, measure whether love.window.setVSync
--- actually gates presents.  Linux additionally binds a real wait (GLX OML /
+-- actually gates presents by timing present() itself (not the gap between
+-- frames — that gap includes FrameCap sleeps and would false-trigger "gated"
+-- during DISPLAY warmup).  Linux additionally binds a real wait (GLX OML /
 -- SGI on native X11) when SDL's swap interval is a no-op (Gamescope /
 -- XWayland).  Wayland: never duplicate wl_surface.frame.  drmWaitVBlank is
--- never used.
+-- never used.  Ambiguous probe results prefer FrameCap over trusting sync.
 
 local PresentProbe = {}
 
+-- Probe present() block time (not inter-frame gaps).  Inter-frame gaps include
+-- FrameCap sleeps and would always look "gated" during DISPLAY warmup.
 local PROBE_FRAMES = 45
 local INSTANT_MS = 0.0005
 local BLOCK_MS = 0.002
+-- If a bound GLX wait ever blocks longer than this, drop it and fall back to
+-- FrameCap.  Covers a stalled compositor without wedging the game loop.
+local WAIT_ABORT_S = 0.1
 
 -- Hot-path: a single cached closure, no ffi.C / string work inside it.
 local waitFn = nil
@@ -23,8 +30,8 @@ local state = {
   strategy = "none",  -- "none" | "sdl" | "oml" | "sgi"
   needsSoftwareCap = false,
   probeCount = 0,
-  lastPresent = nil,
-  intervals = nil,
+  presentStart = nil, -- love.timer time entering present(), probe only
+  intervals = nil,    -- present() block times while probing
   glxGen = 0,
   bindGen = -1,
 }
@@ -102,6 +109,9 @@ local function detectNest(driver)
   return "unknown"
 end
 
+-- Classify from present() block times.  Prefer false (ungated → FrameCap)
+-- whenever the signal is ambiguous: trusting a broken swap interval uncapped
+-- is far worse than pacing in software.
 local function classifyGated(intervals)
   if not intervals or #intervals < 10 then return nil end
   local sorted = {}
@@ -113,11 +123,14 @@ local function classifyGated(intervals)
   local okRR, RR = pcall(require, "src.core.RefreshRate")
   if okRR then hz = RR.hz() end
   local expect = hz and (1 / hz) or (1 / 60)
-  -- Ungated presents are typically << panel period (often < 2ms for this game).
+  -- Ungated: present returns well before a panel period (often < 2ms).
   if mid < expect * 0.45 then return false end
-  if mid > expect * 0.7 and mid < expect * 1.6 then return true end
-  -- Weird ratio (e.g. half-rate): still treat as gated if slow enough.
-  return mid >= (1 / 200)
+  -- Full-rate vsync: block time sits near the panel period.
+  if mid >= expect * 0.7 and mid <= expect * 1.55 then return true end
+  -- Half-rate vsync (e.g. 30Hz on a 60Hz panel).
+  if mid >= expect * 1.7 and mid <= expect * 2.4 then return true end
+  -- CPU-bound mid-range (e.g. 8–12ms on 60Hz) is not evidence of sync.
+  return false
 end
 
 local function loadGlx()
@@ -401,7 +414,7 @@ function PresentProbe.reset()
   state.strategy = "none"
   state.needsSoftwareCap = false
   state.probeCount = 0
-  state.lastPresent = nil
+  state.presentStart = nil
   state.intervals = nil
   state.glxGen = state.glxGen + 1
   state.bindGen = -1
@@ -417,7 +430,7 @@ function PresentProbe.onDisplayChange()
   state.gated = nil
   state.probeCount = 0
   state.intervals = {}
-  state.lastPresent = nil
+  state.presentStart = nil
   state.strategy = "none"
   state.needsSoftwareCap = false
   glLib = nil
@@ -430,7 +443,7 @@ function PresentProbe.reprobe()
   state.gated = nil
   state.probeCount = 0
   state.intervals = {}
-  state.lastPresent = nil
+  state.presentStart = nil
   waitFn = nil
   state.glxGen = state.glxGen + 1
   state.bindGen = -1
@@ -438,10 +451,30 @@ function PresentProbe.reprobe()
   pickStrategy()
 end
 
+local function abandonWait()
+  waitFn = nil
+  state.strategy = "none"
+  state.needsSoftwareCap = true
+  state.gated = false
+  state.bindGen = state.glxGen
+end
+
 -- Hot path: must stay allocation-free and avoid ffi.C / require.
+-- Records presentStart AFTER any GLX wait so the probe measures SDL/GL
+-- swap-interval block time alone (FrameCap sleep lives after notePresent).
 function PresentProbe.waitBeforePresent()
   local fn = waitFn
-  if fn then fn() end
+  if fn then
+    local t0 = love.timer and love.timer.getTime and love.timer.getTime()
+    local ok = pcall(fn)
+    local t1 = love.timer and love.timer.getTime and love.timer.getTime()
+    if not ok or (t0 and t1 and (t1 - t0) > WAIT_ABORT_S) then
+      abandonWait()
+    end
+  end
+  if state.gated == nil and love.timer and love.timer.getTime then
+    state.presentStart = love.timer.getTime()
+  end
 end
 
 function PresentProbe.notePresent()
@@ -457,19 +490,19 @@ function PresentProbe.notePresent()
     return
   end
 
+  local start = state.presentStart
+  state.presentStart = nil
   local now = love.timer and love.timer.getTime and love.timer.getTime()
-  if not now then return end
-  local last = state.lastPresent
-  state.lastPresent = now
-  if not last then return end
-  local dt = now - last
-  if dt <= 0 or dt > 0.25 then return end
+  if not start or not now then return end
+  local block = now - start
+  -- Discard hitches / timer glitches; keep sampling until we have clean ones.
+  if block <= 0 or block > 0.25 then return end
   local intervals = state.intervals
   if not intervals then
     intervals = {}
     state.intervals = intervals
   end
-  intervals[#intervals + 1] = dt
+  intervals[#intervals + 1] = block
   state.probeCount = #intervals
   if #intervals < PROBE_FRAMES then return end
 

--- a/src/core/PresentProbe.lua
+++ b/src/core/PresentProbe.lua
@@ -1,15 +1,15 @@
 -- Present sync: on every platform, measure whether love.window.setVSync
--- actually gates presents by timing present() itself (not the gap between
--- frames — that gap includes FrameCap sleeps and would false-trigger "gated"
--- during DISPLAY warmup).  Linux additionally binds a real wait (GLX OML /
--- SGI on native X11) when SDL's swap interval is a no-op (Gamescope /
--- XWayland).  Wayland: never duplicate wl_surface.frame.  drmWaitVBlank is
--- never used.  Ambiguous probe results prefer FrameCap over trusting sync.
+-- actually gates presents by timing present() itself with the software
+-- limiter disabled (probe isolation — no self-measurement artifacts).
+-- Linux may additionally bind a real wait (GLX OML / SGI on native X11)
+-- when SDL's swap interval is a no-op.  Wayland: never duplicate
+-- wl_surface.frame.  drmWaitVBlank is never used.
+-- Ambiguous or unstable probe results prefer FrameCap over trusting sync.
 
 local PresentProbe = {}
 
--- Probe present() block time (not inter-frame gaps).  Inter-frame gaps include
--- FrameCap sleeps and would always look "gated" during DISPLAY warmup.
+-- Probe present() block time with FrameCap disabled during calibration.
+-- Inter-frame gaps include limiter sleeps and must never be the signal.
 local PROBE_FRAMES = 45
 local INSTANT_MS = 0.0005
 local BLOCK_MS = 0.002
@@ -109,9 +109,10 @@ local function detectNest(driver)
   return "unknown"
 end
 
--- Classify from present() block times.  Prefer false (ungated → FrameCap)
--- whenever the signal is ambiguous: trusting a broken swap interval uncapped
--- is far worse than pacing in software.
+-- Classify from present() block times.
+-- Fail closed: anything ambiguous or non-deterministic → ungated → FrameCap.
+-- Trusting a broken / VRR-jittery swap interval uncapped is far worse than
+-- software pacing.
 local function classifyGated(intervals)
   if not intervals or #intervals < 10 then return nil end
   local sorted = {}
@@ -119,17 +120,26 @@ local function classifyGated(intervals)
   table.sort(sorted)
   local mid = sorted[math.floor(#sorted / 2) + 1]
   if not mid or mid <= 0 then return false end
+
+  -- Known panel Hz required before we ever trust hardware gating.
   local hz = nil
   local okRR, RR = pcall(require, "src.core.RefreshRate")
   if okRR then hz = RR.hz() end
-  local expect = hz and (1 / hz) or (1 / 60)
-  -- Ungated: present returns well before a panel period (often < 2ms).
-  if mid < expect * 0.45 then return false end
-  -- Full-rate vsync: block time sits near the panel period.
-  if mid >= expect * 0.7 and mid <= expect * 1.55 then return true end
-  -- Half-rate vsync (e.g. 30Hz on a 60Hz panel).
-  if mid >= expect * 1.7 and mid <= expect * 2.4 then return true end
-  -- CPU-bound mid-range (e.g. 8–12ms on 60Hz) is not evidence of sync.
+  if not hz or hz <= 0 then return false end
+  local expect = 1 / hz
+
+  -- Spread check: real swap-interval lock is tight; CPU-bound or VRR jitter
+  -- spreads the distribution and must not pass as "gated".
+  local q1 = sorted[math.floor(#sorted * 0.25) + 1]
+  local q3 = sorted[math.floor(#sorted * 0.75) + 1]
+  if not q1 or not q3 or (q3 - q1) > mid * 0.2 then return false end
+
+  -- Ungated: present returns well before a panel period.
+  if mid < expect * 0.5 then return false end
+  -- Full-rate vsync: tight band around the panel period.
+  if mid >= expect * 0.85 and mid <= expect * 1.15 then return true end
+  -- Half-rate vsync (e.g. 30Hz on a 60Hz panel): tight band around 2x.
+  if mid >= expect * 1.85 and mid <= expect * 2.15 then return true end
   return false
 end
 

--- a/src/core/PresentProbe.lua
+++ b/src/core/PresentProbe.lua
@@ -1,20 +1,34 @@
--- Present sync: on every platform, measure whether love.window.setVSync
--- actually gates presents by timing present() itself with the software
--- limiter disabled (probe isolation — no self-measurement artifacts).
--- Linux may additionally bind a real wait (GLX OML / SGI on native X11)
--- when SDL's swap interval is a no-op.  Wayland: never duplicate
--- wl_surface.frame.  drmWaitVBlank is never used.
--- Ambiguous or unstable probe results prefer FrameCap over trusting sync.
+-- Present sync: probe whether presents are actually paced, then pick a
+-- strategy.  Fail closed to FrameCap whenever the signal is ambiguous.
+--
+-- PROBE SIGNAL = inter-present cadence (wall time between present ends),
+-- with FrameCap OFF for the whole calibration.  present()-block alone is
+-- not portable:
+--
+--   wayland   SDL sets EGL swapinterval 0 and waits on wl_surface.frame
+--             (often around swap).  Block timing alone false-failed here.
+--   windows   DWM / flip-model / VRR can return from Present early; the
+--             pacing shows up in the gap between presents (Ally X class).
+--   macos     Compositor / CVDisplayLink similarly; cadence is authoritative.
+--   android/ios  Choreographer-style wait; same cadence probe, no GLX.
+--   x11       GLX swapinterval often blocks in swap, but compositors
+--             (Picom, etc.) can defer — cadence still correct.  If ungated,
+--             try OML/SGI wait (native X11 only).
+--   xwayland/gamescope  Never bind GLX waits (WaitForMsc can hard-hang when
+--             the MSC ticks on a soft clock).  Ungated → FrameCap only.
+--   kmsdrm    Page-flip wait is SDL's; we never call drmWaitVBlank.  Ungated
+--             → FrameCap.
+--
+-- FrameCap sleep must never run during the probe or cadence grades our
+-- own limiter again.
 
 local PresentProbe = {}
 
--- Probe present() block time with FrameCap disabled during calibration.
--- Inter-frame gaps include limiter sleeps and must never be the signal.
+-- Cadence samples between presents while FrameCap is disabled.
 local PROBE_FRAMES = 45
+local PROBE_SKIP = 5          -- drop first samples (startup hitch)
 local INSTANT_MS = 0.0005
 local BLOCK_MS = 0.002
--- If a bound GLX wait ever blocks longer than this, drop it and fall back to
--- FrameCap.  Covers a stalled compositor without wedging the game loop.
 local WAIT_ABORT_S = 0.1
 
 -- Hot-path: a single cached closure, no ffi.C / string work inside it.
@@ -24,14 +38,14 @@ local state = {
   osLinux = false,
   ready = false,
   driver = nil,       -- "wayland" | "x11" | "kmsdrm" | ...
-  nest = nil,         -- "wayland" | "x11" | "xwayland" | "kmsdrm" | "unknown"
+  nest = nil,         -- platform nest string (see platformNest / detectNest)
   gamescope = false,
   gated = nil,        -- nil while probing, then true/false
   strategy = "none",  -- "none" | "sdl" | "oml" | "sgi"
   needsSoftwareCap = false,
   probeCount = 0,
-  presentStart = nil, -- love.timer time entering present(), probe only
-  intervals = nil,    -- present() block times while probing
+  lastPresent = nil,  -- love.timer time of previous present end (cadence)
+  intervals = nil,    -- inter-present cadence while probing
   glxGen = 0,
   bindGen = -1,
 }
@@ -109,10 +123,32 @@ local function detectNest(driver)
   return "unknown"
 end
 
--- Classify from present() block times.
--- Fail closed: anything ambiguous or non-deterministic → ungated → FrameCap.
--- Trusting a broken / VRR-jittery swap interval uncapped is far worse than
--- software pacing.
+-- Classify from inter-present cadence (probe runs with FrameCap off).
+-- Fail closed on ambiguity / jitter.  Prefer FrameCap over a false trust.
+local COMMON_HZ = { 60, 75, 90, 100, 120, 144, 165, 240 }
+
+local function resolveExpect(mid)
+  local hz = nil
+  local okRR, RR = pcall(require, "src.core.RefreshRate")
+  if okRR then hz = RR.hz() end
+  if hz and hz > 0 then return 1 / hz, hz end
+  -- SDL often reports refresh_rate=0 on some paths; infer a panel period
+  -- from the cadence itself against common rates so a working desktop is
+  -- not forced to UNAVAILABLE.
+  if not mid or mid <= 0 then return nil, nil end
+  for i = 1, #COMMON_HZ do
+    local c = COMMON_HZ[i]
+    local e = 1 / c
+    if mid >= e * 0.85 and mid <= e * 1.15 then return e, c end
+  end
+  for i = 1, #COMMON_HZ do
+    local c = COMMON_HZ[i]
+    local e = 1 / c
+    if mid >= e * 1.85 and mid <= e * 2.15 then return e, c end
+  end
+  return nil, nil
+end
+
 local function classifyGated(intervals)
   if not intervals or #intervals < 10 then return nil end
   local sorted = {}
@@ -121,24 +157,15 @@ local function classifyGated(intervals)
   local mid = sorted[math.floor(#sorted / 2) + 1]
   if not mid or mid <= 0 then return false end
 
-  -- Known panel Hz required before we ever trust hardware gating.
-  local hz = nil
-  local okRR, RR = pcall(require, "src.core.RefreshRate")
-  if okRR then hz = RR.hz() end
-  if not hz or hz <= 0 then return false end
-  local expect = 1 / hz
+  local expect = resolveExpect(mid)
+  if not expect then return false end
 
-  -- Spread check: real swap-interval lock is tight; CPU-bound or VRR jitter
-  -- spreads the distribution and must not pass as "gated".
   local q1 = sorted[math.floor(#sorted * 0.25) + 1]
   local q3 = sorted[math.floor(#sorted * 0.75) + 1]
   if not q1 or not q3 or (q3 - q1) > mid * 0.2 then return false end
 
-  -- Ungated: present returns well before a panel period.
   if mid < expect * 0.5 then return false end
-  -- Full-rate vsync: tight band around the panel period.
   if mid >= expect * 0.85 and mid <= expect * 1.15 then return true end
-  -- Half-rate vsync (e.g. 30Hz on a 60Hz panel): tight band around 2x.
   if mid >= expect * 1.85 and mid <= expect * 2.15 then return true end
   return false
 end
@@ -314,6 +341,9 @@ local function pickStrategy()
   end
 
   if not state.osLinux then
+    -- windows / macos / android / ios: never bind GLX.  Cadence probe is the
+    -- authority (DWM, Cocoa compositor, Choreographer can all defer the wait
+    -- past present() return).  Ungated → FrameCap only.
     if state.gated == true then
       state.strategy = "sdl"
     elseif state.gated == false then
@@ -388,6 +418,8 @@ local function platformNest()
   local osName = love.system.getOS()
   if osName == "Windows" then return "windows" end
   if osName == "OS X" or osName == "macOS" then return "macos" end
+  if osName == "Android" then return "android" end
+  if osName == "iOS" then return "ios" end
   if osName == "Linux" then return detectNest(state.driver) end
   return osName:lower()
 end
@@ -424,7 +456,7 @@ function PresentProbe.reset()
   state.strategy = "none"
   state.needsSoftwareCap = false
   state.probeCount = 0
-  state.presentStart = nil
+  state.lastPresent = nil
   state.intervals = nil
   state.glxGen = state.glxGen + 1
   state.bindGen = -1
@@ -440,7 +472,7 @@ function PresentProbe.onDisplayChange()
   state.gated = nil
   state.probeCount = 0
   state.intervals = {}
-  state.presentStart = nil
+  state.lastPresent = nil
   state.strategy = "none"
   state.needsSoftwareCap = false
   glLib = nil
@@ -453,7 +485,7 @@ function PresentProbe.reprobe()
   state.gated = nil
   state.probeCount = 0
   state.intervals = {}
-  state.presentStart = nil
+  state.lastPresent = nil
   waitFn = nil
   state.glxGen = state.glxGen + 1
   state.bindGen = -1
@@ -470,8 +502,9 @@ local function abandonWait()
 end
 
 -- Hot path: must stay allocation-free and avoid ffi.C / require.
--- Records presentStart AFTER any GLX wait so the probe measures SDL/GL
--- swap-interval block time alone (FrameCap sleep lives after notePresent).
+-- Cadence probe: wall time between present ends.  Safe only while FrameCap
+-- is off (PresentSync probe isolation).  present()-block alone is not enough
+-- on Wayland, where the wait often lands on the next frame callback.
 function PresentProbe.waitBeforePresent()
   local fn = waitFn
   if fn then
@@ -481,9 +514,6 @@ function PresentProbe.waitBeforePresent()
     if not ok or (t0 and t1 and (t1 - t0) > WAIT_ABORT_S) then
       abandonWait()
     end
-  end
-  if state.gated == nil and love.timer and love.timer.getTime then
-    state.presentStart = love.timer.getTime()
   end
 end
 
@@ -500,20 +530,23 @@ function PresentProbe.notePresent()
     return
   end
 
-  local start = state.presentStart
-  state.presentStart = nil
   local now = love.timer and love.timer.getTime and love.timer.getTime()
-  if not start or not now then return end
-  local block = now - start
+  if not now then return end
+  local last = state.lastPresent
+  state.lastPresent = now
+  if not last then return end
+  local gap = now - last
   -- Discard hitches / timer glitches; keep sampling until we have clean ones.
-  if block <= 0 or block > 0.25 then return end
+  if gap <= 0 or gap > 0.25 then return end
+  -- Skip the first few presents so window/map boot cost does not widen IQR.
+  state.probeCount = (state.probeCount or 0) + 1
+  if state.probeCount <= PROBE_SKIP then return end
   local intervals = state.intervals
   if not intervals then
     intervals = {}
     state.intervals = intervals
   end
-  intervals[#intervals + 1] = block
-  state.probeCount = #intervals
+  intervals[#intervals + 1] = gap
   if #intervals < PROBE_FRAMES then return end
 
   state.gated = classifyGated(intervals)

--- a/src/core/PresentSync.lua
+++ b/src/core/PresentSync.lua
@@ -1,6 +1,10 @@
 -- Cross-platform present sync: probe whether vsync actually gates presents,
 -- delegate Linux-specific GLX waits to PresentProbe, and decide when FixedStep
 -- may snap dt to the panel refresh (DISPLAY + working sync only).
+--
+-- During DISPLAY+vsync probe warmup, FrameCap still paces at 60 as a thermal
+-- net.  The probe times present() block duration (not inter-frame gaps), so
+-- that sleep does not contaminate the gated/ungated verdict.
 
 local PresentSync = {}
 
@@ -25,6 +29,8 @@ function PresentSync.probingDisplaySync()
   return FrameCap.current == FrameCap.DISPLAY and VSync.isOn()
 end
 
+-- Software FrameCap is required when sync failed, OR while DISPLAY+vsync is
+-- still probing (thermal net only — probe measures present() block time).
 function PresentSync.needsSoftwareCap()
   if probe().needsSoftwareCap() then return true end
   return PresentSync.probingDisplaySync()
@@ -63,6 +69,7 @@ end
 -- FixedStep.refreshPeriod is only set when logic cadence should track the
 -- display.  Snapping dt to 144Hz while software-pacing at 60 (#1958) or
 -- with vsync off is what caused the irregular frame pacing regression.
+-- Also withheld during probe warmup (needsSoftwareCap includes probing).
 function PresentSync.logicRefreshPeriod()
   local FrameCap = require("src.core.FrameCap")
   local VSync = require("src.core.VSync")

--- a/src/core/PresentSync.lua
+++ b/src/core/PresentSync.lua
@@ -1,11 +1,11 @@
 -- Cross-platform present sync: layered fail-safe for vsync / frame pacing.
 --
 -- Defense in depth:
---   1. Probe isolation — calibration measures present() block time with no
---      FrameCap sleep and no FixedStep refresh snap, so the probe cannot
---      grade its own limiter.
---   2. Tight classification — only a stable, panel-aligned present() block
---      distribution counts as hardware-gated; anything else fails closed.
+--   1. Probe isolation — calibration runs with FrameCap OFF and no FixedStep
+--      refresh snap.  Cadence between presents is the signal (Wayland often
+--      returns from present() immediately and waits on the next frame).
+--   2. Tight classification — stable, panel-aligned cadence only; jitter /
+--      unknown rates fail closed.
 --   3. Fallback cascade — ungated / failed / abandoned waits force FrameCap
 --      immediately; logic never snaps to panel Hz unless sync is confirmed.
 --   4. (FixedStep) catch-up debt is hard-capped so speed multipliers cannot

--- a/src/core/PresentSync.lua
+++ b/src/core/PresentSync.lua
@@ -1,10 +1,15 @@
--- Cross-platform present sync: probe whether vsync actually gates presents,
--- delegate Linux-specific GLX waits to PresentProbe, and decide when FixedStep
--- may snap dt to the panel refresh (DISPLAY + working sync only).
+-- Cross-platform present sync: layered fail-safe for vsync / frame pacing.
 --
--- During DISPLAY+vsync probe warmup, FrameCap still paces at 60 as a thermal
--- net.  The probe times present() block duration (not inter-frame gaps), so
--- that sleep does not contaminate the gated/ungated verdict.
+-- Defense in depth:
+--   1. Probe isolation — calibration measures present() block time with no
+--      FrameCap sleep and no FixedStep refresh snap, so the probe cannot
+--      grade its own limiter.
+--   2. Tight classification — only a stable, panel-aligned present() block
+--      distribution counts as hardware-gated; anything else fails closed.
+--   3. Fallback cascade — ungated / failed / abandoned waits force FrameCap
+--      immediately; logic never snaps to panel Hz unless sync is confirmed.
+--   4. (FixedStep) catch-up debt is hard-capped so speed multipliers cannot
+--      spiral into input-starving multi-frame dumps.
 
 local PresentSync = {}
 
@@ -20,7 +25,7 @@ function PresentSync.notePresent()
   probe().notePresent()
 end
 
--- True while the probe still has no gated/ungated verdict for DISPLAY+vsync.
+-- True while DISPLAY+vsync still has no gated/ungated verdict.
 function PresentSync.probingDisplaySync()
   local status = probe().status()
   if status.gated ~= nil then return false end
@@ -29,19 +34,27 @@ function PresentSync.probingDisplaySync()
   return FrameCap.current == FrameCap.DISPLAY and VSync.isOn()
 end
 
--- Software FrameCap is required when sync failed, OR while DISPLAY+vsync is
--- still probing (thermal net only — probe measures present() block time).
+-- Software FrameCap is required only after sync has failed (or a bound wait
+-- was abandoned).  During probe we deliberately do NOT soft-cap: the
+-- calibration must observe the raw swapchain, not our own limiter.
 function PresentSync.needsSoftwareCap()
-  if probe().needsSoftwareCap() then return true end
-  return PresentSync.probingDisplaySync()
+  return probe().needsSoftwareCap() == true
+end
+
+-- Hardware gating is trusted only after a finished probe says gated and the
+-- fallback flag is clear.  Probing or failed → not confirmed.
+function PresentSync.displaySyncConfirmed()
+  if PresentSync.needsSoftwareCap() then return false end
+  local status = probe().status()
+  return status.gated == true
 end
 
 -- Vsync cannot be turned on usefully once the probe has failed; the row still
--- allows stepping to OFF.  Warmup (probingDisplaySync) does not block the row.
+-- allows stepping to OFF.  Warmup does not block the row.
 function PresentSync.vsyncEnableBlocked()
   local VSync = require("src.core.VSync")
   if not VSync.isOn() then return false end
-  return probe().needsSoftwareCap()
+  return PresentSync.needsSoftwareCap()
 end
 
 function PresentSync.vsyncStepAllowed(mode, dir)
@@ -66,10 +79,8 @@ function PresentSync.status()
   return probe().status()
 end
 
--- FixedStep.refreshPeriod is only set when logic cadence should track the
--- display.  Snapping dt to 144Hz while software-pacing at 60 (#1958) or
--- with vsync off is what caused the irregular frame pacing regression.
--- Also withheld during probe warmup (needsSoftwareCap includes probing).
+-- FixedStep.refreshPeriod only when display sync is confirmed working.
+-- Never during probe, never when FrameCap is the live pacing path (#1958).
 function PresentSync.logicRefreshPeriod()
   local FrameCap = require("src.core.FrameCap")
   local VSync = require("src.core.VSync")
@@ -78,11 +89,15 @@ function PresentSync.logicRefreshPeriod()
 
   if cap == FrameCap.DISPLAY then
     if not VSync.isOn() then return nil end
-    if PresentSync.needsSoftwareCap() then return nil end
+    if not PresentSync.displaySyncConfirmed() then return nil end
     return RefreshRate.period()
   end
 
   if not cap or cap <= 0 then return nil end
+  -- Numeric cap matching panel Hz may snap; still withhold while a DISPLAY
+  -- probe failure forced the software limiter (cap may still read DISPLAY
+  -- until main.lua overrides the live sleep budget).
+  if PresentSync.needsSoftwareCap() then return nil end
 
   local hz = RefreshRate.hz()
   if hz and cap == hz then return 1 / hz end

--- a/tests/drivers/linux_present_probe.lua
+++ b/tests/drivers/linux_present_probe.lua
@@ -1,5 +1,6 @@
 -- Live PresentProbe driver. Boots far enough to present, waits for the
--- gated/ungated classification, then prints the result and quits.
+-- gated/ungated classification (present() block time, not inter-frame gaps),
+-- then prints the result and quits.
 --
 --   cd /home/autumn/src/gen1recomp-gaia
 --   POKEPORT_DRIVER=tests/drivers/linux_present_probe.lua POKEPORT_TOUCH=0 \

--- a/tests/engine/present_probe.lua
+++ b/tests/engine/present_probe.lua
@@ -43,11 +43,11 @@ withHz(90, function()
   T.eq(LPS._testClassifyGated(locked90), true, "1/90 presents count as gated")
 end)
 
--- Unknown panel Hz: a 90Hz-looking block is NOT trusted (safe FrameCap fallback)
+-- Unknown SDL Hz: stable cadence at a common rate still gates via inference.
 local locked90unknown = {}
 for i = 1, 20 do locked90unknown[i] = 1 / 90 end
-T.eq(LPS._testClassifyGated(locked90unknown), false,
-  "without a panel Hz, 1/90 is inconclusive and prefers FrameCap")
+T.eq(LPS._testClassifyGated(locked90unknown), true,
+  "without SDL Hz, stable 1/90 cadence still gates via common-rate inference")
 
 withHz(60, function()
   local jittery = {}
@@ -220,40 +220,46 @@ LPS.reset()
 LPS.waitBeforePresent()
 T.eq(true, true, "waitBeforePresent tolerates a cold module")
 
--- Probe measures present() block time, not inter-frame gaps: FrameCap sleep
--- after notePresent must not make a broken swap look gated.
+-- Cadence probe (FrameCap off): compositor-deferred waits (Wayland frame
+-- callback, Win DWM / flip-model, macOS compositor) still gate when the gap
+-- between presents locks to the panel, even if present() returns immediately.
 LPS.reset()
 LPS._testSetState({ osLinux = false, ready = true, nest = "windows", clearGated = true })
 local t = 0
 love.timer = love.timer or {}
 local savedGetTime = love.timer.getTime
 love.timer.getTime = function() return t end
-withHz(60, function()
-  for i = 1, 45 do
-    -- Instant present() (broken vsync), then a fake 16ms FrameCap sleep afterward.
+-- Broken: ~1ms between presents (uncapped spin)
+for i = 1, 60 do
+  LPS.waitBeforePresent()
+  LPS.notePresent()
+  t = t + 0.001
+end
+local st = LPS.status()
+T.eq(st.gated, false, "uncapped ~1ms cadence stays ungated")
+T.eq(LPS.needsSoftwareCap(), true, "so FrameCap becomes the thermal net")
+
+for _, nest in ipairs({ "wayland", "windows", "macos", "android", "ios" }) do
+  LPS.reset()
+  LPS._testSetState({
+    osLinux = (nest == "wayland"),
+    ready = true,
+    nest = nest,
+    clearGated = true,
+    needsSoftwareCap = false,
+  })
+  t = 0
+  for i = 1, 60 do
     LPS.waitBeforePresent()
-    t = t + 0.001
     LPS.notePresent()
     t = t + 1 / 60
   end
-  local st = LPS.status()
-  T.eq(st.gated, false,
-    "instant present() stays ungated even when FrameCap sleeps 16ms after")
-  T.eq(LPS.needsSoftwareCap(), true, "so FrameCap remains the thermal net")
-
-  LPS.reset()
-  LPS._testSetState({ osLinux = false, ready = true, nest = "windows", clearGated = true })
-  t = 0
-  for i = 1, 45 do
-    LPS.waitBeforePresent()
-    t = t + 1 / 60  -- present() itself blocks a full panel period
-    LPS.notePresent()
-    t = t + 1 / 60  -- trailing FrameCap sleep is ignored by the probe
-  end
   st = LPS.status()
-  T.eq(st.gated, true, "a present() that blocks a panel period counts as gated")
-  T.eq(LPS.needsSoftwareCap(), false, "and does not force FrameCap")
-end)
+  T.eq(st.gated, true,
+    nest .. ": compositor-paced ~1/60 cadence counts as gated")
+  T.eq(LPS.needsSoftwareCap(), false,
+    nest .. ": does not force FrameCap when cadence is locked")
+end
 
 -- A bound wait that overruns abandons to FrameCap instead of wedging.
 LPS.reset()

--- a/tests/engine/present_probe.lua
+++ b/tests/engine/present_probe.lua
@@ -11,13 +11,43 @@ local fast = {}
 for i = 1, 20 do fast[i] = 0.001 end
 T.eq(LPS._testClassifyGated(fast), false, "sub-ms presents count as ungated")
 
-local locked60 = {}
-for i = 1, 20 do locked60[i] = 1 / 60 end
-T.eq(LPS._testClassifyGated(locked60), true, "1/60 presents count as gated")
+local function withHz(hz, fn)
+  package.loaded["src.core.RefreshRate"] = {
+    hz = function() return hz end,
+    period = function() return 1 / hz end,
+    mismatch = function() return nil end,
+    sample = function() return false end,
+    reset = function() end,
+  }
+  local ok, err = pcall(fn)
+  package.loaded["src.core.RefreshRate"] = nil
+  if not ok then error(err) end
+end
 
-local locked90 = {}
-for i = 1, 20 do locked90[i] = 1 / 90 end
-T.eq(LPS._testClassifyGated(locked90), true, "1/90 presents count as gated")
+withHz(60, function()
+  local locked60 = {}
+  for i = 1, 20 do locked60[i] = 1 / 60 end
+  T.eq(LPS._testClassifyGated(locked60), true, "1/60 presents count as gated")
+  local half60 = {}
+  for i = 1, 20 do half60[i] = 2 / 60 end
+  T.eq(LPS._testClassifyGated(half60), true, "half-rate 30Hz on 60Hz counts as gated")
+  local ambiguous = {}
+  for i = 1, 20 do ambiguous[i] = 0.010 end
+  T.eq(LPS._testClassifyGated(ambiguous), false,
+    "10ms CPU-bound presents are ungated (not evidence of sync)")
+end)
+
+withHz(90, function()
+  local locked90 = {}
+  for i = 1, 20 do locked90[i] = 1 / 90 end
+  T.eq(LPS._testClassifyGated(locked90), true, "1/90 presents count as gated")
+end)
+
+-- Unknown panel Hz: a 90Hz-looking block is NOT trusted (safe FrameCap fallback)
+local locked90unknown = {}
+for i = 1, 20 do locked90unknown[i] = 1 / 90 end
+T.eq(LPS._testClassifyGated(locked90unknown), false,
+  "without a panel Hz, 1/90 is inconclusive and prefers FrameCap")
 
 T.eq(LPS._testClassifyGated({ 0.016, 0.017 }), nil,
   "too few samples stay unclassified")
@@ -181,10 +211,60 @@ LPS.reset()
 LPS.waitBeforePresent()
 T.eq(true, true, "waitBeforePresent tolerates a cold module")
 
+-- Probe measures present() block time, not inter-frame gaps: FrameCap sleep
+-- after notePresent must not make a broken swap look gated.
+LPS.reset()
+LPS._testSetState({ osLinux = false, ready = true, nest = "windows", clearGated = true })
+local t = 0
+love.timer = love.timer or {}
+local savedGetTime = love.timer.getTime
+love.timer.getTime = function() return t end
+for i = 1, 45 do
+  -- Instant present() (broken vsync), then a fake 16ms FrameCap sleep afterward.
+  LPS.waitBeforePresent()
+  t = t + 0.001
+  LPS.notePresent()
+  t = t + 1 / 60
+end
+local st = LPS.status()
+T.eq(st.gated, false,
+  "instant present() stays ungated even when FrameCap sleeps 16ms after")
+T.eq(LPS.needsSoftwareCap(), true, "so FrameCap remains the thermal net")
+
+LPS.reset()
+LPS._testSetState({ osLinux = false, ready = true, nest = "windows", clearGated = true })
+t = 0
+for i = 1, 45 do
+  LPS.waitBeforePresent()
+  t = t + 1 / 60  -- present() itself blocks a full panel period
+  LPS.notePresent()
+  t = t + 1 / 60  -- trailing FrameCap sleep is ignored by the probe
+end
+st = LPS.status()
+T.eq(st.gated, true, "a present() that blocks a panel period counts as gated")
+T.eq(LPS.needsSoftwareCap(), false, "and does not force FrameCap")
+
+-- A bound wait that overruns abandons to FrameCap instead of wedging.
+LPS.reset()
+LPS._testSetState({
+  osLinux = true, ready = true, nest = "x11", gated = true,
+  strategy = "oml", needsSoftwareCap = false,
+  waitFn = function()
+    t = t + 0.2  -- > WAIT_ABORT_S
+  end,
+})
+t = 0
+LPS.waitBeforePresent()
+T.eq(LPS.needsSoftwareCap(), true, "an overrunning GLX wait falls back to FrameCap")
+T.eq(LPS.status().strategy, "none", "and clears the wait strategy")
+
+love.timer.getTime = savedGetTime
+
 -- status() on non-Linux stays inert (whatever OS the harness reports)
 LPS.reset()
 local status = LPS.status()
 T.eq(type(status.strategy), "string", "status always reports a strategy string")
 T.eq(type(status.linux), "boolean", "and whether this process is Linux")
 
+LPS.reset()
 T.finish("present probe")

--- a/tests/engine/present_probe.lua
+++ b/tests/engine/present_probe.lua
@@ -49,6 +49,15 @@ for i = 1, 20 do locked90unknown[i] = 1 / 90 end
 T.eq(LPS._testClassifyGated(locked90unknown), false,
   "without a panel Hz, 1/90 is inconclusive and prefers FrameCap")
 
+withHz(60, function()
+  local jittery = {}
+  -- Median near 1/60 but IQR > 20% of mid → non-deterministic, fail closed.
+  for i = 1, 10 do jittery[i] = 0.008 end
+  for i = 11, 20 do jittery[i] = 0.024 end
+  T.eq(LPS._testClassifyGated(jittery), false,
+    "high present-time variance fails closed to ungated")
+end)
+
 T.eq(LPS._testClassifyGated({ 0.016, 0.017 }), nil,
   "too few samples stay unclassified")
 
@@ -219,30 +228,32 @@ local t = 0
 love.timer = love.timer or {}
 local savedGetTime = love.timer.getTime
 love.timer.getTime = function() return t end
-for i = 1, 45 do
-  -- Instant present() (broken vsync), then a fake 16ms FrameCap sleep afterward.
-  LPS.waitBeforePresent()
-  t = t + 0.001
-  LPS.notePresent()
-  t = t + 1 / 60
-end
-local st = LPS.status()
-T.eq(st.gated, false,
-  "instant present() stays ungated even when FrameCap sleeps 16ms after")
-T.eq(LPS.needsSoftwareCap(), true, "so FrameCap remains the thermal net")
+withHz(60, function()
+  for i = 1, 45 do
+    -- Instant present() (broken vsync), then a fake 16ms FrameCap sleep afterward.
+    LPS.waitBeforePresent()
+    t = t + 0.001
+    LPS.notePresent()
+    t = t + 1 / 60
+  end
+  local st = LPS.status()
+  T.eq(st.gated, false,
+    "instant present() stays ungated even when FrameCap sleeps 16ms after")
+  T.eq(LPS.needsSoftwareCap(), true, "so FrameCap remains the thermal net")
 
-LPS.reset()
-LPS._testSetState({ osLinux = false, ready = true, nest = "windows", clearGated = true })
-t = 0
-for i = 1, 45 do
-  LPS.waitBeforePresent()
-  t = t + 1 / 60  -- present() itself blocks a full panel period
-  LPS.notePresent()
-  t = t + 1 / 60  -- trailing FrameCap sleep is ignored by the probe
-end
-st = LPS.status()
-T.eq(st.gated, true, "a present() that blocks a panel period counts as gated")
-T.eq(LPS.needsSoftwareCap(), false, "and does not force FrameCap")
+  LPS.reset()
+  LPS._testSetState({ osLinux = false, ready = true, nest = "windows", clearGated = true })
+  t = 0
+  for i = 1, 45 do
+    LPS.waitBeforePresent()
+    t = t + 1 / 60  -- present() itself blocks a full panel period
+    LPS.notePresent()
+    t = t + 1 / 60  -- trailing FrameCap sleep is ignored by the probe
+  end
+  st = LPS.status()
+  T.eq(st.gated, true, "a present() that blocks a panel period counts as gated")
+  T.eq(LPS.needsSoftwareCap(), false, "and does not force FrameCap")
+end)
 
 -- A bound wait that overruns abandons to FrameCap instead of wedging.
 LPS.reset()

--- a/tests/engine/present_sync_logic.lua
+++ b/tests/engine/present_sync_logic.lua
@@ -36,11 +36,14 @@ PresentProbe._testSetState({ osLinux = false, ready = true, gated = false,
   needsSoftwareCap = true, nest = "windows" })
 T.eq(PresentSync.logicRefreshPeriod(), nil,
   "DISPLAY with broken sync falls back to software cap, not panel snap")
+T.check(PresentSync.needsSoftwareCap(), "failed sync trips the FrameCap cascade")
+T.check(not PresentSync.displaySyncConfirmed(), "and is not treated as confirmed")
 
 PresentProbe._testSetState({ osLinux = false, ready = true, gated = true,
   needsSoftwareCap = false, nest = "windows" })
 T.eq(PresentSync.logicRefreshPeriod(), 1 / 144,
   "DISPLAY with working sync tracks the panel")
+T.check(PresentSync.displaySyncConfirmed(), "gated+clear softcap is confirmed sync")
 
 FrameCap.apply(60)
 T.eq(PresentSync.logicRefreshPeriod(), nil,
@@ -53,22 +56,27 @@ T.eq(PresentSync.logicRefreshPeriod(), 1 / 144,
 PresentSync.applyFixedStepPeriod()
 T.eq(FixedStep.refreshPeriod, 1 / 144, "applyFixedStepPeriod writes the module field")
 
+-- Probe isolation: during calibration we do NOT soft-cap (raw swapchain),
+-- and we never snap logic until sync is confirmed.
 FrameCap.apply(FrameCap.DISPLAY)
 VSync.apply("on")
 PresentProbe._testSetState({ osLinux = false, ready = true, clearGated = true,
   needsSoftwareCap = false, nest = "windows" })
 T.check(PresentSync.probingDisplaySync(), "DISPLAY+vsync probes before a verdict")
-T.check(PresentSync.needsSoftwareCap(),
-  "warmup still uses FrameCap as a thermal net during the probe")
+T.check(not PresentSync.needsSoftwareCap(),
+  "probe isolation: FrameCap is not forced during calibration")
+T.check(not PresentSync.displaySyncConfirmed(), "unconfirmed while still probing")
 T.eq(PresentSync.logicRefreshPeriod(), nil, "and does not snap logic during warmup")
 
 PresentProbe._testSetState({ gated = true, needsSoftwareCap = false })
 T.check(not PresentSync.probingDisplaySync(), "a finished probe clears warmup")
-T.check(not PresentSync.needsSoftwareCap(), "so software cap stops once sync is confirmed")
+T.check(PresentSync.displaySyncConfirmed(), "gated verdict confirms display sync")
+T.check(not PresentSync.needsSoftwareCap(), "so software cap stays off once sync is confirmed")
 
 -- Broken sync after an honest ungated probe keeps the thermal net and no snap.
 PresentProbe._testSetState({ gated = false, needsSoftwareCap = true })
 T.check(PresentSync.needsSoftwareCap(), "ungated DISPLAY keeps FrameCap")
+T.check(not PresentSync.displaySyncConfirmed(), "ungated is never confirmed")
 T.eq(PresentSync.logicRefreshPeriod(), nil, "and never snaps logic to the panel")
 
 VSync.apply("on")
@@ -82,12 +90,21 @@ T.check(not PresentSync.vsyncStepAllowed("on", -1),
 FixedStep.refreshPeriod = 1 / 60
 local steps = 0
 FixedStep:init(function() steps = steps + 1 end)
-FixedStep.maxAccum = 0.25
+FixedStep.maxAccum = FixedStep.catchupLimit(4)
 FixedStep:update(1 / 60, 4)
 T.eq(steps, 4, "4X on a snapped 60Hz frame runs four logic steps")
 steps = 0
+FixedStep.maxAccum = FixedStep.catchupLimit(2)
 FixedStep:update(1 / 60, 2)
 T.eq(steps, 2, "and 2X runs two")
+
+-- Catch-up debt hard ceiling: high speed cannot raise maxAccum past MAX_ACCUM.
+T.eq(FixedStep.catchupLimit(1), FixedStep.STEP * 2,
+  "1X catch-up floor is two steps")
+T.eq(FixedStep.catchupLimit(4), 4 * FixedStep.STEP * 1.5,
+  "4X catch-up matches one frame of target work")
+T.eq(FixedStep.catchupLimit(200), FixedStep.MAX_ACCUM,
+  "200X catch-up is hard-capped at MAX_ACCUM (no input-starving spiral)")
 FixedStep.refreshPeriod = nil
 
 love.window.getVSync, love.window.setVSync = nil, nil

--- a/tests/engine/present_sync_logic.lua
+++ b/tests/engine/present_sync_logic.lua
@@ -58,19 +58,37 @@ VSync.apply("on")
 PresentProbe._testSetState({ osLinux = false, ready = true, clearGated = true,
   needsSoftwareCap = false, nest = "windows" })
 T.check(PresentSync.probingDisplaySync(), "DISPLAY+vsync probes before a verdict")
-T.check(PresentSync.needsSoftwareCap(), "warmup uses FrameCap until the probe finishes")
+T.check(PresentSync.needsSoftwareCap(),
+  "warmup still uses FrameCap as a thermal net during the probe")
 T.eq(PresentSync.logicRefreshPeriod(), nil, "and does not snap logic during warmup")
 
 PresentProbe._testSetState({ gated = true, needsSoftwareCap = false })
 T.check(not PresentSync.probingDisplaySync(), "a finished probe clears warmup")
 T.check(not PresentSync.needsSoftwareCap(), "so software cap stops once sync is confirmed")
 
+-- Broken sync after an honest ungated probe keeps the thermal net and no snap.
+PresentProbe._testSetState({ gated = false, needsSoftwareCap = true })
+T.check(PresentSync.needsSoftwareCap(), "ungated DISPLAY keeps FrameCap")
+T.eq(PresentSync.logicRefreshPeriod(), nil, "and never snaps logic to the panel")
+
 VSync.apply("on")
-PresentProbe._testSetState({ needsSoftwareCap = true })
+PresentProbe._testSetState({ needsSoftwareCap = true, gated = false })
 T.check(PresentSync.vsyncEnableBlocked(), "broken sync blocks enabling vsync")
 T.check(PresentSync.vsyncStepAllowed("on", 1), "but one step to OFF is allowed")
 T.check(not PresentSync.vsyncStepAllowed("on", -1),
   "while a step that stays on/adaptive is not")
+
+-- FixedStep snaps wall-clock dt, then applies speed (not the reverse).
+FixedStep.refreshPeriod = 1 / 60
+local steps = 0
+FixedStep:init(function() steps = steps + 1 end)
+FixedStep.maxAccum = 0.25
+FixedStep:update(1 / 60, 4)
+T.eq(steps, 4, "4X on a snapped 60Hz frame runs four logic steps")
+steps = 0
+FixedStep:update(1 / 60, 2)
+T.eq(steps, 2, "and 2X runs two")
+FixedStep.refreshPeriod = nil
 
 love.window.getVSync, love.window.setVSync = nil, nil
 VSync.reset()

--- a/tests/engine/present_sync_logic.lua
+++ b/tests/engine/present_sync_logic.lua
@@ -56,7 +56,7 @@ T.eq(PresentSync.logicRefreshPeriod(), 1 / 144,
 PresentSync.applyFixedStepPeriod()
 T.eq(FixedStep.refreshPeriod, 1 / 144, "applyFixedStepPeriod writes the module field")
 
--- Probe isolation: during calibration we do NOT soft-cap (raw swapchain),
+-- Probe isolation: during calibration we do NOT soft-cap (raw cadence),
 -- and we never snap logic until sync is confirmed.
 FrameCap.apply(FrameCap.DISPLAY)
 VSync.apply("on")


### PR DESCRIPTION
the display sync stuff was probing whether vsync was actually working, but it kept measuring the wrong thing. early on it timed the gap between frames (which includes our own FrameCap sleep 😅) so it always looked gated even when the driver was ignoring vsync. then we switched to present() block time, which still fails closed on wayland/dwm/cocoa/android where present returns early. so now the probe looks at inter-present cadence instead, and if its unclear we just stay on capped 60 and dont snap logic to panel hz.
also fixed fixedstep so it snaps wall-clock dt before applying speed, and hard-capped catch-up debt so 2–4x doesnt turn a bad path into hitching / dropped input.
closes #1910
closes #1958