### PR TITLE
Implement idle render governor and update vsync handling for handheld builds

### DIFF
--- a/build-linux-arm-sbc.sh
+++ b/build-linux-arm-sbc.sh
@@ -358,9 +358,9 @@ export SDL_AUDIO_SAMPLES=1024
 # the handheld speaker sounds effectively identical.
 export POKEPORT_AUDIO_RATE=22050
 
-# Idle-power render governor: after 10s with no input on static screens,
-# presentation drops to IDLE_FPS, cutting idle CPU/GPU compositing ~6x.
-# Any button press restores full framerate next frame.
+# Idle-power render governor: after IDLE_AFTER seconds with no input on static
+# screens, presentation drops to IDLE_FPS (game logic and audio stay full speed).
+export POKEPORT_IDLE_AFTER=10
 export POKEPORT_IDLE_FPS=6
 
 # Memory allocator tuning (limit arena fragmentation on 1GB RAM SBCs)

--- a/conf.lua
+++ b/conf.lua
@@ -62,16 +62,10 @@ function love.conf(t)
     t.window.minheight = 360
   end
   t.version = love._os == "iOS" and "12.0" or "11.5"
-  -- On Linux handhelds with KMSDRM/EGL, driver vsync blocks the CPU thread with
-  -- busy-waiting spinloops inside eglSwapBuffers. Disabling driver vsync allows
-  -- love.run to perform kernel nanosleep(), dropping idle CPU from 25% to 4%.
-  if os.getenv("HANDHELD") == "1" or os.getenv("PORTMASTER") == "1"
-      or os.getenv("POKEPORT_HANDHELD") == "1" or os.getenv("TRIMUI") == "1"
-      or os.getenv("MUOS") == "1" or os.getenv("KNULLI") == "1" then
-    t.window.vsync = 0
-  else
-    t.window.vsync = 1
-  end
+  -- Driver vsync stays on everywhere (including KMSDRM handhelds) so
+  -- PresentSync can probe cadence and pace via the panel.  Turning it off
+  -- here bypassed that stack and forced the FrameCap 1 ms polling loop.
+  t.window.vsync = 1
   t.modules.audio = not companion
   t.modules.joystick = not companion
   t.modules.physics = false

--- a/docs/linux-arm-sbc.md
+++ b/docs/linux-arm-sbc.md
@@ -36,10 +36,10 @@ Suspend/resume uses the existing LÖVE focus/visibility lifecycle: input is rese
 
 ## Power and Performance Tuning
 
-The handheld build applies several optimizations to reduce power draw and ensure smooth 60 FPS frame pacing on low-power ARM SoCs:
+The handheld build applies several optimizations to reduce power draw while keeping smooth frame pacing on low-power ARM SoCs:
 
-- **KMSDRM / EGL Vsync Fix**: Handheld builds disable driver vsync (`vsync = 0`) to prevent GPU driver busy-wait spinloops in `eglSwapBuffers`, allowing `nanosleep()` and dropping idle CPU usage from ~25% to ~4%.
-- **Idle Render Governor**: Drops presentation rate when a static screen (menus, text dialogs, stationary scenes) receives no input, cutting compositing work ~6x while preserving full 60 Hz game and audio clocks. Any button press restores full framerate immediately.
+- **PresentSync / driver vsync**: Handheld builds keep driver vsync enabled so the unified present-sync stack can probe cadence and pace through the panel (KMSDRM page-flip wait). Disabling vsync here bypassed that path and forced the FrameCap 1 ms polling loop at 60 FPS.
+- **Idle Render Governor**: After `POKEPORT_IDLE_AFTER` seconds without input on static in-game screens, presentation drops to `POKEPORT_IDLE_FPS` while game logic and audio stay at full speed. Any button press restores full framerate on the next frame.
 - **Sample Rate Scaling**: Audio synthesis is tuned to 22.05 kHz by default (`POKEPORT_AUDIO_RATE=22050`), halving synthesis CPU overhead on Cortex-A53 cores with no audible quality loss on handheld speakers.
 - **Dynamic CPU Governor**: Defaults to `schedutil` instead of pinning `performance` on all cores, reducing thermals and extending battery life.
 

--- a/main.lua
+++ b/main.lua
@@ -1381,6 +1381,17 @@ local function pacingEnabled()
   return true
 end
 
+-- Shane #1830 idle render governor (POKEPORT_IDLE_*): drop presentation rate
+-- on static in-game screens; game logic and audio stay at full speed.
+local function idlePresentationCap(idleFor)
+  local after = tonumber(os.getenv("POKEPORT_IDLE_AFTER"))
+  local fps = tonumber(os.getenv("POKEPORT_IDLE_FPS"))
+  if not after or after <= 0 or not fps or fps <= 0 then return nil end
+  if idleFor < after then return nil end
+  if Importer or Prelaunch or editorMode or not Game then return nil end
+  return fps
+end
+
 function love.run()
   if love.load then love.load(love.arg.parseGameArguments(arg), arg) end
 
@@ -1388,6 +1399,7 @@ function love.run()
   if love.timer then love.timer.step() end
 
   local FrameCap = require("src.core.FrameCap")
+  FrameCap.bootHandheld()
   local RefreshRate = require("src.core.RefreshRate")
   local FixedStep = require("src.core.FixedStep")
   local VSync = require("src.core.VSync")
@@ -1400,6 +1412,18 @@ function love.run()
   local dt = 0
   local idleFor = 0
   local SLEEP_FLOOR = 0.001
+  -- Sleep until deadline with one or two kernel waits, not 1 ms polling.
+  local function sleepUntilFrame(deadline)
+    while true do
+      local remaining = deadline - love.timer.getTime()
+      if remaining <= SLEEP_FLOOR then break end
+      if remaining > 0.004 then
+        love.timer.sleep(remaining - 0.002)
+      else
+        love.timer.sleep(remaining)
+      end
+    end
+  end
   local WAKE = {
     keypressed = true, keyreleased = true, textinput = true,
     mousepressed = true, mousereleased = true, mousemoved = true,
@@ -1460,7 +1484,11 @@ function love.run()
       cap = 10
     elseif Importer and (not focused or idleFor > 30) then
       cap = 15
-    elseif cap == FrameCap.DISPLAY and not VSync.isOn() then
+    else
+      local idleCap = idlePresentationCap(idleFor)
+      if idleCap then cap = idleCap end
+    end
+    if cap == FrameCap.DISPLAY and not VSync.isOn() then
       cap = FrameCap.DEFAULT
     elseif cap == FrameCap.DISPLAY and PresentSync.needsSoftwareCap() then
       -- Fallback cascade: probe failed / wait abandoned / sync non-
@@ -1482,11 +1510,11 @@ function love.run()
     PresentSync.applyFixedStepPeriod()
 
     if love.timer then
-      if paced and cap ~= FrameCap.DISPLAY then
+      if paced and cap ~= FrameCap.DISPLAY and not PresentSync.hardwarePacesCap(cap) then
         -- Sleep out the remainder of the frame budget, measured from the
-        -- carried deadline, in small chunks so the OS timer stays
-        -- responsive.  The pacer yields to vsync inside a 1ms dead band, so
-        -- when the panel already paces at or below the cap it is a no-op.
+        -- carried deadline.  When vsync already gates at or above the cap,
+        -- hardwarePacesCap skips this entirely.  Otherwise one kernel sleep
+        -- covers the bulk; only the last couple ms re-check for overshoot.
         local budget = 1 / cap
         nextFrame = nextFrame + budget
         local now = love.timer.getTime()
@@ -1496,11 +1524,7 @@ function love.run()
         if now - nextFrame > budget then
           nextFrame = now
         end
-        while true do
-          local remaining = nextFrame - love.timer.getTime()
-          if remaining <= SLEEP_FLOOR then break end
-          love.timer.sleep(0.001)
-        end
+        sleepUntilFrame(nextFrame)
       else
         love.timer.sleep(0.001)
       end

--- a/src/core/FrameCap.lua
+++ b/src/core/FrameCap.lua
@@ -13,6 +13,12 @@
 
 local FrameCap = {}
 
+local function isHandheldEnv()
+  return os.getenv("HANDHELD") == "1" or os.getenv("PORTMASTER") == "1"
+    or os.getenv("POKEPORT_HANDHELD") == "1" or os.getenv("TRIMUI") == "1"
+    or os.getenv("MUOS") == "1" or os.getenv("KNULLI") == "1"
+end
+
 -- Selectable steps: the normal framerate stops between the floor and the
 -- ceiling.  STEPS[1] == MIN and STEPS[#STEPS] == MAX, so the nearest-step
 FrameCap.STEPS = { 30, 40, 50, 60, 75, 90, 100, 120, 144, 160 }
@@ -74,7 +80,39 @@ function FrameCap.apply(value)
 end
 
 function FrameCap.applyOptions(opts)
-  FrameCap.apply(opts and opts.fpsCap)
+  local cap = opts and opts.fpsCap
+  -- Handheld KMSDRM builds follow the panel through PresentSync; the stored
+  -- default 60 would bypass DISPLAY pacing and force the software limiter.
+  if (cap == nil or cap == FrameCap.DEFAULT) and isHandheldEnv() then
+    cap = FrameCap.DISPLAY
+  end
+  return FrameCap.apply(cap)
+end
+
+-- Launcher / pre-save boot: same DISPLAY default before any save applies.
+function FrameCap.bootHandheld()
+  if isHandheldEnv() and FrameCap.current == FrameCap.DEFAULT then
+    return FrameCap.apply(FrameCap.DISPLAY)
+  end
+  return FrameCap.current
+end
+
+-- Performance LOW tier caps extras; do not rewrite DISPLAY to numeric 60 when
+-- the panel is already at or below the ceiling (that bypasses PresentSync).
+function FrameCap.clampToPerformance(fpsMax)
+  fpsMax = tonumber(fpsMax)
+  if not fpsMax then return FrameCap.current end
+  if FrameCap.current > fpsMax then
+    return FrameCap.apply(fpsMax)
+  end
+  if FrameCap.current == FrameCap.DISPLAY then
+    local ok, RR = pcall(require, "src.core.RefreshRate")
+    local hz = ok and RR.hz()
+    if hz and hz > fpsMax then
+      return FrameCap.apply(fpsMax)
+    end
+  end
+  return FrameCap.current
 end
 
 return FrameCap

--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -1329,11 +1329,7 @@ function Game:applyOptions(opts)
   Zoom.allowSurvey = caps.survey
   if not caps.survey and Zoom.offset < 0 then Zoom.offset = 0 end
   if caps.fpsMax then
-    local FrameCap = require("src.core.FrameCap")
-    if FrameCap.current == FrameCap.DISPLAY
-       or FrameCap.current > caps.fpsMax then
-      FrameCap.apply(caps.fpsMax)
-    end
+    require("src.core.FrameCap").clampToPerformance(caps.fpsMax)
   end
   Input:applyBindings(opts.bindings)
   TouchControls:applyOptions(opts)

--- a/src/core/Game2.lua
+++ b/src/core/Game2.lua
@@ -2202,11 +2202,7 @@ function Game2:applyOptions()
   Zoom.allowSurvey = caps.survey
   if not caps.survey and Zoom.offset < 0 then Zoom.offset = 0 end
   if caps.fpsMax then
-    local FrameCap = require("src.core.FrameCap")
-    if FrameCap.current == FrameCap.DISPLAY
-       or FrameCap.current > caps.fpsMax then
-      FrameCap.apply(caps.fpsMax)
-    end
+    require("src.core.FrameCap").clampToPerformance(caps.fpsMax)
   end
   if shaderfxCleared and self.save then
     -- applyOptions returns true when it had to clear an unresolved preset.

--- a/src/core/PresentSync.lua
+++ b/src/core/PresentSync.lua
@@ -49,6 +49,19 @@ function PresentSync.displaySyncConfirmed()
   return status.gated == true
 end
 
+-- True when vsync + a confirmed (or in-progress trusted) swapchain already
+-- gates at or above the numeric cap, so the 1 ms FrameCap poll adds nothing.
+function PresentSync.hardwarePacesCap(cap)
+  cap = tonumber(cap)
+  if not cap or cap <= 0 then return false end
+  if PresentSync.needsSoftwareCap() then return false end
+  local VSync = require("src.core.VSync")
+  if not VSync.isOn() then return false end
+  local hz = require("src.core.RefreshRate").hz()
+  if not hz or hz <= 0 then return false end
+  return cap >= hz
+end
+
 -- Vsync cannot be turned on usefully once the probe has failed; the row still
 -- allows stepping to OFF.  Warmup does not block the row.
 function PresentSync.vsyncEnableBlocked()

--- a/tests/engine/frame_cap_display.lua
+++ b/tests/engine/frame_cap_display.lua
@@ -32,16 +32,43 @@ FrameCap.apply(FrameCap.DISPLAY)
 T.eq(FrameCap.current, 0, "apply stores the uncapped value as-is")
 FrameCap.apply(before)
 
+local function measure(hz)
+  RefreshRate.reset()
+  for _ = 1, 31 do RefreshRate.sample(1 / hz) end
+end
+
+-- Handheld: default 60 follows the panel through PresentSync, not the software pacer.
+local savedGetenv = os.getenv
+os.getenv = function(name)
+  if name == "POKEPORT_HANDHELD" then return "1" end
+  return savedGetenv(name)
+end
+FrameCap.current = FrameCap.DEFAULT
+FrameCap.applyOptions({ fpsCap = 60 })
+T.eq(FrameCap.current, FrameCap.DISPLAY, "handheld default 60 maps to DISPLAY")
+FrameCap.applyOptions({ fpsCap = 144 })
+T.eq(FrameCap.current, 144, "handheld explicit caps are kept")
+FrameCap.current = FrameCap.DEFAULT
+FrameCap.bootHandheld()
+T.eq(FrameCap.current, FrameCap.DISPLAY, "bootHandheld picks DISPLAY before a save loads")
+os.getenv = savedGetenv
+FrameCap.apply(before)
+
+-- Performance LOW must not force DISPLAY → 60 on a 60 Hz panel.
+measure(60)
+FrameCap.apply(FrameCap.DISPLAY)
+FrameCap.clampToPerformance(60)
+T.eq(FrameCap.current, FrameCap.DISPLAY, "LOW tier leaves DISPLAY on a 60 Hz panel")
+FrameCap.apply(144)
+FrameCap.clampToPerformance(60)
+T.eq(FrameCap.current, 60, "LOW tier clamps 144 down to 60")
+FrameCap.apply(before)
+
 
 local opts = { fpsCap = 60 }
 FrameCap.applyOptions(opts)
 T.eq(opts.fpsCap, 60, "an unknown refresh leaves the 60 default alone")
 T.eq(FrameCap.current, 60, "and paces to it")
-
-local function measure(hz)
-  RefreshRate.reset()
-  for _ = 1, 31 do RefreshRate.sample(1 / hz) end
-end
 
 measure(90)
 T.eq(RefreshRate.mismatch(), 90, "90Hz is not a multiple of 60")

--- a/tests/engine/present_probe.lua
+++ b/tests/engine/present_probe.lua
@@ -239,7 +239,7 @@ local st = LPS.status()
 T.eq(st.gated, false, "uncapped ~1ms cadence stays ungated")
 T.eq(LPS.needsSoftwareCap(), true, "so FrameCap becomes the thermal net")
 
-for _, nest in ipairs({ "wayland", "windows", "macos", "android", "ios" }) do
+for _, nest in ipairs({ "wayland", "windows", "macos", "android", "ios", "kmsdrm" }) do
   LPS.reset()
   LPS._testSetState({
     osLinux = (nest == "wayland"),

--- a/tests/engine/present_sync_logic.lua
+++ b/tests/engine/present_sync_logic.lua
@@ -48,7 +48,22 @@ T.check(PresentSync.displaySyncConfirmed(), "gated+clear softcap is confirmed sy
 FrameCap.apply(60)
 T.eq(PresentSync.logicRefreshPeriod(), nil,
   "a 60 cap on a 144Hz panel leaves refresh snapping off")
+T.check(not PresentSync.hardwarePacesCap(60),
+  "60 on 144Hz still needs software pacing headroom")
 
+measure(60)
+FrameCap.apply(60)
+PresentProbe._testSetState({ osLinux = true, ready = true, gated = true,
+  needsSoftwareCap = false, nest = "kmsdrm" })
+T.check(PresentSync.hardwarePacesCap(60),
+  "60 on 60Hz with working vsync skips the software pacer")
+FrameCap.apply(30)
+T.check(not PresentSync.hardwarePacesCap(30),
+  "30 on 60Hz still needs software pacing")
+
+measure(144)
+PresentProbe._testSetState({ osLinux = false, ready = true, gated = true,
+  needsSoftwareCap = false, nest = "windows" })
 FrameCap.apply(144)
 T.eq(PresentSync.logicRefreshPeriod(), 1 / 144,
   "a 144 cap on a 144Hz panel may snap logic to the panel")


### PR DESCRIPTION

- Introduced the `POKEPORT_IDLE_AFTER` and `POKEPORT_IDLE_FPS` environment variables to manage presentation rates on static screens, allowing game logic and audio to maintain full speed.
- Updated the vsync handling to keep it enabled across all platforms, including KMSDRM handhelds, to leverage PresentSync for improved cadence and pacing.
- Enhanced FrameCap logic to ensure proper handling of performance caps in handheld environments, preventing unnecessary software pacing when hardware capabilities are sufficient.
- Adjusted documentation to reflect these changes and their impact on power efficiency and performance.