### PR TITLE
fix(present): android + xbox uwp nests that dont fake being desktop windows

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1421,7 +1421,7 @@ function love.run()
   if love.timer then love.timer.step() end
 
   local FrameCap = require("src.core.FrameCap")
-  FrameCap.bootHandheld()
+  FrameCap.bootPanelSync()
   local RefreshRate = require("src.core.RefreshRate")
   local FixedStep = require("src.core.FixedStep")
   local VSync = require("src.core.VSync")

--- a/src/core/FrameCap.lua
+++ b/src/core/FrameCap.lua
@@ -19,6 +19,21 @@ local function isHandheldEnv()
     or os.getenv("MUOS") == "1" or os.getenv("KNULLI") == "1"
 end
 
+-- Platforms where PresentSync should pace via the panel (DISPLAY), not a
+-- numeric FrameCap default.  Android/iOS/UWP need uncapped probe isolation
+-- so composed GLES swapchains can lock; PortMaster handhelds likewise
+-- follow KMSDRM through PresentSync.
+function FrameCap.prefersPanelSync()
+  if isHandheldEnv() then return true end
+  if love and love.system and love.system.getOS then
+    local osName = love.system.getOS()
+    if osName == "Android" or osName == "iOS" or osName == "UWP" then
+      return true
+    end
+  end
+  return false
+end
+
 -- Selectable steps: the normal framerate stops between the floor and the
 -- ceiling.  STEPS[1] == MIN and STEPS[#STEPS] == MAX, so the nearest-step
 FrameCap.STEPS = { 30, 40, 50, 60, 75, 90, 100, 120, 144, 160 }
@@ -81,21 +96,25 @@ end
 
 function FrameCap.applyOptions(opts)
   local cap = opts and opts.fpsCap
-  -- Handheld KMSDRM builds follow the panel through PresentSync; the stored
-  -- default 60 would bypass DISPLAY pacing and force the software limiter.
-  if (cap == nil or cap == FrameCap.DEFAULT) and isHandheldEnv() then
+  -- Handheld / Android / iOS / UWP follow the panel through PresentSync; the
+  -- stored default 60 would bypass DISPLAY pacing and force the software
+  -- limiter (and on composed GLES nests that also prevents vsync locking).
+  if (cap == nil or cap == FrameCap.DEFAULT) and FrameCap.prefersPanelSync() then
     cap = FrameCap.DISPLAY
   end
   return FrameCap.apply(cap)
 end
 
 -- Launcher / pre-save boot: same DISPLAY default before any save applies.
-function FrameCap.bootHandheld()
-  if isHandheldEnv() and FrameCap.current == FrameCap.DEFAULT then
+function FrameCap.bootPanelSync()
+  if FrameCap.prefersPanelSync() and FrameCap.current == FrameCap.DEFAULT then
     return FrameCap.apply(FrameCap.DISPLAY)
   end
   return FrameCap.current
 end
+
+-- Alias kept for existing call sites / docs.
+FrameCap.bootHandheld = FrameCap.bootPanelSync
 
 -- Performance LOW tier caps extras; do not rewrite DISPLAY to numeric 60 when
 -- the panel is already at or below the ceiling (that bypasses PresentSync).

--- a/src/core/PresentProbe.lua
+++ b/src/core/PresentProbe.lua
@@ -10,7 +10,15 @@
 --   windows   DWM / flip-model / VRR can return from Present early; the
 --             pacing shows up in the gap between presents (Ally X class).
 --   macos     Compositor / CVDisplayLink similarly; cadence is authoritative.
---   android/ios  Choreographer-style wait; same cadence probe, no GLX.
+--   android/ios  SurfaceFlinger BufferQueue back-pressure via eglSwapBuffers
+--             (LOVE/SDL does not use Choreographer).  Swap returns fast until
+--             the queue is full, then blocks on VSYNC.  Fail-closed must also
+--             silence driver vsync: sleeping under FrameCap while swapinterval
+--             stays 1 keeps the queue from staying full, so vsync never locks.
+--   uwp       Xbox (and other LOVE UWP) builds: ANGLE → D3D11 under the
+--             console compositor (Dev Mode sits in Hyper-V).  Not desktop
+--             DWM.  Same fail-closed rule as BufferQueue: soft-cap alone
+--             while swapinterval stays 1 prevents a clean lock.
 --   x11       GLX swapinterval often blocks in swap, but compositors
 --             (Picom, etc.) can defer — cadence still correct.  If ungated,
 --             try OML/SGI wait (native X11 only).
@@ -27,6 +35,9 @@ local PresentProbe = {}
 -- Cadence samples between presents while FrameCap is disabled.
 local PROBE_FRAMES = 45
 local PROBE_SKIP = 5          -- drop first samples (startup hitch)
+-- Android/iOS/UWP: early swaps return near-instant while the composed
+-- swapchain / BufferQueue fills before back-pressure engages.
+local PROBE_SKIP_COMPOSITED = 12
 local INSTANT_MS = 0.0005
 local BLOCK_MS = 0.002
 local WAIT_ABORT_S = 0.1
@@ -43,6 +54,9 @@ local state = {
   gated = nil,        -- nil while probing, then true/false
   strategy = "none",  -- "none" | "sdl" | "oml" | "sgi"
   needsSoftwareCap = false,
+  -- Composited GLES nests: drop swapinterval when soft-capping so FrameCap
+  -- is the sole pacer (android / ios / uwp).
+  silenceDriver = false,
   probeCount = 0,
   lastPresent = nil,  -- love.timer time of previous present end (cadence)
   intervals = nil,    -- inter-present cadence while probing
@@ -324,12 +338,23 @@ local function bindGlxWait(nest)
   return nil, nil
 end
 
+local function isCompositedGlesNest(nest)
+  return nest == "android" or nest == "ios" or nest == "uwp"
+end
+
+local function silenceDriverIfNeeded()
+  if not state.silenceDriver then return end
+  local okV, VSync = pcall(require, "src.core.VSync")
+  if okV and VSync.silenceDriver then pcall(VSync.silenceDriver) end
+end
+
 local function pickStrategy()
   -- Always drop any prior wait first.  While gated is nil we are probing
   -- unassisted present intervals — never re-bind mid-probe or the sample
   -- measures our own wait instead of the driver's raw behaviour.
   waitFn = nil
   state.needsSoftwareCap = false
+  state.silenceDriver = false
   state.strategy = "none"
 
   local vsyncOn = true
@@ -340,10 +365,29 @@ local function pickStrategy()
     return
   end
 
+  local nest = state.nest
+  if isCompositedGlesNest(nest) then
+    -- Android/iOS BufferQueue or Xbox UWP ANGLE→D3D11 composition.
+    -- Never bind GLX.  Fail-closed silences driver vsync so FrameCap alone
+    -- paces (soft-cap + swapinterval 1 prevents the composed swapchain
+    -- from locking cleanly).
+    if state.gated == true then
+      state.strategy = "sdl"
+    elseif state.gated == false then
+      state.needsSoftwareCap = true
+      state.silenceDriver = true
+      state.strategy = "none"
+      silenceDriverIfNeeded()
+    else
+      state.strategy = "sdl"
+    end
+    return
+  end
+
   if not state.osLinux then
-    -- windows / macos / android / ios: never bind GLX.  Cadence probe is the
-    -- authority (DWM, Cocoa compositor, Choreographer can all defer the wait
-    -- past present() return).  Ungated → FrameCap only.
+    -- windows / macos: never bind GLX.  Cadence probe is the authority
+    -- (DWM / Cocoa compositor can defer the wait past present() return).
+    -- Ungated → FrameCap only.  Desktop does not silence driver vsync.
     if state.gated == true then
       state.strategy = "sdl"
     elseif state.gated == false then
@@ -355,7 +399,6 @@ local function pickStrategy()
     return
   end
 
-  local nest = state.nest
   if nest == "wayland" then
     -- SDL owns wl_surface.frame.  Never duplicate it.
     state.strategy = "sdl"
@@ -420,6 +463,8 @@ local function platformNest()
   if osName == "OS X" or osName == "macOS" then return "macos" end
   if osName == "Android" then return "android" end
   if osName == "iOS" then return "ios" end
+  -- LOVE_WINDOWS_UWP (Xbox package): not desktop DWM.
+  if osName == "UWP" then return "uwp" end
   if osName == "Linux" then return detectNest(state.driver) end
   return osName:lower()
 end
@@ -455,6 +500,7 @@ function PresentProbe.reset()
   state.gated = nil
   state.strategy = "none"
   state.needsSoftwareCap = false
+  state.silenceDriver = false
   state.probeCount = 0
   state.lastPresent = nil
   state.intervals = nil
@@ -475,6 +521,7 @@ function PresentProbe.onDisplayChange()
   state.lastPresent = nil
   state.strategy = "none"
   state.needsSoftwareCap = false
+  state.silenceDriver = false
   glLib = nil
   -- Keep driver/nest; re-probe effectiveness and rebind on next presents.
   pickStrategy()
@@ -489,6 +536,7 @@ function PresentProbe.reprobe()
   waitFn = nil
   state.glxGen = state.glxGen + 1
   state.bindGen = -1
+  state.silenceDriver = false
   glLib = nil
   pickStrategy()
 end
@@ -499,6 +547,10 @@ local function abandonWait()
   state.needsSoftwareCap = true
   state.gated = false
   state.bindGen = state.glxGen
+  if isCompositedGlesNest(state.nest) then
+    state.silenceDriver = true
+    silenceDriverIfNeeded()
+  end
 end
 
 -- Hot path: must stay allocation-free and avoid ffi.C / require.
@@ -538,9 +590,11 @@ function PresentProbe.notePresent()
   local gap = now - last
   -- Discard hitches / timer glitches; keep sampling until we have clean ones.
   if gap <= 0 or gap > 0.25 then return end
-  -- Skip the first few presents so window/map boot cost does not widen IQR.
+  -- Skip early presents so window/map boot (and composed-swapchain /
+  -- BufferQueue fill on Android/iOS/UWP) does not widen IQR.
   state.probeCount = (state.probeCount or 0) + 1
-  if state.probeCount <= PROBE_SKIP then return end
+  local skip = isCompositedGlesNest(state.nest) and PROBE_SKIP_COMPOSITED or PROBE_SKIP
+  if state.probeCount <= skip then return end
   local intervals = state.intervals
   if not intervals then
     intervals = {}
@@ -567,6 +621,7 @@ function PresentProbe.status()
     gated = state.gated,
     strategy = state.strategy,
     needsSoftwareCap = state.needsSoftwareCap,
+    silenceDriver = state.silenceDriver,
     probeCount = state.probeCount,
   }
 end

--- a/src/core/PresentSync.lua
+++ b/src/core/PresentSync.lua
@@ -49,14 +49,13 @@ function PresentSync.displaySyncConfirmed()
   return status.gated == true
 end
 
--- True when vsync + a confirmed (or in-progress trusted) swapchain already
--- gates at or above the numeric cap, so the 1 ms FrameCap poll adds nothing.
+-- True when confirmed display sync already gates at or above the numeric
+-- cap, so FrameCap sleep adds nothing.  Requires a finished gated probe —
+-- never skip the limiter during warmup or on a guessed refresh rate.
 function PresentSync.hardwarePacesCap(cap)
   cap = tonumber(cap)
   if not cap or cap <= 0 then return false end
-  if PresentSync.needsSoftwareCap() then return false end
-  local VSync = require("src.core.VSync")
-  if not VSync.isOn() then return false end
+  if not PresentSync.displaySyncConfirmed() then return false end
   local hz = require("src.core.RefreshRate").hz()
   if not hz or hz <= 0 then return false end
   return cap >= hz

--- a/src/core/VSync.lua
+++ b/src/core/VSync.lua
@@ -76,6 +76,17 @@ function VSync.applyOptions(opts)
   VSync.apply(opts and opts.vsync)
 end
 
+-- Drop the live swap interval without changing wanted and without re-entering
+-- PresentSync.reprobe.  Used by Android/iOS/UWP composited-GLES fail-closed:
+-- FrameCap cannot keep the swapchain engaged while eglSwapInterval stays 1,
+-- so vsync never locks unless the driver wait is silenced for the software path.
+function VSync.silenceDriver()
+  if love and love.window and love.window.setVSync then
+    pcall(love.window.setVSync, 0)
+  end
+  live = "off"
+end
+
 -- True when the user asked for sync (on/adaptive), even if the driver
 -- reported the interval as 0 afterwards.
 function VSync.isOn()

--- a/tests/engine/frame_cap_display.lua
+++ b/tests/engine/frame_cap_display.lua
@@ -54,6 +54,24 @@ T.eq(FrameCap.current, FrameCap.DISPLAY, "bootHandheld picks DISPLAY before a sa
 os.getenv = savedGetenv
 FrameCap.apply(before)
 
+-- Android/iOS/UWP also prefer DISPLAY so composed GLES can lock during probe.
+local savedGetOS = love and love.system and love.system.getOS
+love = love or {}
+love.system = love.system or {}
+for _, osName in ipairs({ "Android", "UWP" }) do
+  love.system.getOS = function() return osName end
+  FrameCap.current = FrameCap.DEFAULT
+  FrameCap.applyOptions({ fpsCap = 60 })
+  T.eq(FrameCap.current, FrameCap.DISPLAY,
+    osName .. " default 60 maps to DISPLAY")
+  FrameCap.current = FrameCap.DEFAULT
+  FrameCap.bootPanelSync()
+  T.eq(FrameCap.current, FrameCap.DISPLAY,
+    "bootPanelSync picks DISPLAY on " .. osName)
+end
+love.system.getOS = savedGetOS or function() return "Linux" end
+FrameCap.apply(before)
+
 -- Performance LOW must not force DISPLAY → 60 on a 60 Hz panel.
 measure(60)
 FrameCap.apply(FrameCap.DISPLAY)

--- a/tests/engine/present_probe.lua
+++ b/tests/engine/present_probe.lua
@@ -239,17 +239,18 @@ local st = LPS.status()
 T.eq(st.gated, false, "uncapped ~1ms cadence stays ungated")
 T.eq(LPS.needsSoftwareCap(), true, "so FrameCap becomes the thermal net")
 
-for _, nest in ipairs({ "wayland", "windows", "macos", "android", "ios", "kmsdrm" }) do
+for _, nest in ipairs({ "wayland", "windows", "macos", "android", "ios", "uwp", "kmsdrm" }) do
   LPS.reset()
   LPS._testSetState({
-    osLinux = (nest == "wayland"),
+    osLinux = (nest == "wayland" or nest == "kmsdrm"),
     ready = true,
     nest = nest,
     clearGated = true,
     needsSoftwareCap = false,
   })
   t = 0
-  for i = 1, 60 do
+  -- Composited GLES nests skip more warmup frames before sampling.
+  for i = 1, 80 do
     LPS.waitBeforePresent()
     LPS.notePresent()
     t = t + 1 / 60
@@ -259,6 +260,36 @@ for _, nest in ipairs({ "wayland", "windows", "macos", "android", "ios", "kmsdrm
     nest .. ": compositor-paced ~1/60 cadence counts as gated")
   T.eq(LPS.needsSoftwareCap(), false,
     nest .. ": does not force FrameCap when cadence is locked")
+  T.eq(st.silenceDriver, false,
+    nest .. ": does not silence driver vsync when gated")
+end
+
+-- Android/iOS/UWP composited-GLES fail-closed: soft-cap AND silence driver
+-- vsync so FrameCap can pace without fighting a half-locked swapinterval.
+for _, nest in ipairs({ "android", "uwp" }) do
+  local calls = {}
+  love.window = love.window or {}
+  love.window.setVSync = function(v) calls[#calls + 1] = v end
+  love.window.getVSync = function() return 1 end
+  local VSync = require("src.core.VSync")
+  VSync.reset()
+  VSync.apply("on")
+  calls = {}
+  LPS.reset()
+  LPS._testSetState({
+    osLinux = false, ready = true, nest = nest, gated = false,
+    needsSoftwareCap = false, silenceDriver = false, waitFn = false,
+  })
+  local strategy, soft = LPS._testPickStrategy()
+  T.eq(strategy, "none", "ungated " .. nest .. " drops to FrameCap")
+  T.eq(soft, true, "ungated " .. nest .. " needs the software cap")
+  T.eq(LPS.status().silenceDriver, true,
+    "ungated " .. nest .. " marks driver vsync for silence")
+  T.eq(calls[#calls], 0, nest .. " silenceDriver sets swap interval 0")
+  T.eq(VSync.isOn(), true, nest .. ": user wanted-ON is preserved")
+  T.eq(VSync.effective(), "off", nest .. ": live driver bit is off")
+  love.window.setVSync, love.window.getVSync = nil, nil
+  VSync.reset()
 end
 
 -- A bound wait that overruns abandons to FrameCap instead of wedging.

--- a/tests/engine/present_sync_logic.lua
+++ b/tests/engine/present_sync_logic.lua
@@ -61,6 +61,17 @@ FrameCap.apply(30)
 T.check(not PresentSync.hardwarePacesCap(30),
   "30 on 60Hz still needs software pacing")
 
+-- Warmup must not skip FrameCap on a guessed panel rate.
+PresentProbe._testSetState({ osLinux = false, ready = true, clearGated = true,
+  needsSoftwareCap = false, nest = "android" })
+FrameCap.apply(60)
+T.check(not PresentSync.hardwarePacesCap(60),
+  "Android still probing does not skip FrameCap via hardwarePacesCap")
+PresentProbe._testSetState({ nest = "uwp", clearGated = true,
+  needsSoftwareCap = false })
+T.check(not PresentSync.hardwarePacesCap(60),
+  "UWP still probing does not skip FrameCap via hardwarePacesCap")
+
 measure(144)
 PresentProbe._testSetState({ osLinux = false, ready = true, gated = true,
   needsSoftwareCap = false, nest = "windows" })

--- a/tests/engine/vsync_option.lua
+++ b/tests/engine/vsync_option.lua
@@ -61,6 +61,19 @@ T.eq(calls[#calls], 1, "ON still asks the driver for interval 1")
 T.eq(VSync.isOn(), true, "requested ON stays wanted even if getVSync is 0")
 T.eq(VSync.effective(), "off", "while effective tracks the driver bit")
 
+-- BufferQueue fail-closed: silence live swapinterval without flipping wanted.
+VSync.reset()
+calls = {}
+interval = 1
+love.window.getVSync = function() return interval end
+love.window.setVSync = function(v) calls[#calls + 1] = v; interval = v end
+VSync.apply("on")
+calls = {}
+VSync.silenceDriver()
+T.eq(calls[#calls], 0, "silenceDriver asks for interval 0")
+T.eq(VSync.isOn(), true, "wanted stays ON after silenceDriver")
+T.eq(VSync.effective(), "off", "effective follows the silenced driver")
+
 love.window.getVSync, love.window.setVSync = nil, nil
 VSync.reset()
 


### PR DESCRIPTION
## Summary
- android was getting lumped into the generic non-linux present path and acting like it had choreographer when it doesnt; its surfaceflinger bufferqueue via eglSwapBuffers
- xbox uwp was even worse; love reports `UWP` and we just lowercased it into the windows-ish path even though the build is angle -> d3d11 under the console compositor (dev mode is hyper-v-ish), not desktop dwm
- both now have real nests in presentsync: default DISPLAY so probe isolation can lock, and if sync fails we soft-cap AND silence driver vsync so framecap isnt fighting a half-locked swapinterval

## Why
leaving vsync on while sleeping under framecap keeps the composed swapchain from staying engaged, so vsync never cleanly locks and pacing shits the bed. same root cause shape on both platforms, different adapters.

desktop windows is untouched on purpose.

## Test plan
- [ ] unit tests: present_probe / present_sync_logic / frame_cap_display / vsync_option
- [ ] android: boot with defaults (DISPLAY + vsync on), confirm cadence gates and walking feels even
- [ ] android: force a soft-cap path and confirm swapinterval gets silenced (no hybrid mess)
- [ ] xbox uwp / dev mode: same checks, make sure it isnt still acting like desktop windows