### PR TITLE
fix(checkpoint): keep poisonSteps across a restore (#1971)

### DIFF
--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -1428,12 +1428,20 @@ function Game:restoreCheckpointSave(loaded)
   self.save = loaded
   self:adoptSave(loaded)
   while self.stack:top() do self.stack:pop() end
-  -- freshBoot unconditionally: Checkpoint.resume (src/core/Checkpoint.lua)
-  -- is this method's only caller, and it is itself gated to the title
-  -- session (isTitleSession).
+  -- setMap zeroes poisonSteps on every non-seamless map entry, mirroring
+  -- ClearVariablesOnEnterMap.  Re-entering the map is how a restore installs
+  -- the world, but it is not a map entry from the player's point of view, and
+  -- Checkpoint.restore verifies the applied state against the checkpoint --
+  -- so the discarded counter failed the comparison and rolled the whole
+  -- restore back three steps out of four (#1971).
+  local poisonSteps = loaded.poisonSteps
+  -- freshBoot unconditionally: both callers arrive through Checkpoint.apply
+  -- (src/core/Checkpoint.lua), which serves Checkpoint.resume from the title
+  -- session and Checkpoint.restore from a settled runtime.
   self.stack:push(self.overworld, loaded.player.map,
                   loaded.player.x, loaded.player.y, loaded.player.facing,
                   { via = "checkpoint", checkpoint = true, freshBoot = true })
+  self.save.poisonSteps = poisonSteps
 end
 
 -- Install a reconstructed battle without calling BattleState:enter(), whose

--- a/tests/engine/restore_poison_steps_bug1971.lua
+++ b/tests/engine/restore_poison_steps_bug1971.lua
@@ -1,0 +1,80 @@
+-- poisonSteps is a plain step counter -- (poisonSteps + 1) % 4 on EVERY step,
+-- not only while a mon is poisoned (OverworldController:applyFieldPoison) --
+-- so it is non-zero three steps out of four in ordinary play.
+--
+-- Restoring a checkpoint re-enters the map, and the map-enter path zeroes it
+-- (setMap, mirroring ClearVariablesOnEnterMap). Checkpoint.restore then
+-- re-captures the applied state and compares it with the checkpoint, so the
+-- field it just discarded fails the comparison and the whole restore rolls
+-- back: "restored state differed at $.save.poisonSteps" (#1971).
+--
+-- A restore is not a map entry from the player's point of view; the counter
+-- belongs to the state being restored.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+if not _G.love then _G.love = require("tests.love_stub") end
+
+local T = require("tests.modkit")
+local Data = T.fixtures.fresh()
+Data.tilesets.FIX_OUT.tilesPerRow = 16
+Data.field.flyWarps = Data.field.flyWarps or {}
+Data.field.playerSprites = { walk = "SPRITE_FIX_PLAYER" }
+Data.field.waterTilesets = {}
+Data.field.forcedMovement = { tiles = {} }
+Data.audio = Data.audio or {}
+Data.audio.songs = Data.audio.songs or {}
+Data.audio.mapSongs = Data.audio.mapSongs or {}
+
+local SaveData = require("src.core.SaveData")
+local Game = require("src.core.Game")
+local StateStack = require("src.core.StateStack")
+local OverworldState = require("src.world.OverworldController")
+
+Game.data = Data
+Game.save = SaveData.newGame()
+Game.save.player.name = "RED"
+Game.save.player.map = "FIX_TOWN"
+StateStack:init()
+Game.stack = StateStack
+Game.overworld = OverworldState
+Game.input = {
+  isDown = function() return false end,
+  wasPressed = function() return false end,
+  step = function() end, state = {}, pressQueue = {},
+}
+Game.renderer = {
+  beginWorldPass = function() end, endWorldPass = function() end,
+  beginUIPass = function() end, endUIPass = function() end,
+  worldViewSize = function() return 160, 144 end,
+  setSGBZones = function() end,
+}
+
+local function checkpointSave(steps)
+  local save = SaveData.newGame()
+  save.player.map = "FIX_TOWN"
+  save.player.x, save.player.y = 4, 4
+  save.poisonSteps = steps
+  return save
+end
+
+-- === the bug: the counter survives a checkpoint restore
+for _, steps in ipairs({ 1, 2, 3 }) do
+  Game:restoreCheckpointSave(checkpointSave(steps))
+  T.eq(Game.save.poisonSteps, steps,
+    ("a checkpoint restore keeps poisonSteps = %d"):format(steps))
+end
+
+-- === zero stays zero (the case that accidentally worked before)
+Game:restoreCheckpointSave(checkpointSave(0))
+T.eq(Game.save.poisonSteps, 0, "a checkpoint restore keeps poisonSteps = 0")
+
+-- === an ordinary map entry still clears it, which is the cart behaviour
+Game.save.poisonSteps = 3
+OverworldState:setMap("FIX_TOWN", 4, 4, "up", {})
+T.eq(Game.save.poisonSteps, 0, "a plain map entry still zeroes the counter")
+
+-- === and a seamless connection crossing still does not
+Game.save.poisonSteps = 3
+OverworldState:setMap("FIX_TOWN", 4, 4, "up", { seamless = true })
+T.eq(Game.save.poisonSteps, 3, "a seamless crossing still carries it across")
+
+T.finish("poisonSteps survives a checkpoint restore (#1971)")


### PR DESCRIPTION
Retarget of #1973 onto `dev` as requested. Same commit, rebased; #1973 is closed in favour of this one.

Fixes #1971.

`Checkpoint.restore()` rejects most valid checkpoints:

```
Checkpoint restoration failed: restored state differed at $.save.poisonSteps
```

`poisonSteps` is a plain step counter — `(poisonSteps + 1) % 4` on **every** step, not only while a mon is poisoned (`OverworldController:applyFieldPoison`) — so it is non-zero three steps out of four in ordinary play.

Installing the restored world re-enters the map, and the map-enter path zeroes the counter, correctly mirroring `ClearVariablesOnEnterMap`. `Checkpoint.restore` then re-captures the applied state and compares it against the checkpoint, so the field it had just discarded fails the comparison and the whole restore rolls back.

A restore is not a map entry from the player's point of view: the counter belongs to the state being restored. This carries it across the push.

### Why it stayed hidden

The two autosave triggers a checkpoint consumer naturally uses — `map.entered` and `player.warped` — are emitted from inside the very paths that zero the counter:

```
OverworldController.lua:377   Game.save.poisonSteps = 0
OverworldController.lua:572   Runtime.emit("map.entered", …)
OverworldController.lua:4664  Game.save.poisonSteps = 0
OverworldController.lua:4783  Runtime.emit("player.warped", …)
```

So those captures hold `0` and restore cleanly. Only a capture taken at an arbitrary step — a manual quicksave, or one tied to the ordinary `SAVE` — carries a non-zero value. The T4 title-checkpoint tier misses it for the same reason: its save is fresh, so the counter is already `0`.

I found it building a mod that captures on `save.writing`, which is the one trigger uncorrelated with map entry.

### A stale comment, corrected

The comment above the push said `Checkpoint.resume` was this method's only caller. Both callers arrive through `Checkpoint.apply` — which serves `resume` from the title session and `restore` from a settled runtime — and that is exactly why the map-entry side effects matter here.

### Tests

`tests/engine/restore_poison_steps_bug1971.lua` covers `1..3` and `0` across a restore, and pins the two behaviours that must **not** change:

- a plain map entry still zeroes the counter
- a seamless connection crossing still carries it across

It fails on the current tree at `3/6` with `got 0, want 3`, and passes with this change.

Also run locally on this `dev` base: the six existing checkpoint suites (`battle_checkpoint_restore` 43/43, `battle_checkpoint_capture` 29/29, `battle_checkpoint_boundary` 21/21, `restore_standing_trigger_bug1547` 6/6, `resume_boot_music_no_fade` 13/13, `scripted_battle_checkpoint_test` 20/20) and `scripts/test.sh --quick` — **ALL TIERS PASSED**.

Verified end to end as well: with this patch applied to a 0.2.39 build, checkpoints captured at `poisonSteps` 1–3 restore live, where the same records were refused before.