### PR TITLE
Route the remaining RBY and Gen2 text through translations

### DIFF
--- a/docs/mod-api-gen2-compat.md
+++ b/docs/mod-api-gen2-compat.md
@@ -339,6 +339,13 @@ copies, so what a mod merges is what the game walks: a registered map is a map
 Gold can warp into, a patched tileset is the one `Map.new` reads, a patched
 encounter table is the one the grass rolls.
 
+Gold also exposes the Gen 2-only `rom_text` registry for label-keyed engine
+prose extracted to `data/generated/rom_text.lua`. It merges into `data.text`,
+the table `src/core/RomText.lua` reads. This is deliberately distinct from
+`text`, which remains the overworld VM's bank:address table at
+`data.gen2Text`: use `mod.content.rom_text:override(label, value)` for labels
+such as `_WokeUpText`, and `mod.content.text` for script pointers.
+
 The battle-rule six are the newer half and work slightly differently: there is
 no table on disk for them at all. They come into existence *as* the merge, and
 each consumer reads a record through a lookup that falls back to its own module
@@ -357,7 +364,7 @@ records when no loader ran, so a mod-free Gold boot behaves identically:
 rather than Red's. It has to: both games call it `GREAT_BALL`, and Red's record
 carries no `multiplier`, so seeding Red's would leave Gold's x1.5 reading nil.
 
-**Content registries that exist because Gold does.** Six systems Red has no
+**Content registries that exist because Gold does.** Seven systems Red has no
 counterpart for, so there is no Gen 1 table to share and none of these carries
 a Gen 1 target at all. The routed Gen 2 path is their only home, and
 `Schemas.GEN1` gates them on a Red boot the way `Schemas.GEN2` gates
@@ -371,17 +378,21 @@ a Gen 1 target at all. The routed Gen 2 path is their only home, and
 | `apricorns` | apricorn item ids | `Apricorns.useRegistry`, which rebuilds all three lookups and Kurt's menu order |
 | `landmarks` | `LANDMARK_*` | `Nests.landmarkId` / `Nests.landmark`, which resolve a map header's landmark byte |
 | `radio_channels` | station ids | `MapRadio.channelRecord`, which puts a registered station on the dial |
+| `rom_text` | disassembly text labels | `RomText(data, label, fallback)`, through `data.text` |
 
 `Game2:load` calls `Phone.useRegistry`, `Decorations.useRegistry`,
 `Apricorns.useRegistry` and `ItemEffects.applyHeldItems` immediately after
 `mods:load`, so the merge is live before the first frame. `landmarks` and
-`radio_channels` need no such call: their consumers take `data` at call time.
+`radio_channels` and `rom_text` need no such call: their consumers take `data`
+at call time.
 
 `landmarks` merges onto the cache's own `gen2Landmarks.landmarks` and
 `held_items` onto the view `Game2` builds from `data.items`, so both fold
 against the vanilla row -- a `register` for an existing id collides, a
-`patch` stacks. The other four come into existence as the merge, seeded from
-their module's literals by `src/mods/Builtins.lua`.
+`patch` stacks. Phone contacts, decorations, apricorns and radio channels come
+into existence as the merge, seeded from their module's literals by
+`src/mods/Builtins.lua`; `rom_text` folds against the extracted `data.text`
+table loaded by `Game2`.
 
 Four honest limits on that surface:
 
@@ -399,9 +410,14 @@ Four honest limits on that surface:
   (contact bytes 8, 9, 10 and 25). The manifest gives all four the same id, and
   one id cannot key four rows. They stay copies of the wrong-number filler,
   which is what the cart does with them.
+- `phone_contacts.name` is an optional display override. It does not replace
+  `class` / `member`, so trainer identity and rematch behavior stay stable;
+  when omitted, trainer contacts still resolve through the trainer table and
+  non-trainer contacts use their built-in caller name.
 - `radio_channels` and `phone_contacts` register *content*, not new UI: a
-  registered station gets a dial position and a name, and a registered contact
-  gets a row the Pokegear indexes, but neither invents a screen.
+  registered wall station gets a dial position and a name (Pokegear-only
+  signals may carry just a name), and a registered contact gets a row the
+  Pokegear indexes, but neither invents a screen.
 
 **Record shapes.** A registry whose Gen 2 records genuinely differ carries a
 Gen 2 schema beside its Gen 1 one (`gen2Fields` / `gen2Keys` / `gen2Write` in

--- a/docs/modding/reference/registries.md
+++ b/docs/modding/reference/registries.md
@@ -796,6 +796,7 @@ and reported. See the Gold subsection below for where it does land.
 | `index` | integer >= 0 | yes |
 | `map` | maps id | no |
 | `member` | string | no |
+| `name` | string | no |
 | `number` | integer 0..255 | no |
 
 ```lua
@@ -898,7 +899,7 @@ and reported. See the Gold subsection below for where it does land.
 
 | field | type | required |
 |---|---|---|
-| `channel` | integer 0..255 | yes |
+| `channel` | integer 0..255 | no |
 | `name` | string | no |
 
 ```lua
@@ -932,6 +933,25 @@ mod.content.radio_channels:register("PIRATE_RADIO", { channel = 9, name = "PIRAT
 ```lua
 mod.content.render_pipelines:register("voxel", { label = "VOXEL", levels = { "OFF", "15", "35", "50" }, drawWorld = fn })
 ```
+
+## rom_text
+
+- semantics: `record`
+- target: none
+
+Gen 2 only: Red, Blue and Yellow have no such system, so there is no
+Gen 1 table to merge into and a write here on a Gen 1 boot is dropped
+and reported. See the Gold subsection below for where it does land.
+- value: string
+
+```lua
+mod.content.rom_text:override("_WokeUpText", "%s se réveille !")
+```
+
+### On Gold (Gen 2)
+
+- semantics: `record`
+- target: `Data.text`
 
 ## rulesets
 

--- a/src/battle/BattleState.lua
+++ b/src/battle/BattleState.lua
@@ -6765,8 +6765,12 @@ function BattleState:drawTextArea()
       elseif def then
         Font.draw(Strings("TYPE/"), 8, 72)
         -- the type record's display name (a mod type shows its name, and
-        -- PSYCHIC_TYPE prints PSYCHIC like the original)
-        Font.draw(def.type and TypeChart.displayName(def.type) or "", 16, 80)
+        -- PSYCHIC_TYPE prints PSYCHIC like the original). self.data is
+        -- game.data by reference (set above TypeChart.load(game.data)), so
+        -- this is a no-op against TypeChart's own cache today -- kept for
+        -- the same call convention as the pre-battle screens (SummaryMenu,
+        -- HallOfFame) that genuinely need the explicit data.
+        Font.draw(def.type and TypeChart.displayName(def.type, self.data) or "", 16, 80)
         local maxPP = def.pp + (sel.ppUps or 0) * math.floor(def.pp / 5)
         Font.draw(("%2d/%2d"):format(sel.pp, maxPP), 40, 88)
       end

--- a/src/battle/Status.lua
+++ b/src/battle/Status.lua
@@ -175,6 +175,21 @@ function Status.hudLabelFor(statuses, id)
   return record and (record.hudLabel or record.label) or id
 end
 
+-- Gen 2's own statuses registry (src/battle/gen2/Battle.lua) uses the full
+-- names (poison/burn/freeze/paralyze/sleep) as ids; PartyMenu and SummaryMenu
+-- both read a mon's status byte as the three/four-letter cart abbreviation
+-- first (psn/brn/frz/par/paralysis/slp) and need this to look the record up.
+-- `paralysis` mirrors the same three-way spelling (par/paralysis/paralyze)
+-- src/core/gen2/ItemEffects.lua's STATUS_CLASS already recognizes for status
+-- cures; battle itself only ever sets mon.status to the full Gen 2 spelling
+-- ("paralyze"), so no live path produces "paralysis" today, but nothing
+-- guarantees a save-compat or Gen 1-side path never will, and the two
+-- tables should stay in sync either way.
+Status.GEN2_ID_ALIASES = {
+  psn = "poison", brn = "burn", frz = "freeze",
+  par = "paralyze", paralysis = "paralyze", slp = "sleep",
+}
+
 local function battleStatuses(battle)
   return battle and battle.data and battle.data.statuses
 end

--- a/src/battle/TypeChart.lua
+++ b/src/battle/TypeChart.lua
@@ -8,6 +8,11 @@ local index -- [atk][def] -> x10 multiplier
 local matchups -- ROM-ordered TypeEffects rows
 local types -- merged type records (physical/special category, display name)
 
+-- Identifiers whose cart-facing spelling differs even without loaded data.
+-- CURSE_TYPE is Gen 2's ??? type and is deliberately not a Gen 1 registry
+-- record; keeping it here avoids exposing a non-existent Gen 1 type.
+local DISPLAY_NAMES = { PSYCHIC_TYPE = "PSYCHIC", CURSE_TYPE = "???" }
+
 function TypeChart.load(data)
   index = {}
   matchups = data.type_chart.matchups
@@ -27,9 +32,15 @@ end
 
 -- display name for the move-select TYPE/ box (mod types render their
 -- name instead of their raw id)
-function TypeChart.displayName(typeId)
-  local record = types and types[typeId] or TypeChart.TYPES[typeId]
-  return record and record.name or typeId
+function TypeChart.displayName(typeId, data)
+  -- Menus can be opened before the first battle has called TypeChart.load.
+  -- Accept their live Data explicitly so a merged type_chart translation is
+  -- still visible there; battle callers retain the cached-table fast path.
+  local supplied = data and data.type_chart and data.type_chart.types
+  local record = supplied and supplied[typeId]
+    or types and types[typeId]
+    or TypeChart.TYPES[typeId]
+  return record and record.name or DISPLAY_NAMES[typeId] or typeId
 end
 
 -- The x10 multipliers of every TypeEffects row that applies, in ROM

--- a/src/battle/WideBattle.lua
+++ b/src/battle/WideBattle.lua
@@ -253,7 +253,12 @@ local function drawMoveDetails(battle, move)
   local maxPP = def.pp + (move.ppUps or 0) * math.floor(def.pp / 5)
   love.graphics.setColor(0, 0, 0, 1)
   Font.draw(("PP %2d/%2d"):format(move.pp or 0, maxPP), 232, 112)
-  Font.draw(fitName(TypeChart.displayName(def.type), 64), 232, 128)
+  -- battle.data is game.data by reference (BattleState:startBattle sets it
+  -- before TypeChart.load(game.data)), so this resolves through the exact
+  -- same merged table TypeChart's own cache already has -- a no-op today,
+  -- kept only for the same call convention as the pre-battle screens
+  -- (SummaryMenu, HallOfFame) that genuinely need the explicit data.
+  Font.draw(fitName(TypeChart.displayName(def.type, battle.data), 64), 232, 128)
 end
 
 local function drawMoveGrid(battle, moves, selected)

--- a/src/battle/gen2/Battle.lua
+++ b/src/battle/gen2/Battle.lua
@@ -976,7 +976,7 @@ local function checkTurn(self, mon, moveId)
   local vol = self:volatile(mon)
   if vol.recharge then
     vol.recharge = nil
-    self:emit({ kind = "message", text = name .. " must recharge!" })
+    self:emit({ kind = "message", text = Strings("%s must recharge!", name) })
     return false
   end
   -- The status arms, through the merged record.  beforeMovePriority is what
@@ -1001,7 +1001,7 @@ local function checkTurn(self, mon, moveId)
   -- moves once they write the same flag.
   if vol.flinched then
     vol.flinched = nil
-    self:emit({ kind = "message", text = name .. " flinched!" })
+    self:emit({ kind = "message", text = Strings("%s flinched!", name) })
     return false
   end
   -- SUBSTATUS_CONFUSED (CheckPlayerTurn past `.not_flinched`): the count
@@ -1012,9 +1012,10 @@ local function checkTurn(self, mon, moveId)
     vol.confuseCount = vol.confuseCount - 1
     if vol.confuseCount <= 0 then
       vol.confuseCount = nil
-      self:emit({ kind = "message", text = name .. "'s confused no more!" })
+      self:emit({ kind = "message",
+        text = Strings("%s's confused no more!", name) })
     else
-      self:emit({ kind = "message", text = name .. " is confused!" })
+      self:emit({ kind = "message", text = Strings("%s is confused!", name) })
       if rand(self.random, 256) < 128 then
         self:confusionSelfHit(mon)
         return false
@@ -1259,7 +1260,7 @@ function Battle:hitOnce(attacker, defender, def, opts)
     -- immune hit into MoveDelay and no animation at all.
     self:markMissed()
     self:emit({ kind = "message",
-      text = "It doesn't affect " .. self:monName(defender) .. "..." })
+      text = Strings("It doesn't affect %s...", self:monName(defender)) })
     return 0, info
   end
   -- BattleCommand_FalseSwipe (engine/battle/move_effects/false_swipe.asm):
@@ -1293,11 +1294,12 @@ function Battle:dealDamage(attacker, defender, damage, opts)
     local absorbed = math.min(state.substitute, damage)
     state.substitute = state.substitute - absorbed
     self:emit({ kind = "message",
-      text = "The SUBSTITUTE took damage for " .. self:monName(defender) .. "!" })
+      text = Strings("The SUBSTITUTE took damage for %s!",
+        self:monName(defender)) })
     if state.substitute <= 0 then
       state.substitute = nil
       self:emit({ kind = "message",
-        text = self:monName(defender) .. "'s SUBSTITUTE broke!" })
+        text = Strings("%s's SUBSTITUTE broke!", self:monName(defender)) })
     end
     return absorbed
   end
@@ -1336,7 +1338,7 @@ function Battle:dealDamage(attacker, defender, damage, opts)
     effectiveness = opts.effectiveness,
   })
   if opts.critical then
-    self:emit({ kind = "message", text = "A critical hit!" })
+    self:emit({ kind = "message", text = Strings("A critical hit!") })
   end
   -- SuperEffectiveText / NotVeryEffectiveText (data/text/battle.asm:603,608).
   -- The cart breaks both across the box's two lines and hyphenates "super-"
@@ -1350,14 +1352,14 @@ function Battle:dealDamage(attacker, defender, damage, opts)
   end
   if endured then
     self:emit({ kind = "message",
-      text = self:monName(defender) .. " endured the hit!" })
+      text = Strings("%s endured the hit!", self:monName(defender)) })
   elseif hungOn then
     -- HungOnText, named after the item the way the cart pipes it through
     -- wStringBuffer1.
     local def = self:itemDef(defender.item)
     self:emit({ kind = "message",
-      text = self:monName(defender) .. " hung on with "
-        .. ((def and def.name) or "FOCUS BAND") .. "!" })
+      text = Strings("%s hung on with %s!", self:monName(defender),
+        (def and def.name) or "FOCUS BAND") })
   end
   -- SUBSTATUS_RAGE: being hit while raging raises the rager's Attack.
   if defenderState.rage and damage > 0 and (defender.hp or 0) > 0 then
@@ -1417,9 +1419,11 @@ function Battle:changeStage(target, stat, stages)
   local name = self:monName(target)
   if not applied then
     -- WontRiseAnymoreText / WontDropAnymoreText (data/text/battle.asm:718-732).
-    self:emit({ kind = "message", text = ("%s's %s won't %s anymore!"):format(
-      name, Effects.STAT_NAMES[stat] or stat,
-      stages > 0 and "rise" or "drop") })
+    local label = Strings(Effects.STAT_NAMES[stat] or stat)
+    local source = stages > 0
+      and Strings.source("%s's %s won't rise anymore!")
+      or Strings.source("%s's %s won't drop anymore!")
+    self:emit({ kind = "message", text = Strings(source, name, label) })
     return false
   end
   self:emit({ kind = "stage", side = self:sideOf(target), stat = stat,
@@ -1459,7 +1463,7 @@ function Battle:useMove(attacker, defender, moveId)
   -- effect list runs, so nothing a previous move set can reach this one.
   self.moveEvent = nil
   if not def then
-    self:emit({ kind = "message", text = name .. " has no move to use!" })
+    self:emit({ kind = "message", text = Strings("%s has no move to use!", name) })
     return
   end
 
@@ -1581,7 +1585,7 @@ function Battle:useMove(attacker, defender, moveId)
     end
     if not picked or (self.copyDepth or 0) > 0 then
       self:markMissed()
-      self:emit({ kind = "message", text = "But it failed!" })
+      self:emit({ kind = "message", text = Strings("But it failed!") })
       return
     end
     self.copyDepth = (self.copyDepth or 0) + 1
@@ -1608,7 +1612,7 @@ function Battle:useMove(attacker, defender, moveId)
     end
     if not picked then
       self:markMissed()
-      self:emit({ kind = "message", text = "But it failed!" })
+      self:emit({ kind = "message", text = Strings("But it failed!") })
       return
     end
     state.lastMove = nil
@@ -1659,15 +1663,15 @@ function Battle:useMove(attacker, defender, moveId)
     -- BattleCommand_Charge picks the line off the MOVE, not the shared
     -- EFFECT_FLY (`cp DIG`, effect_commands.asm:5464).
     local text = charge.text
-    if moveId == "DIG" then text = "%s dug a hole!" end
-    self:emit({ kind = "message", text = text:format(name) })
+    if moveId == "DIG" then text = Strings.source("%s dug a hole!") end
+    self:emit({ kind = "message", text = Strings(text, name) })
     return
   end
 
   -- BattleCommand_Snore (engine/battle/move_effects/snore.asm:1-9)
   if def.effect == "EFFECT_SNORE" and attacker.status ~= "sleep" then
     self:markMissed()
-    self:emit({ kind = "message", text = "But it failed!" })
+    self:emit({ kind = "message", text = Strings("But it failed!") })
     return
   end
 
@@ -1678,7 +1682,7 @@ function Battle:useMove(attacker, defender, moveId)
     local taken = state.tookThisTurn or 0
     if taken <= 0 or state.tookKind ~= counterKind then
       self:markMissed()
-      self:emit({ kind = "message", text = "But it failed!" })
+      self:emit({ kind = "message", text = Strings("But it failed!") })
       return
     end
     self:dealDamage(attacker, defender, Effects.counterDamage(taken),
@@ -1692,7 +1696,7 @@ function Battle:useMove(attacker, defender, moveId)
     if def.effect == "EFFECT_SELFDESTRUCT" then self:selfdestructUser(attacker) end
     self:markMissed()
     self:emit({ kind = "message",
-      text = self:monName(defender) .. " protected itself!" })
+      text = Strings("%s protected itself!", self:monName(defender)) })
     return
   end
 
@@ -1720,7 +1724,7 @@ function Battle:useMove(attacker, defender, moveId)
     -- so `selfdestruct` still runs ahead of failuretext.
     if def.effect == "EFFECT_SELFDESTRUCT" then self:selfdestructUser(attacker) end
     self:markMissed()
-    self:emit({ kind = "message", text = name .. "'s attack missed!" })
+    self:emit({ kind = "message", text = Strings("%s's attack missed!", name) })
     return
   end
 
@@ -1744,7 +1748,7 @@ function Battle:useMove(attacker, defender, moveId)
   -- refusing the move only after it had already hit and healed.
   if def.effect == "EFFECT_DREAM_EATER" and defender.status ~= "sleep" then
     self:markMissed()
-    self:emit({ kind = "message", text = name .. "'s attack missed!" })
+    self:emit({ kind = "message", text = Strings("%s's attack missed!", name) })
     return
   end
 
@@ -1763,7 +1767,7 @@ function Battle:useMove(attacker, defender, moveId)
     end
     self.moveEvent = self:emit({ kind = "message",
       moveAnim = moveId, side = self:sideOf(attacker),
-      text = ("Magnitude %d!"):format(number) })
+      text = Strings("Magnitude %d!", number) })
   end
 
   -- data/moves/effects.asm:1607, :1649
@@ -1779,7 +1783,7 @@ function Battle:useMove(attacker, defender, moveId)
     -- failuretext, so a missed Explosion still kills the user.
     if def.effect == "EFFECT_SELFDESTRUCT" then self:selfdestructUser(attacker) end
     self:markMissed()
-    self:emit({ kind = "message", text = name .. "'s attack missed!" })
+    self:emit({ kind = "message", text = Strings("%s's attack missed!", name) })
     -- Fury Cutter's ramp resets the moment it misses.
     state.rampMove = nil
     state.rampCount = nil
@@ -1801,7 +1805,7 @@ function Battle:useMove(attacker, defender, moveId)
     local cost = Effects.substituteCost(maxHp)
     if (attacker.hp or 0) <= cost or (state.substitute or 0) > 0 then
       self:markMissed()
-      self:emit({ kind = "message", text = "But it failed!" })
+      self:emit({ kind = "message", text = Strings("But it failed!") })
       return
     end
     attacker.hp = attacker.hp - cost
@@ -1811,7 +1815,7 @@ function Battle:useMove(attacker, defender, moveId)
     self:emit({ kind = "damage", side = self:sideOf(attacker), amount = cost,
       hp = attacker.hp, anim = false })
     self:emit({ kind = "message",
-      text = name .. " made a SUBSTITUTE!" })
+      text = Strings("%s made a SUBSTITUTE!", name) })
     return
   end
 
@@ -1831,7 +1835,7 @@ function Battle:useMove(attacker, defender, moveId)
     if Damage.typeMultiplier(def.type, defenderTypes, matchups) == 0 then
       self:markMissed()
       self:emit({ kind = "message",
-        text = "It doesn't affect " .. self:monName(defender) .. "..." })
+        text = Strings("It doesn't affect %s...", self:monName(defender)) })
       return
     end
     self:dealDamage(attacker, defender, fixed, { move = def, moveId = moveId })
@@ -1938,11 +1942,12 @@ function Battle:useMove(attacker, defender, moveId)
       -- (effect_commands.asm:5674-5687).
       self:emit({ kind = "damage", side = self:sideOf(attacker),
         amount = recoil, hp = attacker.hp, anim = false })
-      self:emit({ kind = "message", text = name .. " is hit with recoil!" })
+      self:emit({ kind = "message",
+        text = Strings("%s is hit with recoil!", name) })
     elseif Effects.DRAIN[def.effect] and dealt > 0 then
       self:heal(attacker, Effects.drainAmount(dealt))
       self:emit({ kind = "message",
-        text = self:monName(defender) .. "'s energy was drained!" })
+        text = Strings("%s's energy was drained!", self:monName(defender)) })
     end
 
     -- BattleCommand_RechargeNextTurn (effect_commands.asm:5899): HYPER BEAM
@@ -2003,7 +2008,7 @@ function Battle:useMove(attacker, defender, moveId)
         local trapText = Battle.TRAP_TEXT[moveId]
         self:emit({ kind = "message",
           text = trapText and trapText(self:monName(defender), name)
-            or (self:monName(defender) .. " was trapped!") })
+            or Strings("%s was trapped!", self:monName(defender)) })
       end
     end
   end
@@ -2023,7 +2028,7 @@ function Battle:useMove(attacker, defender, moveId)
         and def.effect ~= "EFFECT_ACCURACY_DOWN_HIT"
         and self:aiRandomFail(attacker, target) then
       self:markMissed()
-      self:emit({ kind = "message", text = "But it failed!" })
+      self:emit({ kind = "message", text = Strings("But it failed!") })
     elseif not self:changeStageAgainstMist(attacker, target, change[1], change[2])
     then
       self:markMissed()
@@ -2058,11 +2063,11 @@ function Battle:useMove(attacker, defender, moveId)
     if self:statusRefusedByType(defender, def.type, status) then
       self:markMissed()
       self:emit({ kind = "message",
-        text = "It doesn't affect " .. self:monName(defender) .. "..." })
+        text = Strings("It doesn't affect %s...", self:monName(defender)) })
     elseif Battle.AI_FAIL_STATUSES[status]
         and self:aiRandomFail(attacker, defender) then
       self:markMissed()
-      self:emit({ kind = "message", text = "But it failed!" })
+      self:emit({ kind = "message", text = Strings("But it failed!") })
     elseif not self:applyStatus(defender, status, attacker) then
       self:markMissed()
     end
@@ -2103,7 +2108,7 @@ Battle.MOVE_EFFECTS = {}
 -- marked the same way a missed one is.
 local function fail(self)
   self:markMissed()
-  self:emit({ kind = "message", text = "But it failed!" })
+  self:emit({ kind = "message", text = Strings("But it failed!") })
 end
 
 -- BattleCommand_Splash (engine/battle/move_effects/splash.asm): the whole
@@ -2128,7 +2133,7 @@ for effect, weather in pairs(Effects.WEATHER) do
     self.weather = weather
     self.weatherTurns = Effects.WEATHER_TURNS
     self:emit({ kind = "weather", weather = weather,
-      text = Effects.WEATHER_START_TEXT[weather] })
+      text = Strings(Effects.WEATHER_START_TEXT[weather]) })
   end
 end
 
@@ -2163,7 +2168,7 @@ Battle.MOVE_EFFECTS.EFFECT_ENCORE = function(self, attacker, defender)
   target.encore = last
   target.encoreTurns = Effects.encoreTurns(self.random)
   self:emit({ kind = "message",
-    text = self:monName(defender) .. " got an ENCORE!" })
+    text = Strings("%s got an ENCORE!", self:monName(defender)) })
 end
 
 -- BattleCommand_Disable: one of the target's moves, for 2-9 turns.  It fails
@@ -2180,8 +2185,11 @@ Battle.MOVE_EFFECTS.EFFECT_DISABLE = function(self, attacker, defender)
   if not found then return fail(self) end
   target.disabled = last
   target.disabledTurns = Effects.disableTurns(self.random)
+  local moveDef = self:moveDef(last)
+  local moveName = (moveDef and moveDef.name) or last or "?"
   self:emit({ kind = "message",
-    text = self:monName(defender) .. "'s " .. last .. " was disabled!" })
+    text = Strings("%s's %s was disabled!", self:monName(defender),
+      moveName) })
 end
 
 -- BattleCommand_LockOn: Lock-On and Mind Reader set SUBSTATUS_LOCK_ON on the
@@ -2194,12 +2202,12 @@ Battle.MOVE_EFFECTS.EFFECT_LOCK_ON = function(self, attacker, defender)
     -- animation is AnimateCurrentMove on the success arm only.
     self:markMissed()
     self:emit({ kind = "message",
-      text = "It doesn't affect " .. self:monName(defender) .. "..." })
+      text = Strings("It doesn't affect %s...", self:monName(defender)) })
     return
   end
   target.lockOn = true
   self:emit({ kind = "message",
-    text = self:monName(attacker) .. " took aim!" })
+    text = Strings("%s took aim!", self:monName(attacker)) })
 end
 
 -- engine/battle/move_effects/foresight.asm
@@ -2213,8 +2221,8 @@ Battle.MOVE_EFFECTS.EFFECT_FORESIGHT = function(self, attacker, defender,
   if target.vanished or target.identified then return fail(self) end
   target.identified = true
   self:emit({ kind = "message",
-    text = self:monName(attacker) .. " identified "
-      .. self:monName(defender) .. "!" })
+    text = Strings("%s identified %s!", self:monName(attacker),
+      self:monName(defender)) })
 end
 
 -- BattleCommand_CheckHit's .LockOn: the flag is read AND cleared by the next
@@ -2283,7 +2291,7 @@ function Battle:changeStageAgainstMist(attacker, target, stat, stages)
   if target ~= attacker and (stages or 0) < 0
       and self:volatile(target).mist then
     self:emit({ kind = "message",
-      text = self:monName(target) .. "'s protected by MIST." })
+      text = Strings("%s's protected by MIST.", self:monName(target)) })
     return false
   end
   return self:changeStage(target, stat, stages)
@@ -2300,7 +2308,8 @@ Battle.MOVE_EFFECTS.EFFECT_SPIKES = function(self, attacker, defender)
   -- src/ui/gen2/BattleState.lua sets self.message straight from the event and
   -- printMessage cuts past two rows, so the cart's line cannot be told here
   -- yet without the name being dropped on screen.  Left as it stands.
-  self:emit({ kind = "message", text = "Spikes were scattered all around!" })
+  self:emit({ kind = "message",
+    text = Strings("Spikes were scattered all around!") })
 end
 
 -- BattleCommand_Protect / Endure share ProtectChance, which halves the odds
@@ -2320,12 +2329,15 @@ local function protectLike(field, text)
     end
     state.protectCount = (state.protectCount or 0) + 1
     state[field] = true
-    self:emit({ kind = "message", text = self:monName(attacker) .. text })
+    self:emit({ kind = "message",
+      text = Strings(text, self:monName(attacker)) })
   end
 end
 
-Battle.MOVE_EFFECTS.EFFECT_PROTECT = protectLike("protect", " protected itself!")
-Battle.MOVE_EFFECTS.EFFECT_ENDURE = protectLike("endure", " braced itself!")
+Battle.MOVE_EFFECTS.EFFECT_PROTECT = protectLike("protect",
+  Strings.source("%s protected itself!"))
+Battle.MOVE_EFFECTS.EFFECT_ENDURE = protectLike("endure",
+  Strings.source("%s braced itself!"))
 
 -- BattleCommand_UnleashEnergy / StoreEnergy.  Turn one starts the store; the
 -- turn the counter runs out the user hits for double everything it took.
@@ -2337,19 +2349,19 @@ Battle.MOVE_EFFECTS.EFFECT_BIDE = function(self, attacker, defender, def, moveId
     -- engine/battle/core.asm:574-576
     state.bideMove = moveId
     self:emit({ kind = "message",
-      text = self:monName(attacker) .. " is storing energy!" })
+      text = Strings("%s is storing energy!", self:monName(attacker)) })
     return
   end
   state.bideTurns = state.bideTurns - 1
   if state.bideTurns > 0 then
     self:emit({ kind = "message",
-      text = self:monName(attacker) .. " is storing energy!" })
+      text = Strings("%s is storing energy!", self:monName(attacker)) })
     return
   end
   local damage = Effects.bideDamage(state.bideStored)
   state.bideTurns, state.bideStored, state.bideMove = nil, nil, nil
   self:emit({ kind = "message",
-    text = self:monName(attacker) .. " unleashed energy!" })
+    text = Strings("%s unleashed energy!", self:monName(attacker)) })
   if damage <= 0 then return fail(self) end
   self:dealDamage(attacker, defender, damage, { move = def, moveId = moveId })
 end
@@ -2362,6 +2374,7 @@ Battle.MOVE_EFFECTS.EFFECT_TRANSFORM = function(self, attacker, defender)
     return fail(self)
   end
   state.transformed = true
+  local attackerName = self:monName(attacker)
   -- The cart copies the target into BATTLE ram (wBattleMon / wEnemyMon) and
   -- leaves the struct the mon was loaded FROM alone, so every route out of the
   -- battle -- SwitchOutMon reloading the party slot, and PokeBallEffect
@@ -2397,6 +2410,10 @@ Battle.MOVE_EFFECTS.EFFECT_TRANSFORM = function(self, attacker, defender)
     stats[key] = theirs[key] or stats[key]
   end
   attacker.stats = stats
+  local targetName = (targetDef and targetDef.name)
+    or defender.species or self:monName(defender) or "?"
+  self:emit({ kind = "message", text = Strings("%s TRANSFORMED into %s!",
+    attackerName, targetName) })
   -- The moment itself, for the screen.  src/ui/gen2/BattleState.lua draws each
   -- side's pic and HUD from `shownMon`, which follows the EVENT QUEUE rather
   -- than the battle -- a whole round is resolved by Battle:takeTurn before its
@@ -2410,8 +2427,6 @@ Battle.MOVE_EFFECTS.EFFECT_TRANSFORM = function(self, attacker, defender)
   self:emit({ kind = "transform", side = self:sideOf(attacker),
     mon = attacker, species = attacker.species,
     from = state.preTransform.species })
-  self:emit({ kind = "message", text = self:monName(attacker)
-    .. " TRANSFORMED into " .. (defender.species or "?") .. "!" })
 end
 
 -- SwitchOutMon / PokeBallEffect's reload: the copy Transform wrote lives in
@@ -2466,7 +2481,7 @@ Battle.MOVE_EFFECTS.EFFECT_FUTURE_SIGHT = function(self, attacker, defender, def
   state.futureSightDamage = math.max(1, damage)
   state.futureSightSide = self:sideOf(defender)
   self:emit({ kind = "message",
-    text = self:monName(attacker) .. " foresaw an attack!" })
+    text = Strings("%s foresaw an attack!", self:monName(attacker)) })
 end
 
 -- BattleCommand_OHKO: fails outright against a higher-level target, and the
@@ -2481,7 +2496,7 @@ Battle.MOVE_EFFECTS.EFFECT_OHKO = function(self, attacker, defender, def, _,
     -- so the level refusal plays MoveDelay and nothing else.
     self:markMissed()
     self:emit({ kind = "message",
-      text = "It doesn't affect " .. self:monName(defender) .. "..." })
+      text = Strings("It doesn't affect %s...", self:monName(defender)) })
     return
   end
   -- BattleCommand_OHKO ends on `call BattleCommand_CheckHit`, so a lock-on
@@ -2492,12 +2507,12 @@ Battle.MOVE_EFFECTS.EFFECT_OHKO = function(self, attacker, defender, def, _,
   if not hit then
     self:markMissed()
     self:emit({ kind = "message",
-      text = self:monName(attacker) .. "'s attack missed!" })
+      text = Strings("%s's attack missed!", self:monName(attacker)) })
     return
   end
   self:dealDamage(attacker, defender, defender.hp or 1,
     { move = def, moveId = def and def.id })
-  self:emit({ kind = "message", text = "It's a one-hit KO!" })
+  self:emit({ kind = "message", text = Strings("It's a one-hit KO!") })
 end
 
 -- BattleCommand_BeatUp: one hit per healthy, unstatused party member, each
@@ -2533,7 +2548,7 @@ Battle.MOVE_EFFECTS.EFFECT_BEAT_UP = function(self, attacker, defender, def)
       random = self.random,
     })
     self:emit({ kind = "message",
-      text = self:monName(entry.mon) .. "'s attack!" })
+      text = Strings("%s's attack!", self:monName(entry.mon)) })
     self:dealDamage(attacker, defender, math.max(1, damage),
       { move = def, moveId = def and def.id })
     landed = landed + 1
@@ -2551,7 +2566,7 @@ Battle.MOVE_EFFECTS.EFFECT_HEAL = function(self, attacker, _, _, moveId)
   if (attacker.hp or 0) >= maxHp then
     self:markMissed()
     self:emit({ kind = "message",
-      text = self:monName(attacker) .. "'s HP is full!" })
+      text = Strings("%s's HP is full!", self:monName(attacker)) })
     return
   end
   if moveId == "REST" then
@@ -2561,17 +2576,18 @@ Battle.MOVE_EFFECTS.EFFECT_HEAL = function(self, attacker, _, _, moveId)
     attacker.status = "sleep"
     attacker.statusTurns = 3
     attacker.toxicCounter = nil
+    local source = cured
+      and Strings.source("%s fell asleep and became healthy!")
+      or Strings.source("%s went to sleep!")
     self:emit({ kind = "status", side = self:sideOf(attacker),
-      status = "sleep", text = self:monName(attacker)
-        .. (cured and " fell asleep and became healthy!"
-          or " went to sleep!") })
+      status = "sleep", text = Strings(source, self:monName(attacker)) })
     self:heal(attacker, maxHp)
   else
     self:heal(attacker, math.max(1, math.floor(maxHp / 2)))
   end
   -- effect_commands.asm:6058, RegainedHealthText.
   self:emit({ kind = "message",
-    text = self:monName(attacker) .. " regained health!" })
+    text = Strings("%s regained health!", self:monName(attacker)) })
 end
 
 -- BattleCommand_TimeBasedHealContinue (effect_commands.asm:6374) answers the
@@ -2583,7 +2599,7 @@ for effect, wants in pairs(Effects.SUN_HEAL) do
     if (attacker.hp or 0) >= maxHp then
       self:markMissed()
       self:emit({ kind = "message",
-        text = self:monName(attacker) .. "'s HP is full!" })
+        text = Strings("%s's HP is full!", self:monName(attacker)) })
       return
     end
     -- effect_commands.asm:6396-6417, the time of day and the weather (#1751).
@@ -2591,7 +2607,7 @@ for effect, wants in pairs(Effects.SUN_HEAL) do
       self.timeOfDay)
     self:heal(attacker, math.max(1, math.floor(maxHp * fraction)))
     self:emit({ kind = "message",
-      text = self:monName(attacker) .. " regained health!" })
+      text = Strings("%s regained health!", self:monName(attacker)) })
   end
 end
 
@@ -2615,7 +2631,7 @@ Battle.MOVE_EFFECTS.EFFECT_BATON_PASS = function(self, attacker)
   -- leaves the field with is an empty one, the same as any other switch out.
   self:clearVolatile(attacker)
   self:emit({ kind = "baton-pass", side = side, index = target,
-    text = self:monName(attacker) .. " passed the baton!" })
+    text = Strings("%s passed the baton!", self:monName(attacker)) })
   if side == "player" then
     self.playerIndex = target
     self.player = party[target]
@@ -2632,7 +2648,7 @@ Battle.MOVE_EFFECTS.EFFECT_BATON_PASS = function(self, attacker)
   self:emit({ kind = "send", side = side, mon = sent,
     hp = sent.hp or 0, status = sent.status or false,
     level = sent.level, experience = sent.experience,
-    text = "Go! " .. self:monName(sent) .. "!" })
+    text = Strings("Go! %s!", self:monName(sent)) })
 end
 
 -- BattleCommand_TrapTarget's .Traps table, one line per move: target first,
@@ -2640,13 +2656,13 @@ end
 -- fallback in the caller.
 Battle.TRAP_TEXT = {
   BIND = function(target, user)
-    return user .. " used BIND on " .. target .. "!"
+    return Strings("%s used BIND on %s!", user, target)
   end,
   WRAP = function(target, user)
-    return target .. " was WRAPPED by " .. user .. "!"
+    return Strings("%s was WRAPPED by %s!", target, user)
   end,
   CLAMP = function(target, user)
-    return target .. " was CLAMPED by " .. user .. "!"
+    return Strings("%s was CLAMPED by %s!", target, user)
   end,
 }
 
@@ -2677,7 +2693,7 @@ Battle.MOVE_EFFECTS.EFFECT_SAFEGUARD = function(self, attacker)
   if (side.safeguard or 0) > 0 then return fail(self) end
   side.safeguard = Battle.SCREEN_TURNS
   self:emit({ kind = "message",
-    text = self:monName(attacker) .. "'s covered by a veil!" })
+    text = Strings("%s's covered by a veil!", self:monName(attacker)) })
 end
 
 -- BattleCommand_Curse (engine/battle/move_effects/curse.asm): two moves in
@@ -2701,7 +2717,7 @@ Battle.MOVE_EFFECTS.EFFECT_CURSE = function(self, attacker, defender)
       -- The raising arm is the only one that calls AnimateCurrentMove.
       self:markMissed()
       self:emit({ kind = "message",
-        text = name .. "'s ATTACK won't rise anymore!" })
+        text = Strings("%s's ATTACK won't rise anymore!", name) })
       return
     end
     -- The cart's own order: Speed down first, then the two raises.  The
@@ -2724,8 +2740,8 @@ Battle.MOVE_EFFECTS.EFFECT_CURSE = function(self, attacker, defender)
   self:emit({ kind = "damage", side = self:sideOf(attacker), amount = cost,
     hp = attacker.hp, anim = false })
   self:emit({ kind = "message",
-    text = name .. " cut its own HP and put a CURSE on "
-      .. self:monName(defender) .. "!" })
+    text = Strings("%s cut its own HP and put a CURSE on %s!", name,
+      self:monName(defender)) })
 end
 
 -- engine/battle/move_effects/belly_drum.asm:1, data/moves/effects.asm:1835
@@ -2761,7 +2777,7 @@ Battle.MOVE_EFFECTS.EFFECT_LEECH_SEED = function(self, attacker, defender,
       and not self:accuracyRoll(def, attacker, defender) then
     self:markMissed()
     self:emit({ kind = "message",
-      text = self:monName(defender) .. " evaded the attack!" })
+      text = Strings("%s evaded the attack!", self:monName(defender)) })
     return
   end
   for _, type_ in ipairs((self:speciesDef(defender) or {}).types
@@ -2769,7 +2785,7 @@ Battle.MOVE_EFFECTS.EFFECT_LEECH_SEED = function(self, attacker, defender,
     if type_ == "GRASS" then
       self:markMissed()
       self:emit({ kind = "message",
-        text = "It doesn't affect " .. self:monName(defender) .. "..." })
+        text = Strings("It doesn't affect %s...", self:monName(defender)) })
       return
     end
   end
@@ -2777,12 +2793,12 @@ Battle.MOVE_EFFECTS.EFFECT_LEECH_SEED = function(self, attacker, defender,
   if (target.substitute or 0) > 0 or target.leechSeed then
     self:markMissed()
     self:emit({ kind = "message",
-      text = self:monName(defender) .. " evaded the attack!" })
+      text = Strings("%s evaded the attack!", self:monName(defender)) })
     return
   end
   target.leechSeed = true
   self:emit({ kind = "message",
-    text = self:monName(defender) .. " was seeded!" })
+    text = Strings("%s was seeded!", self:monName(defender)) })
 end
 
 -- BattleCommand_Spite (engine/battle/move_effects/spite.asm): 2-5 PP off the
@@ -2804,7 +2820,7 @@ Battle.MOVE_EFFECTS.EFFECT_SPITE = function(self, attacker, defender, def, _,
   local function didntAffect()
     self:markMissed()
     self:emit({ kind = "message",
-      text = "It didn't affect " .. self:monName(defender) .. "!" })
+      text = Strings("It didn't affect %s!", self:monName(defender)) })
   end
   if not sureHit
       and not self:accuracyRoll(def, attacker, defender) then
@@ -2820,7 +2836,7 @@ Battle.MOVE_EFFECTS.EFFECT_SPITE = function(self, attacker, defender, def, _,
   entry.pp = entry.pp - loss
   local moveName = (self:moveDef(last) or {}).name or last
   self:emit({ kind = "message",
-    text = ("%s's %s was reduced by %d!"):format(self:monName(defender),
+    text = Strings("%s's %s was reduced by %d!", self:monName(defender),
       moveName, loss) })
 end
 
@@ -2837,7 +2853,7 @@ Battle.MOVE_EFFECTS.EFFECT_MEAN_LOOK = function(self, attacker, defender)
   end
   self:volatile(attacker).trapsTarget = true
   self:emit({ kind = "message",
-    text = self:monName(defender) .. " can't escape now!" })
+    text = Strings("%s can't escape now!", self:monName(defender)) })
 end
 
 -- engine/battle/move_effects/attract.asm:1, CheckOppositeGender :24
@@ -2895,9 +2911,11 @@ Battle.MOVE_EFFECTS.EFFECT_FORCE_SWITCH = function(self, attacker, defender,
     -- FledInFearText for ROAR, BlownAwayText for everything else, naming
     -- the mon that was sent away.
     self.forcedSwitch = true
+    local source = moveId == "ROAR"
+      and Strings.source("%s fled in fear!")
+      or Strings.source("%s was blown away!")
     self:emit({ kind = "run", side = self:sideOf(defender),
-      text = self:monName(defender)
-        .. (moveId == "ROAR" and " fled in fear!" or " was blown away!") })
+      text = Strings(source, self:monName(defender)) })
     return
   end
 
@@ -2933,7 +2951,7 @@ Battle.MOVE_EFFECTS.EFFECT_FORCE_SWITCH = function(self, attacker, defender,
   self:emit({ kind = "send", side = self:sideOf(incoming), mon = incoming,
     hp = incoming.hp or 0, status = incoming.status or false,
     level = incoming.level, experience = incoming.experience,
-    text = self:monName(incoming) .. " was dragged out!" })
+    text = Strings("%s was dragged out!", self:monName(incoming)) })
   self:breakTrapsOnSend(incoming)
   self:spikesDamage(incoming)
   -- wForcedSwitch: the round ends here, skipping the between-turn effects.
@@ -2966,7 +2984,7 @@ Battle.MOVE_EFFECTS.EFFECT_TELEPORT = function(self, attacker, defender)
   self.outcome = "fled"
   self.forcedSwitch = true
   self:emit({ kind = "run", side = self:sideOf(attacker),
-    text = self:monName(attacker) .. " fled from battle!" })
+    text = Strings("%s fled from battle!", self:monName(attacker)) })
 end
 
 -- -------------------------------------------------------- the move effects
@@ -3070,8 +3088,9 @@ end
 -- status inflicts, chips, blocks a turn and cuts a stat like the vanilla six.
 Battle.STATUSES = {
   sleep = {
-    id = "sleep", label = "SLP", hudLabel = "SLP", healClass = "slp",
-    inflictText = " fell asleep!",
+    id = "sleep", label = Strings.source("SLP"),
+    healClass = "slp",
+    inflictText = Strings.source(" fell asleep!"),
     catchBonus = 10, catchBonusIntended = 10,
     -- BattleCommand_SleepTarget's .random_loop rerolls 0 and SLP_MASK before
     -- `inc a`, so sleep opens at 2 (effect_commands.asm:3591-3598, #1707).
@@ -3086,26 +3105,29 @@ Battle.STATUSES = {
       if mon.statusTurns <= 0 then
         mon.status = nil
         mon.statusTurns = nil
-        battle:emit({ kind = "message", text = name .. " woke up!" })
+        battle:emit({ kind = "message", text = Strings("%s woke up!", name) })
         return true
       end
-      battle:emit({ kind = "message", text = name .. " is fast asleep!" })
+      battle:emit({ kind = "message",
+        text = Strings("%s is fast asleep!", name) })
       return false
     end,
   },
   poison = {
-    id = "poison", label = "PSN", hudLabel = "PSN", healClass = "psn",
-    inflictText = " was poisoned!",
+    id = "poison", label = Strings.source("PSN"),
+    healClass = "psn",
+    inflictText = Strings.source(" was poisoned!"),
     catchBonus = 0, catchBonusIntended = 5,
     residual = function(_, _, maxHp)
       return math.max(1, math.floor(maxHp / Battle.POISON_FRACTION)),
-        " is hurt by poison!"
+        Strings.source(" is hurt by poison!")
     end,
   },
   toxic = {
     -- SUBSTATUS_TOXIC rides the poison byte, so the HUD says PSN either way.
-    id = "toxic", label = "PSN", hudLabel = "PSN", healClass = "psn",
-    inflictText = " was badly poisoned!",
+    id = "toxic", label = Strings.source("PSN"),
+    healClass = "psn",
+    inflictText = Strings.source(" was badly poisoned!"),
     catchBonus = 0, catchBonusIntended = 5,
     onInflict = function(_, mon) mon.toxicCounter = 1 end,
     -- Toxic ramps: n/16 of max HP on the nth turn.
@@ -3113,12 +3135,13 @@ Battle.STATUSES = {
       local counter = mon.toxicCounter or 1
       mon.toxicCounter = counter + 1
       return math.max(1, math.floor(maxHp * counter / 16)),
-        " is hurt by poison!"
+        Strings.source(" is hurt by poison!")
     end,
   },
   paralyze = {
-    id = "paralyze", label = "PAR", hudLabel = "PAR", healClass = "par",
-    inflictText = " is paralyzed! It may be unable to move!",
+    id = "paralyze", label = Strings.source("PAR"),
+    healClass = "par",
+    inflictText = Strings.source(" is paralyzed! It may be unable to move!"),
     catchBonus = 0, catchBonusIntended = 5,
     statPenalty = { stat = "speed", div = Battle.PARALYSIS_SPEED_DIVISOR },
     -- CheckPlayerTurn's last arm: after the flinch and confusion block.
@@ -3127,32 +3150,36 @@ Battle.STATUSES = {
       if rand(battle.random, Battle.PARALYSIS_SKIP_CHANCE) ~= 0 then
         return true
       end
-      battle:emit({ kind = "message", text = name .. "'s fully paralyzed!" })
+      battle:emit({ kind = "message",
+        text = Strings("%s's fully paralyzed!", name) })
       return false
     end,
   },
   burn = {
-    id = "burn", label = "BRN", hudLabel = "BRN", healClass = "brn",
-    inflictText = " was burned!",
+    id = "burn", label = Strings.source("BRN"),
+    healClass = "brn",
+    inflictText = Strings.source(" was burned!"),
     catchBonus = 0, catchBonusIntended = 5,
     statPenalty = { stat = "attack", div = Battle.BURN_ATTACK_DIVISOR },
     residual = function(_, _, maxHp)
       return math.max(1, math.floor(maxHp / Battle.BURN_FRACTION)),
-        " is hurt by its burn!"
+        Strings.source(" is hurt by its burn!")
     end,
   },
   freeze = {
-    id = "freeze", label = "FRZ", hudLabel = "FRZ", healClass = "frz",
-    inflictText = " was frozen solid!",
+    id = "freeze", label = Strings.source("FRZ"),
+    healClass = "frz",
+    inflictText = Strings.source(" was frozen solid!"),
     catchBonus = 10, catchBonusIntended = 10,
     beforeMovePriority = 30,
     beforeMove = function(battle, mon, name)
       if rand(battle.random, Battle.THAW_CHANCE) == 0 then
         mon.status = nil
-        battle:emit({ kind = "message", text = name .. " thawed out!" })
+        battle:emit({ kind = "message", text = Strings("%s thawed out!", name) })
         return true
       end
-      battle:emit({ kind = "message", text = name .. " is frozen solid!" })
+      battle:emit({ kind = "message",
+        text = Strings("%s is frozen solid!", name) })
       return false
     end,
   },
@@ -3161,7 +3188,8 @@ Battle.STATUSES = {
   -- It is a record all the same because its landing line is one of the seven
   -- src/core/gen2/ItemEffects.lua is held against.
   confuse = {
-    id = "confuse", label = "CONFUSED", inflictText = " became confused!",
+    id = "confuse", label = Strings.source("CONFUSED"),
+    inflictText = Strings.source(" became confused!"),
     substatus = true,
   },
 }
@@ -3187,6 +3215,31 @@ Battle.STATUS_TEXT = {}
 for id, record in pairs(Battle.STATUSES) do
   Battle.STATUS_TEXT[id] = record.inflictText
 end
+
+-- The vanilla records historically expose suffixes because mods can add the
+-- same shape.  Keep that API, but use complete templates for the built-ins so
+-- translators can move the battler name instead of being forced to prepend it.
+Battle.STATUS_INFLICT_TEMPLATES = {
+  sleep = Strings.source("%s fell asleep!"),
+  poison = Strings.source("%s was poisoned!"),
+  toxic = Strings.source("%s was badly poisoned!"),
+  paralyze = Strings.source("%s is paralyzed! It may be unable to move!"),
+  burn = Strings.source("%s was burned!"),
+  freeze = Strings.source("%s was frozen solid!"),
+  confuse = Strings.source("%s became confused!"),
+}
+
+Battle.STATUS_RESIDUAL_TEMPLATES = {
+  poison = Strings.source("%s is hurt by poison!"),
+  toxic = Strings.source("%s is hurt by poison!"),
+  burn = Strings.source("%s is hurt by its burn!"),
+}
+
+Battle.STATUS_RESIDUAL_SUFFIXES = {
+  poison = Strings.source(" is hurt by poison!"),
+  toxic = Strings.source(" is hurt by poison!"),
+  burn = Strings.source(" is hurt by its burn!"),
+}
 
 -- The merged `statuses` record for a status id, the module's own when no
 -- loader ran -- src/battle/BattleState.lua:effectRecord is the Gen 1 twin.
@@ -3272,13 +3325,12 @@ function Battle:applyStatus(mon, status, source)
   if source and self:sideOf(source) ~= self:sideOf(mon)
       and self:safeguarded(mon) then
     self:emit({ kind = "message",
-      text = self:monName(mon) .. " is protected by SAFEGUARD!" })
+      text = Strings("%s is protected by SAFEGUARD!", self:monName(mon)) })
     return false
   end
   -- One major status at a time.
   if mon.status then
-    self:emit({ kind = "message",
-      text = "But it failed!" })
+    self:emit({ kind = "message", text = Strings("But it failed!") })
     return false
   end
   mon.status = status
@@ -3286,9 +3338,18 @@ function Battle:applyStatus(mon, status, source)
   -- counter live, so a mod status can arm its own counter here too.
   local record = Battle.statusRecordFor(self.data, status)
   if record and record.onInflict then record.onInflict(self, mon) end
+  local template = Battle.STATUS_INFLICT_TEMPLATES[status]
+  local vanilla = Battle.STATUSES[status]
+  local text
+  if template and vanilla
+      and (not record or record.inflictText == vanilla.inflictText) then
+    text = Strings(template, self:monName(mon))
+  else
+    text = Strings("%s%s", self:monName(mon),
+      Strings((record and record.inflictText) or " is afflicted!"))
+  end
   self:emit({ kind = "status", side = self:sideOf(mon), status = status,
-    text = self:monName(mon)
-      .. ((record and record.inflictText) or " is afflicted!") })
+    text = text })
   -- battle.status_inflicted, the payload src/battle/StatusRegistry.lua emits on
   -- Gen 1, for the major status only -- confusion is a substatus in both
   -- generations and Gen 1 raises nothing for it either.  The `status` VALUE is
@@ -3316,7 +3377,7 @@ function Battle:applyConfusion(mon, turns, source)
   if source and self:sideOf(source) ~= self:sideOf(mon)
       and self:safeguarded(mon) then
     self:emit({ kind = "message",
-      text = self:monName(mon) .. " is protected by SAFEGUARD!" })
+      text = Strings("%s is protected by SAFEGUARD!", self:monName(mon)) })
     return false
   end
   local state = self:volatile(mon)
@@ -3325,14 +3386,18 @@ function Battle:applyConfusion(mon, turns, source)
   if held == "HELD_PREVENT_CONFUSE" then return false end
   if state.confuseCount then
     self:emit({ kind = "message",
-      text = self:monName(mon) .. "'s already confused!" })
+      text = Strings("%s's already confused!", self:monName(mon)) })
     return false
   end
   state.confuseCount = turns or (rand(self.random, 4) + 2)
   local record = Battle.statusRecordFor(self.data, "confuse")
+  local template = Battle.STATUS_INFLICT_TEMPLATES.confuse
+  local vanilla = Battle.STATUSES.confuse
   self:emit({ kind = "message",
-    text = self:monName(mon)
-      .. ((record and record.inflictText) or " became confused!") })
+    text = (not record or record.inflictText == vanilla.inflictText)
+      and Strings(template, self:monName(mon))
+      or Strings("%s%s", self:monName(mon),
+        Strings((record and record.inflictText) or " became confused!")) })
   return true
 end
 
@@ -3355,7 +3420,11 @@ function Battle:tickStatus(mon)
   local damage, text = residual(self, mon, maxHp)
   if not damage or damage <= 0 then return end
   mon.hp = math.max(0, mon.hp - damage)
-  self:emit({ kind = "message", text = name .. (text or " is hurt!") })
+  local template = Battle.STATUS_RESIDUAL_TEMPLATES[mon.status]
+  local suffix = Battle.STATUS_RESIDUAL_SUFFIXES[mon.status]
+  self:emit({ kind = "message", text = template and text == suffix
+      and Strings(template, name)
+      or Strings("%s%s", name, Strings(text or " is hurt!")) })
   -- Call_PlayBattleAnim_OnlyIfVisible runs on the sufferer's own turn
   -- (core.asm:970-976); a mod status the cart never had gets nothing.
   self:emit({ kind = "damage", side = self:sideOf(mon), amount = damage,
@@ -3377,9 +3446,11 @@ function Battle:resolveFaints()
       return false
     end
     self.enemyFaintAnnounced = self.enemy
+    local template = self.wild
+      and Strings.source("Wild %s fainted!")
+      or Strings.source("%s fainted!")
     self:emit({ kind = "faint", side = "enemy",
-      text = (self.wild and "Wild " or "") .. self:monName(self.enemy)
-        .. " fainted!" })
+      text = Strings(template, self:monName(self.enemy)) })
     -- battle.fainted, the payload BattleState:onFaint emits on Gen 1.
     -- `battler` is the mon itself here: Gen 2's engine has no battler wrapper.
     Runtime.emit("battle.fainted", { battle = self, battler = self.enemy,
@@ -3388,8 +3459,8 @@ function Battle:resolveFaints()
     local nextIndex = Battle.firstHealthy(self.enemyParty)
     if not nextIndex then
       if self.trainer then
-        self:emit({ kind = "message",
-          text = (self.trainer.name or "TRAINER") .. " was defeated!" })
+        self:emit({ kind = "message", text = Strings("%s was defeated!",
+          self.trainer.name or "TRAINER") })
         self:printWinLossText("win")
         self:awardPrizeMoney()
       end
@@ -3424,8 +3495,9 @@ function Battle:resolveFaints()
       replacement = true,
       hp = self.enemy.hp or 0, status = self.enemy.status or false,
       level = self.enemy.level, experience = self.enemy.experience,
-      text = (self.trainer and self.trainer.name or "Foe") .. " sent out "
-        .. self:monName(self.enemy) .. "!" })
+      text = Strings("%s sent out %s!",
+        self.trainer and self.trainer.name or "Foe",
+        self:monName(self.enemy)) })
     Runtime.emit("battle.battler_switched", {
       battle = self, side = self:sideRecord(self.enemy), battler = self.enemy,
       previous = previous,
@@ -3458,14 +3530,15 @@ function Battle:resolveFaints()
     if self.faintAnnounced ~= self.player then
       self.faintAnnounced = self.player
       self:emit({ kind = "faint", side = "player",
-        text = self:monName(self.player) .. " fainted!" })
+        text = Strings("%s fainted!", self:monName(self.player)) })
       Runtime.emit("battle.fainted", { battle = self, battler = self.player,
         side = self:sideRecord(self.player) })
       self:faintHappiness(self.player)
     end
     local nextIndex = Battle.firstHealthy(self.party)
     if not nextIndex then
-      self:emit({ kind = "message", text = "You have no more POKéMON!" })
+      self:emit({ kind = "message",
+        text = Strings("You have no more POKéMON!") })
       -- LostBattle (engine/battle/core.asm:2763-2782): only BATTLETYPE_CANLOSE
       -- reaches PrintWinLossText on a loss; every other loss whites out.
       if self.battleType == Battle.BATTLETYPE_CANLOSE then
@@ -3628,8 +3701,10 @@ function Battle:giveExperiencePass(loser, def, recipients, count, halved,
       if not silent then
         self:emit({ kind = "experience", index = index, amount = amount,
           -- BoostedExpPointsText, keyed on the traded arm alone.
-          text = self:monName(mon) .. " gained "
-            .. (traded and "a boosted " or "") .. amount .. " EXP. Points!" })
+          text = traded
+            and Strings("%s gained a boosted %d EXP. Points!",
+              self:monName(mon), amount)
+            or Strings("%s gained %d EXP. Points!", self:monName(mon), amount) })
       end
       if result.levels > 0 then
         -- "level up happiness mod", the cart's own comment, sitting right
@@ -3638,7 +3713,7 @@ function Battle:giveExperiencePass(loser, def, recipients, count, halved,
         -- ChangeHappiness is outside the level loop.
         Happiness.change(mon, "GAINLEVEL")
         self:emit({ kind = "level", index = index, level = mon.level,
-          text = self:monName(mon) .. " grew to level " .. mon.level .. "!",
+          text = Strings("%s grew to level %d!", self:monName(mon), mon.level),
           sfx = "Sfx_DexFanfare5079", waitSfx = true })
         for _, moveId in ipairs(result.learned) do
           local ok, reason, entry = Mon.learnMove(mon, moveId, self.data)
@@ -3648,7 +3723,7 @@ function Battle:giveExperiencePass(loser, def, recipients, count, halved,
             -- data/text/common_3.asm:119
             self:emit({ kind = "message",
               sfx = "Sfx_DexFanfare5079", waitSfx = true,
-              text = self:monName(mon) .. " learned " .. moveName .. "!" })
+              text = Strings("%s learned %s!", self:monName(mon), moveName) })
           elseif reason == "full" then
             -- LearnMove's full-moveset arm calls ForgetMove, which asks with
             -- AskForgetMoveText (engine/pokemon/learn.asm:29-34, :121-124).
@@ -3793,12 +3868,12 @@ function Battle:resolveForget(index, slot, entry, moveName)
     self.player.moves = mon.moves
   end
   self:emit({ kind = "message",
-    text = "1, 2 and… " .. self:monName(mon) .. " forgot " .. oldName .. "!" })
+    text = Strings("1, 2 and… %s forgot %s!", self:monName(mon), oldName) })
   -- engine/pokemon/learn.asm:115, data/text/common_3.asm:119
   self:emit({ kind = "message",
     sfx = "Sfx_DexFanfare5079", waitSfx = true,
-    text = self:monName(mon) .. " learned "
-      .. (moveName or (entry and entry.id) or "?") .. "!" })
+    text = Strings("%s learned %s!", self:monName(mon),
+      moveName or (entry and entry.id) or "?") })
   -- The forget path writes the slot itself rather than going through
   -- Mon.learnMove, so pokemon.move_learned is raised here too: a move WAS
   -- learned, and a mod counting moves must not miss the four-slot case.
@@ -3809,9 +3884,8 @@ end
 -- The other answer: keep the four it has.  MoveDidntLearn's line.
 function Battle:declineForget(index, moveName)
   local mon = self.party[index]
-  self:emit({ kind = "message",
-    text = (mon and self:monName(mon) or "It") .. " did not learn "
-      .. (moveName or "the move") .. "." })
+  self:emit({ kind = "message", text = Strings("%s did not learn %s.",
+    mon and self:monName(mon) or "It", moveName or "the move") })
 end
 
 -- NewBattleMonStatus / the enemy switch tail (core.asm:3864 and 3405): ANY
@@ -3874,7 +3948,7 @@ function Battle:switch(index)
   self:emit({ kind = "send", side = "player", mon = mon,
     hp = mon.hp or 0, status = mon.status or false,
     level = mon.level, experience = mon.experience,
-    text = "Go! " .. self:monName(mon) .. "!" })
+    text = Strings("Go! %s!", self:monName(mon)) })
   -- battle.battler_switched, the payload BattleState:resolveSwitch emits on
   -- Gen 1: the side record, whoever walked in, and whoever walked out.
   Runtime.emit("battle.battler_switched", {
@@ -3909,8 +3983,8 @@ function Battle:checkBerserkGene(mon)
   local def = self:itemDef(mon.item)
   mon.item = nil
   self:emit({ kind = "message",
-    text = self:monName(mon) .. "'s "
-      .. ((def and def.name) or "BERSERK GENE") .. " activated!" })
+    text = Strings("%s's %s activated!", self:monName(mon),
+      (def and def.name) or "BERSERK GENE") })
   self:changeStage(mon, "attack", 2)
   self:applyConfusion(mon, Battle.BERSERK_GENE_CONFUSE_TURNS)
   return true
@@ -3953,7 +4027,7 @@ function Battle:confusionSelfHit(mon)
   damage = math.min(damage, Damage.MAX_DAMAGE - Damage.MIN_DAMAGE)
     + Damage.MIN_DAMAGE
   self:emit({ kind = "message",
-    text = "It hurt itself in its confusion!" })
+    text = Strings("It hurt itself in its confusion!") })
   mon.hp = math.max(0, (mon.hp or 0) - damage)
   -- HitConfusion flickers with ANIM_HIT_CONFUSION on the self-hitter's own
   -- turn, not the move after-anim (effect_commands.asm:624-632, :521-529).
@@ -4015,21 +4089,22 @@ function Battle:checkObedience(moveId)
     mon.statusTurns = rand(self.random, 7) + 1
     mon.toxicCounter = nil
     self:emit({ kind = "status", side = self:sideOf(mon), status = "sleep",
-      text = name .. " began to nap!" })
+      text = Strings("%s began to nap!", name) })
     return true
   end
   if roll - margin < margin then
-    self:emit({ kind = "message", text = name .. " won't obey!" })
+    self:emit({ kind = "message", text = Strings("%s won't obey!", name) })
     self:confusionSelfHit(mon)
     return true
   end
   -- `.DoNothing`: one of four lines.
   local lines = {
-    " is loafing around.", " won't obey!", " turned away!",
-    " ignored orders!",
+    Strings.source("%s is loafing around."),
+    Strings.source("%s won't obey!"), Strings.source("%s turned away!"),
+    Strings.source("%s ignored orders!"),
   }
   self:emit({ kind = "message",
-    text = name .. lines[rand(self.random, 4) + 1] })
+    text = Strings(lines[rand(self.random, 4) + 1], name) })
   return true
 end
 
@@ -4044,7 +4119,7 @@ function Battle:useBattleItem(itemId)
   if stat then
     local def = self:itemDef(itemId)
     self:emit({ kind = "message",
-      text = "Used the " .. ((def and def.name) or itemId) .. "." })
+      text = Strings("Used the %s.", (def and def.name) or itemId) })
     self:changeStage(self.player, stat, 1)
     return true
   end
@@ -4055,13 +4130,13 @@ function Battle:useBattleItem(itemId)
   state[field] = true
   local def = self:itemDef(itemId)
   self:emit({ kind = "message",
-    text = "Used the " .. ((def and def.name) or itemId) .. "." })
+    text = Strings("Used the %s.", (def and def.name) or itemId) })
   if itemId == "GUARD_SPEC" then
     self:emit({ kind = "message",
-      text = self:monName(self.player) .. "'s shrouded in MIST!" })
+      text = Strings("%s's shrouded in MIST!", self:monName(self.player)) })
   elseif itemId == "DIRE_HIT" then
     self:emit({ kind = "message",
-      text = self:monName(self.player) .. " is getting pumped!" })
+      text = Strings("%s is getting pumped!", self:monName(self.player)) })
   end
   return true
 end
@@ -4082,7 +4157,7 @@ function Battle:spikesDamage(mon)
   local damage = math.max(1, math.floor(maxHp / 8))
   mon.hp = math.max(0, mon.hp - damage)
   self:emit({ kind = "message",
-    text = self:monName(mon) .. " is hurt by SPIKES!" })
+    text = Strings("%s is hurt by SPIKES!", self:monName(mon)) })
   -- SpikesDamage is text, HP and a HUD redraw: no anim (core.asm:3902-3910).
   self:emit({ kind = "damage", side = side, amount = damage, hp = mon.hp,
     anim = false })
@@ -4189,13 +4264,13 @@ function Battle:tryRun(pSpd)
   -- trainer check and any speed math.  Without this, running from the Red
   -- Gyarados returned a WIN to the script and forfeited the one-shot shiny.
   if self:noEscapeBattleType() then
-    self:emit({ kind = "message", text = "Can't escape!" })
+    self:emit({ kind = "message", text = Strings("Can't escape!") })
     self.runRefused = true
     return false
   end
   if self.trainer then
-    self:emit({ kind = "message", text = "No! There's no running from a "
-      .. "trainer battle!" })
+    self:emit({ kind = "message",
+      text = Strings("No! There's no running from a trainer battle!") })
     self.runRefused = true
     return false
   end
@@ -4204,7 +4279,7 @@ function Battle:tryRun(pSpd)
   -- and before the attempt is even counted.
   if self:volatile(self.enemy).trapsTarget
       or (self:volatile(self.player).wrapCount or 0) > 0 then
-    self:emit({ kind = "message", text = "Can't escape!" })
+    self:emit({ kind = "message", text = Strings("Can't escape!") })
     self.runRefused = true
     return false
   end
@@ -4212,11 +4287,11 @@ function Battle:tryRun(pSpd)
   -- engine/battle/core.asm:2614
   if self:runRoll(pSpd or self:effectiveSpeed(self.player),
       self:effectiveSpeed(self.enemy)) then
-    self:emit({ kind = "run", text = "Got away safely!" })
+    self:emit({ kind = "run", text = Strings("Got away safely!") })
     self:endBattle("run")
     return true
   end
-  self:emit({ kind = "message", text = "Can't escape!" })
+  self:emit({ kind = "message", text = Strings("Can't escape!") })
   return false
 end
 
@@ -4294,7 +4369,7 @@ end
 function Battle:enemyFled()
   self:endBattle("fled")
   self:emit({ kind = "run", side = "enemy",
-    text = "Wild " .. self:monName(self.enemy) .. " fled!" })
+    text = Strings("Wild %s fled!", self:monName(self.enemy)) })
   return true
 end
 
@@ -4397,8 +4472,8 @@ function Battle:switchEnemy(index)
   self:clearVolatile(self.enemy)
   local outgoing = self.enemy
   local trainerName = (self.trainer and self.trainer.name) or "TRAINER"
-  self:emit({ kind = "message",
-    text = trainerName .. " withdrew " .. self:monName(outgoing) .. "!" })
+  self:emit({ kind = "message", text = Strings("%s withdrew %s!",
+    trainerName, self:monName(outgoing)) })
   self.enemyIndex = index
   self.enemy = mon
   -- AI_Switch (engine/battle/ai/items.asm:697)
@@ -4409,7 +4484,8 @@ function Battle:switchEnemy(index)
   self:emit({ kind = "send", side = "enemy", mon = self.enemy,
     hp = self.enemy.hp or 0, status = self.enemy.status or false,
     level = self.enemy.level, experience = self.enemy.experience,
-    text = trainerName .. " sent out " .. self:monName(self.enemy) .. "!" })
+    text = Strings("%s sent out %s!", trainerName,
+      self:monName(self.enemy)) })
   Runtime.emit("battle.battler_switched", {
     battle = self, side = self:sideRecord(self.enemy), battler = self.enemy,
     previous = outgoing,
@@ -4437,9 +4513,10 @@ function Battle:enemyUseItem(item)
     self.enemy.status = nil
     self:volatile(self.enemy).confuseCount = nil
   end
-  self:emit({ kind = "message",
-    text = ((self.trainer and self.trainer.name) or "TRAINER")
-      .. " used " .. item .. "!" })
+  local itemDef = self:itemDef(item)
+  local itemName = (itemDef and itemDef.name) or item or "?"
+  self:emit({ kind = "message", text = Strings("%s used %s!",
+    (self.trainer and self.trainer.name) or "TRAINER", itemName) })
   return true
 end
 
@@ -4700,7 +4777,7 @@ local function runTurn(self, action, enemyAction)
     if not charging and not bideLocked
         and not self:hasUsableMoves(self.player) then
       self:emit({ kind = "message",
-        text = self:monName(self.player) .. " has no moves left!" })
+        text = Strings("%s has no moves left!", self:monName(self.player)) })
       move = Battle.STRUGGLE
     end
     -- CheckPlayerTurn's disabled arm spends the turn, whatever was selected
@@ -4710,8 +4787,11 @@ local function runTurn(self, action, enemyAction)
       -- vanished FLY/DIG user back (:364-368).
       local state = self:volatile(self.player)
       state.chargeMove, state.vanished = nil, nil
+      local moveDef = self:moveDef(move)
+      local moveName = (moveDef and moveDef.name) or move or "?"
       self:emit({ kind = "message",
-        text = self:monName(self.player) .. "'s " .. move .. " is DISABLED!" })
+        text = Strings("%s's %s is DISABLED!", self:monName(self.player),
+          moveName) })
       return
     end
     -- BattleCommand_CheckObedience runs at the head of the move's effect
@@ -4738,15 +4818,17 @@ local function runTurn(self, action, enemyAction)
       if not charging and not bideLocked
           and not self:hasUsableMoves(self.enemy) then
         self:emit({ kind = "message",
-          text = self:monName(self.enemy) .. " has no moves left!" })
+          text = Strings("%s has no moves left!", self:monName(self.enemy)) })
         enemyMoveId = Battle.STRUGGLE
       end
       if not enemyMoveId then enemyMoveId = Battle.STRUGGLE end
       if self:moveDisabled(self.enemy, enemyMoveId) then
         local state = self:volatile(self.enemy)
         state.chargeMove, state.vanished = nil, nil
-        self:emit({ kind = "message", text = self:monName(self.enemy)
-          .. "'s " .. enemyMoveId .. " is DISABLED!" })
+        local moveDef = self:moveDef(enemyMoveId)
+        local moveName = (moveDef and moveDef.name) or enemyMoveId or "?"
+        self:emit({ kind = "message", text = Strings("%s's %s is DISABLED!",
+          self:monName(self.enemy), moveName) })
         return
       end
       self:useMove(self.enemy, self.player, enemyMoveId)
@@ -4768,8 +4850,10 @@ local function runTurn(self, action, enemyAction)
     if self:moveDisabled(self.enemy, enemyMoveId) then
       local state = self:volatile(self.enemy)
       state.chargeMove, state.vanished = nil, nil
-      self:emit({ kind = "message",
-        text = self:monName(self.enemy) .. "'s " .. enemyMoveId .. " is DISABLED!" })
+      local moveDef = self:moveDef(enemyMoveId)
+      local moveName = (moveDef and moveDef.name) or enemyMoveId or "?"
+      self:emit({ kind = "message", text = Strings("%s's %s is DISABLED!",
+        self:monName(self.enemy), moveName) })
       return
     end
     self:useMove(self.enemy, self.player, enemyMoveId)
@@ -4882,12 +4966,12 @@ function Battle:tickWeather()
   self.weatherTurns = self.weatherTurns - 1
   if self.weatherTurns <= 0 then
     self:emit({ kind = "weather", weather = nil,
-      text = Effects.WEATHER_END_TEXT[self.weather] })
+      text = Strings(Effects.WEATHER_END_TEXT[self.weather]) })
     self.weather = nil
     return
   end
   self:emit({ kind = "message",
-    text = Effects.WEATHER_TURN_TEXT[self.weather] })
+    text = Strings(Effects.WEATHER_TURN_TEXT[self.weather]) })
   if self.weather ~= "sandstorm" then return end
   for _, mon in ipairs({ self.player, self.enemy }) do
     if (mon.hp or 0) > 0 and not self:volatile(mon).vanished then
@@ -4898,7 +4982,8 @@ function Battle:tickWeather()
         local damage = Effects.sandstormDamage(maxHp)
         mon.hp = math.max(0, mon.hp - damage)
         self:emit({ kind = "message",
-          text = self:monName(mon) .. " is buffeted by the sandstorm!" })
+          text = Strings("%s is buffeted by the sandstorm!",
+            self:monName(mon)) })
         -- .SandstormDamage plays ANIM_IN_SANDSTORM between two SwitchTurnCore
         -- calls, so it runs from the OTHER side (core.asm:1688-1693).
         self:emit({ kind = "damage", side = self:sideOf(mon),
@@ -4920,8 +5005,9 @@ function Battle:tickFutureSight(mon)
   state.futureSight, state.futureSightDamage, state.futureSightSide =
     nil, nil, nil
   if (target.hp or 0) <= 0 then return end
-  self:emit({ kind = "message", text = self:monName(target)
-    .. " took the FUTURE SIGHT attack!" })
+  self:emit({ kind = "message",
+    text = Strings("%s took the FUTURE SIGHT attack!",
+      self:monName(target)) })
   self:dealDamage(mon, target, damage, {})
 end
 
@@ -4931,8 +5017,8 @@ function Battle:tickPerish(mon)
   if not state.perish or (mon.hp or 0) <= 0 then return end
   state.perish = state.perish - 1
   if state.perish > 0 then
-    self:emit({ kind = "message", text = self:monName(mon)
-      .. "'s PERISH count is " .. state.perish .. "!" })
+    self:emit({ kind = "message", text = Strings("%s's PERISH count is %d!",
+      self:monName(mon), state.perish) })
     return
   end
   state.perish = nil
@@ -4954,7 +5040,7 @@ function Battle:tickSeedAndCurse(mon)
     local damage = math.min(math.max(1, math.floor(maxHp / 8)), mon.hp)
     mon.hp = mon.hp - damage
     self:emit({ kind = "message",
-      text = "LEECH SEED saps " .. self:monName(mon) .. "!" })
+      text = Strings("LEECH SEED saps %s!", self:monName(mon)) })
     -- ANIM_SAP plays between two SwitchTurnCore calls, from the seeder's side
     -- (core.asm:1013-1021).
     self:emit({ kind = "damage", side = self:sideOf(mon), amount = damage,
@@ -4966,7 +5052,7 @@ function Battle:tickSeedAndCurse(mon)
     local damage = math.max(1, math.floor(maxHp / 4))
     mon.hp = math.max(0, mon.hp - damage)
     self:emit({ kind = "message",
-      text = self:monName(mon) .. "'s hurt by the CURSE!" })
+      text = Strings("%s's hurt by the CURSE!", self:monName(mon)) })
     -- The curse arm borrows ANIM_IN_NIGHTMARE, on the sufferer's own turn
     -- (core.asm:1057-1060).
     self:emit({ kind = "damage", side = self:sideOf(mon), amount = damage,
@@ -4986,14 +5072,14 @@ function Battle:tickWrap(mon)
   if state.wrapCount <= 0 then
     state.wrapCount, state.wrapMove, state.wrapMoveId = nil, nil, nil
     self:emit({ kind = "message",
-      text = self:monName(mon) .. " was released from " .. moveName .. "!" })
+      text = Strings("%s was released from %s!", self:monName(mon), moveName) })
     return
   end
   local maxHp = mon.maxHp or (mon.stats and mon.stats.hp) or 16
   local damage = math.max(1, math.floor(maxHp / 16))
   mon.hp = math.max(0, mon.hp - damage)
   self:emit({ kind = "message",
-    text = self:monName(mon) .. "'s hurt by " .. moveName .. "!" })
+    text = Strings("%s's hurt by %s!", self:monName(mon), moveName) })
   -- The trapping move's own anim, played from the trapper's side between two
   -- SwitchTurnCore calls (core.asm:1198-1203).
   self:emit({ kind = "damage", side = self:sideOf(mon), amount = damage,
@@ -5002,10 +5088,12 @@ end
 
 -- HandleScreens (engine/battle/core.asm:1564): each side's five-turn counts
 -- tick down and the screen falls the turn its count reaches zero.
-Battle.SCREEN_SIDE_LABEL = { player = "Your", enemy = "Enemy" }
+Battle.SCREEN_SIDE_LABEL = {
+  player = Strings.source("Your"), enemy = Strings.source("Enemy"),
+}
 Battle.SCREEN_FALL_TEXT = {
-  lightScreen = " POKéMON's LIGHT SCREEN fell!",
-  reflect = " POKéMON's REFLECT faded!",
+  lightScreen = Strings.source("%s POKéMON's LIGHT SCREEN fell!"),
+  reflect = Strings.source("%s POKéMON's REFLECT faded!"),
 }
 
 function Battle:tickScreens()
@@ -5019,11 +5107,12 @@ function Battle:tickScreens()
           if field == "safeguard" then
             -- engine/battle/core.asm:1527
             self:emit({ kind = "message",
-              text = self:monName(self[side]) .. "'s SAFEGUARD faded!" })
+              text = Strings("%s's SAFEGUARD faded!",
+                self:monName(self[side])) })
           else
             self:emit({ kind = "message",
-              text = Battle.SCREEN_SIDE_LABEL[side]
-                .. Battle.SCREEN_FALL_TEXT[field] })
+              text = Strings(Battle.SCREEN_FALL_TEXT[field],
+                Strings(Battle.SCREEN_SIDE_LABEL[side])) })
           end
         end
       end
@@ -5045,7 +5134,7 @@ function Battle:tickCounters(mon)
     if state.encoreTurns <= 0 then
       state.encore, state.encoreTurns = nil, nil
       self:emit({ kind = "message",
-        text = self:monName(mon) .. "'s ENCORE ended!" })
+        text = Strings("%s's ENCORE ended!", self:monName(mon)) })
     end
   end
   if state.disabledTurns then
@@ -5053,7 +5142,8 @@ function Battle:tickCounters(mon)
     if state.disabledTurns <= 0 then
       state.disabled, state.disabledTurns = nil, nil
       self:emit({ kind = "message",
-        text = self:monName(mon) .. "'s move is no longer disabled!" })
+        text = Strings("%s's move is no longer disabled!",
+          self:monName(mon)) })
     end
   end
 end
@@ -5101,7 +5191,8 @@ function Battle:tickHeldItem(mon)
     local healed = self:heal(mon, math.max(1, math.floor(maxHp / 16)))
     if healed > 0 then
       self:emit({ kind = "message",
-        text = name .. "'s " .. (def.name or "item") .. " restored health!" })
+        text = Strings("%s's %s restored health!", name,
+          def.name or "item") })
     end
     return
   end
@@ -5111,7 +5202,7 @@ function Battle:tickHeldItem(mon)
     self:heal(mon, parameter > 0 and parameter or 10, { anim = "RECOVER" })
     mon.item = nil
     self:emit({ kind = "message",
-      text = name .. " ate the " .. (def.name or "BERRY") .. "!" })
+      text = Strings("%s ate the %s!", name, def.name or "BERRY") })
     return
   end
 
@@ -5123,7 +5214,8 @@ function Battle:tickHeldItem(mon)
     mon.toxicCounter = nil
     mon.item = nil
     self:emit({ kind = "status", side = self:sideOf(mon), status = nil,
-      text = name .. "'s " .. (def.name or "item") .. " cured its status!" })
+      text = Strings("%s's %s cured its status!", name,
+        def.name or "item") })
   end
 
   -- UseConfusionHealingItem: HELD_HEAL_CONFUSION (a Bitter Berry) and the
@@ -5134,8 +5226,8 @@ function Battle:tickHeldItem(mon)
     self:volatile(mon).confuseCount = nil
     mon.item = nil
     self:emit({ kind = "message",
-      text = name .. "'s " .. (def.name or "item")
-        .. " cured its confusion!" })
+      text = Strings("%s's %s cured its confusion!", name,
+        def.name or "item") })
   end
 end
 
@@ -5159,8 +5251,8 @@ function Battle:forcedReplacement(side, index)
     self:emit({ kind = "send", side = "enemy", mon = mon, replacement = true,
       hp = mon.hp or 0, status = mon.status or false,
       level = mon.level, experience = mon.experience,
-      text = ((self.trainer and self.trainer.name) or "Foe") .. " sent out "
-        .. self:monName(mon) .. "!" })
+      text = Strings("%s sent out %s!",
+        (self.trainer and self.trainer.name) or "Foe", self:monName(mon)) })
     Runtime.emit("battle.battler_switched", {
       battle = self, side = self:sideRecord(mon), battler = mon,
       previous = previous,

--- a/src/battle/gen2/Effects.lua
+++ b/src/battle/gen2/Effects.lua
@@ -12,6 +12,8 @@
 -- returns a value or a small table, which is what lets the tests drive them
 -- directly.
 
+local Strings = require("src.core.Strings")
+
 local Effects = {}
 
 -- --------------------------------------------------------------- stat stages
@@ -64,9 +66,11 @@ Effects.ALL_UP_STATS = {
 }
 
 Effects.STAT_NAMES = {
-  attack = "ATTACK", defense = "DEFENSE", speed = "SPEED",
-  specialAttack = "SPCL.ATK", specialDefense = "SPCL.DEF",
-  accuracy = "ACCURACY", evasion = "EVASION",
+  attack = Strings.source("ATTACK"), defense = Strings.source("DEFENSE"),
+  speed = Strings.source("SPEED"),
+  specialAttack = Strings.source("SPCL.ATK"),
+  specialDefense = Strings.source("SPCL.DEF"),
+  accuracy = Strings.source("ACCURACY"), evasion = Strings.source("EVASION"),
 }
 
 -- Stages clamp at ±6 (BattleCommand_StatUp's .CantRaise / .CantLower).
@@ -88,10 +92,17 @@ end
 -- BattleCommand_StatUpMessage / StatDownMessage: one stage is "rose"/"fell",
 -- two are "sharply rose" / "sharply fell".
 function Effects.stageMessage(name, stat, applied)
-  local label = Effects.STAT_NAMES[stat] or stat
-  local sharply = math.abs(applied) >= 2 and "sharply " or ""
-  local verb = applied > 0 and "rose" or "fell"
-  return ("%s's %s %s%s!"):format(name, label, sharply, verb)
+  local label = Strings(Effects.STAT_NAMES[stat] or stat)
+  if applied > 0 then
+    if math.abs(applied) >= 2 then
+      return Strings("%s's %s sharply rose!", name, label)
+    end
+    return Strings("%s's %s rose!", name, label)
+  end
+  if math.abs(applied) >= 2 then
+    return Strings("%s's %s sharply fell!", name, label)
+  end
+  return Strings("%s's %s fell!", name, label)
 end
 
 -- ------------------------------------------------------------------ hit count
@@ -156,11 +167,11 @@ Effects.DRAIN = {
 -- stores the move, turn two attacks.  Fly and Dig also make the user
 -- untargetable in between, which is the `semi-invulnerable` flag here.
 Effects.CHARGE = {
-  EFFECT_RAZOR_WIND = { text = "%s made a whirlwind!" },
-  EFFECT_SOLARBEAM = { text = "%s took in sunlight!" },
-  EFFECT_SKULL_BASH = { text = "%s lowered its head!" },
-  EFFECT_SKY_ATTACK = { text = "%s is glowing!" },
-  EFFECT_FLY = { text = "%s flew up high!", vanish = true },
+  EFFECT_RAZOR_WIND = { text = Strings.source("%s made a whirlwind!") },
+  EFFECT_SOLARBEAM = { text = Strings.source("%s took in sunlight!") },
+  EFFECT_SKULL_BASH = { text = Strings.source("%s lowered its head!") },
+  EFFECT_SKY_ATTACK = { text = Strings.source("%s is glowing!") },
+  EFFECT_FLY = { text = Strings.source("%s flew up high!"), vanish = true },
 }
 
 -- CheckHit's .FlyDigMoves (effect_commands.asm:1713-1746): a vanished target
@@ -308,21 +319,21 @@ Effects.WEATHER = {
 Effects.WEATHER_TURNS = 5
 
 Effects.WEATHER_START_TEXT = {
-  rain = "It started to rain!",
-  sun = "The sunlight got bright!",
-  sandstorm = "A sandstorm brewed!",
+  rain = Strings.source("It started to rain!"),
+  sun = Strings.source("The sunlight got bright!"),
+  sandstorm = Strings.source("A sandstorm brewed!"),
 }
 
 Effects.WEATHER_TURN_TEXT = {
-  rain = "Rain continues to fall.",
-  sun = "The sunlight is strong.",
-  sandstorm = "The sandstorm rages.",
+  rain = Strings.source("Rain continues to fall."),
+  sun = Strings.source("The sunlight is strong."),
+  sandstorm = Strings.source("The sandstorm rages."),
 }
 
 Effects.WEATHER_END_TEXT = {
-  rain = "The rain stopped.",
-  sun = "The sunlight faded.",
-  sandstorm = "The sandstorm subsided.",
+  rain = Strings.source("The rain stopped."),
+  sun = Strings.source("The sunlight faded."),
+  sandstorm = Strings.source("The sandstorm subsided."),
 }
 
 -- data/battle/weather_modifiers.asm pairs each weather with MORE_EFFECTIVE or

--- a/src/core/gen2/Boxes.lua
+++ b/src/core/gen2/Boxes.lua
@@ -195,10 +195,14 @@ function Boxes.move(save, fromBox, slot, toBox)
   return true, mon
 end
 
--- .CheckCanUsePC: "You'll need a POKéMON to call with."
+-- .CheckCanUsePC: "You'll need a POKéMON to call with." Three lines, and the
+-- box only has room for two before a `\n` here would just glue the third
+-- onto the second with no separator -- `\f` (BoxMenu.lua's own
+-- BOX_FAILURE_SOURCES entry for this exact string, already in the catalog
+-- under that key) breaks it into its own page instead.
 function Boxes.canUsePc(save)
   if not (save and save.party and #save.party > 0) then
-    return false, "You'll need a\nPOKéMON to call\nwith."
+    return false, "You'll need a\nPOKéMON to call\fwith."
   end
   return true
 end

--- a/src/core/gen2/Decorations.lua
+++ b/src/core/gen2/Decorations.lua
@@ -300,6 +300,16 @@ function Decorations.useRegistry(data)
   return registryRows ~= nil
 end
 
+-- GetDecoName's grammar.  These are templates rather than translated suffix
+-- fragments so a language can move the kind before or after the authored
+-- colour/species name.  Strings.source keeps the templates visible to the
+-- translation catalog while the lookup stays at use time, after mods load.
+local BED_NAME = Strings.source("%s BED")
+local CARPET_NAME = Strings.source("%s CARPET")
+local POSTER_NAME = Strings.source("%s POSTER")
+local DOLL_NAME = Strings.source("%s DOLL")
+local BIG_DOLL_NAME = Strings.source("BIG %s")
+
 -- GetDecoName: the display name, built from the type and the name column.  The
 -- four types that name a SPECIES read the mon's name out of the data table,
 -- which is what `monName` is for; with no resolver the constant is already the
@@ -308,12 +318,12 @@ function Decorations.name(decoId, monName)
   local attr = Decorations.attributes(decoId)
   if not attr then return "" end
   local base = attr.name
-  if attr.type == BED then return base .. " BED" end
-  if attr.type == CARPET then return base .. " CARPET" end
+  if attr.type == BED then return Strings(BED_NAME, base) end
+  if attr.type == CARPET then return Strings(CARPET_NAME, base) end
   local mon = (monName and monName(base)) or base
-  if attr.type == POSTER then return mon .. " POSTER" end
-  if attr.type == DOLL then return mon .. " DOLL" end
-  if attr.type == BIGDOLL then return "BIG " .. mon end
+  if attr.type == POSTER then return Strings(POSTER_NAME, mon) end
+  if attr.type == DOLL then return Strings(DOLL_NAME, mon) end
+  if attr.type == BIGDOLL then return Strings(BIG_DOLL_NAME, mon) end
   return base
 end
 

--- a/src/core/gen2/Phone.lua
+++ b/src/core/gen2/Phone.lua
@@ -134,20 +134,30 @@ Phone.PERMANENT_NUMBERS = { Phone.PHONECONTACT_MOM, Phone.PHONECONTACT_ELM }
 -- The table is indexed from ZERO: PHONE_00 is a real row (the wrong-number
 -- filler that LoadCallerScript falls back to) and three of its siblings sit in
 -- the middle of the table as const_skip holes.
+--
+-- The non-trainer rows also carry their own `name`, copied verbatim from
+-- NON_TRAINER_NAMES rather than left for Phone.contactName() to look up
+-- there: the phone_contacts registry overrides `name` directly (see
+-- Phone.contactName below), so a row needs its vanilla value sitting in the
+-- same field a patch would replace, not in a separate table a patched row
+-- would silently keep falling through to.
 Phone.CONTACTS = {
-  [0]  = { number = 0, map = nil,
+  [0]  = { number = 0, name = "----------", map = nil,
            calleeTime = 0, callee = "UnusedPhoneScript",
            callerTime = 0, caller = "UnusedPhoneScript" },
-  [1]  = { number = Phone.PHONECONTACT_MOM, map = "PLAYERS_HOUSE_1F",
+  [1]  = { number = Phone.PHONECONTACT_MOM, name = "MOM",
+           map = "PLAYERS_HOUSE_1F",
            calleeTime = Phone.ANYTIME, callee = "MomPhoneCalleeScript",
            callerTime = 0, caller = "UnusedPhoneScript" },
-  [2]  = { number = Phone.PHONECONTACT_BIKESHOP, map = "OAKS_LAB",
+  [2]  = { number = Phone.PHONECONTACT_BIKESHOP, name = "BIKE SHOP",
+           map = "OAKS_LAB",
            calleeTime = 0, callee = "UnusedPhoneScript",
            callerTime = 0, caller = "UnusedPhoneScript" },
-  [3]  = { number = Phone.PHONECONTACT_BILL, map = nil,
+  [3]  = { number = Phone.PHONECONTACT_BILL, name = "BILL", map = nil,
            calleeTime = Phone.ANYTIME, callee = "BillPhoneCalleeScript",
            callerTime = 0, caller = "BillPhoneCallerScript" },
-  [4]  = { number = Phone.PHONECONTACT_ELM, map = "ELMS_LAB",
+  [4]  = { number = Phone.PHONECONTACT_ELM, name = "PROF.ELM",
+           map = "ELMS_LAB",
            calleeTime = Phone.ANYTIME, callee = "ElmPhoneCalleeScript",
            callerTime = 0, caller = "ElmPhoneCallerScript" },
   [5]  = { class = "SCHOOLBOY", member = "JACK1", map = "NATIONAL_PARK",
@@ -234,7 +244,7 @@ Phone.CONTACTS = {
 for index = 0, Phone.NUM_PHONE_CONTACTS do
   local row = Phone.CONTACTS[index]
   if row == false or row == nil then
-    row = { number = 0, map = nil,
+    row = { number = 0, name = "----------", map = nil,
             calleeTime = 0, callee = "UnusedPhoneScript",
             callerTime = 0, caller = "UnusedPhoneScript" }
     Phone.CONTACTS[index] = row
@@ -752,6 +762,19 @@ end
 function Phone.contactName(id, trainerData)
   local contact = Phone.CONTACTS[id or -1]
   if not contact then return Phone.NON_TRAINER_NAMES[0], nil end
+  -- `name` is presentation only.  Keeping class/member untouched preserves
+  -- trainer lookup, rematches and script identity while allowing both the
+  -- non-trainer names and an individual trainer contact to be localized by
+  -- the phone_contacts registry.
+  if contact.name then
+    local className
+    if contact.class then
+      local class = trainerData and trainerData.classes
+        and trainerData.classes[contact.class]
+      className = (class and class.name) or contact.class
+    end
+    return contact.name, className
+  end
   if not contact.class then
     return Phone.NON_TRAINER_NAMES[contact.number or 0]
       or Phone.NON_TRAINER_NAMES[0], nil

--- a/src/import/CacheContract.lua
+++ b/src/import/CacheContract.lua
@@ -167,8 +167,8 @@ local SEMANTIC_MODULES = {
   },
   [2] = {
     "pokemon", "moves", "items", "type_chart", "audio", "font", "maps",
-    "tilesets", "text", "trainers", "encounters", "sprites", "palettes",
-    "icons", "battle_anims", "constants", "landmarks",
+    "tilesets", "text", "rom_text", "trainers", "encounters", "sprites",
+    "palettes", "icons", "battle_anims", "constants", "landmarks",
   },
 }
 

--- a/src/link/LinkBattle2.lua
+++ b/src/link/LinkBattle2.lua
@@ -10,6 +10,13 @@ local Strings = require("src.core.Strings")
 
 local LinkBattle2 = {}
 
+-- BattleState:refuseMenu already wraps its argument in Strings() (needed by
+-- every other caller, which passes a raw Strings.source() marker); these two
+-- used to pre-translate before that, which is now a harmless-in-practice but
+-- real double Strings() call on an already-translated string.
+local TEXT_NO_ITEMS_IN_LINK = Strings.source("Items can't be used in a link battle!")
+local TEXT_NO_RUNNING_IN_LINK = Strings.source("No running from a link battle!")
+
 local function makeRandom(seed, owner)
   local s = tonumber(seed) or 1
   if s ~= s or s == math.huge or s == -math.huge then s = 1 end
@@ -304,10 +311,10 @@ function LinkBattle2.new(game, net, opts)
   hooks.submit = function(s, action)
     if ended then return end
     if action.kind == "item" then
-      return s:refuseMenu(Strings("Items can't be used in a link battle!"))
+      return s:refuseMenu(TEXT_NO_ITEMS_IN_LINK)
     end
     if action.kind == "run" then
-      return s:refuseMenu(Strings("No running from a link battle!"))
+      return s:refuseMenu(TEXT_NO_RUNNING_IN_LINK)
     end
     local msg = encodeAction(battle, action)
     send(msg)
@@ -318,11 +325,11 @@ function LinkBattle2.new(game, net, opts)
 
   hooks.menuChoice = function(s, choice)
     if choice == "item" then
-      s:refuseMenu(Strings("Items can't be used in a link battle!"))
+      s:refuseMenu(TEXT_NO_ITEMS_IN_LINK)
       return true
     end
     if choice == "run" then
-      s:refuseMenu(Strings("No running from a link battle!"))
+      s:refuseMenu(TEXT_NO_RUNNING_IN_LINK)
       return true
     end
     return false

--- a/src/mods/DatasetViews.lua
+++ b/src/mods/DatasetViews.lua
@@ -41,6 +41,7 @@ local GEN2_ROOTS = {
   pokemon = "pokemon", moves = "moves", items = "items",
   type_chart = "type_chart", audio = "audio", font = "font",
   gen2Maps = "maps", gen2Tilesets = "tilesets", gen2Text = "text",
+  text = "rom_text",
   gen2Trainers = "trainers", gen2Encounters = "encounters",
   gen2Sprites = "sprites", gen2Palettes = "palettes",
   gen2Icons = "icons", gen2BattleAnims = "battle_anims",

--- a/src/mods/Schemas.lua
+++ b/src/mods/Schemas.lua
@@ -521,6 +521,10 @@ Schemas.GEN2 = {
   -- its walkability as `collision` where Gen 1 says `walkable`.
   maps = "gen2Maps", tilesets = "gen2Tilesets", sprites = "gen2Sprites",
   text = "gen2Text",
+  -- Label-keyed engine prose is extracted separately from the VM's
+  -- bank:address script text.  Keep a distinct public registry name while
+  -- landing it on the shared RomText helper's data.text lookup table.
+  rom_text = "text",
   -- Namespaced AND differently shaped, and the shape is what these waited on.
   -- Each carries a Gen 2 record schema in its catalog entry now, so the id
   -- space is the one Gold actually keys by: the encounter KIND (.grass), the
@@ -636,6 +640,7 @@ Schemas.GEN2 = {
 Schemas.GEN1 = {
   held_items = false, phone_contacts = false, decorations = false,
   apricorns = false, landmarks = false, radio_channels = false,
+  rom_text = false,
 }
 
 -- The routing table for a generation: which one is consulted is the only
@@ -1262,6 +1267,16 @@ R.text = {
   semantics = "record", target = "text",
   value = f.str,
   example = 'mod.content.text:override("_PalletTownText1", "HELLO!")',
+}
+
+-- Gen 2's data/generated/text.lua is VM script text keyed by bank:address;
+-- data/generated/rom_text.lua is engine prose keyed by disassembly label.
+-- They deliberately do not share a registry: `text` keeps targeting
+-- data.gen2Text on Gold, while this Gen 2-only surface targets data.text.
+R.rom_text = {
+  semantics = "record",
+  value = f.str,
+  example = 'mod.content.rom_text:override("_WokeUpText", "%s se réveille !")',
 }
 
 -- The engine's own authored text, the half of the game `text` does not
@@ -2150,6 +2165,11 @@ R.phone_contacts = {
     -- name are looked up by
     number = f.opt(f.int(0, 255)),
     class = f.opt(f.str), member = f.opt(f.str),
+    -- Optional display override.  The four non-trainer rows seed this from
+    -- NonTrainerCallerNames; trainer rows normally resolve their name from
+    -- the trainer table, but a translation or content mod may override it
+    -- without replacing the trainer identity used by rematches.
+    name = f.opt(f.str),
     map = f.opt(f.id("maps")),
     -- the SCRIPT1 / SCRIPT2 time masks: MORN | DAY | NITE, 0 for "never"
     calleeTime = f.opt(f.int(0, 7)), callerTime = f.opt(f.int(0, 7)),
@@ -2232,9 +2252,12 @@ R.landmarks = {
 R.radio_channels = {
   semantics = "record",
   fields = {
-    channel = f.int(0, 255),
-    -- the name quoted in the text box; without one the Pokegear's own
-    -- STATION_NAMES row is used, which is where the vanilla eight get theirs
+    -- MAPRADIO_* position for a wall-radio station.  Pokegear-only signals
+    -- (POKE_FLUTE_RADIO / EVOLUTION_RADIO) have no such byte and carry just
+    -- their display name.
+    channel = f.opt(f.int(0, 255)),
+    -- the name quoted in the text box; every vanilla Pokegear signal seeds
+    -- one, including the two that have no wall-radio channel
     name = f.opt(f.str),
   },
   example = 'mod.content.radio_channels:register("PIRATE_RADIO", '

--- a/src/ui/BagMenu.lua
+++ b/src/ui/BagMenu.lua
@@ -500,7 +500,7 @@ local function pickTargetAndUse(game, battle, id, list)
           right = ("%d"):format(mv.pp),
         })
       end
-      game.stack:push(ListMenu.new(game, "Which move?", rows, {
+      game.stack:push(ListMenu.new(game, Strings.source("Which move?"), rows, {
         onChoose = function(row, l)
           l:close()
           useOn(game, battle, id, mon, list, row.value)
@@ -557,7 +557,7 @@ function BagMenu.new(game, opts)
   opts = opts or {}
   local battle = opts.battle
   local list
-  list = ListMenu.new(game, "ITEMS", buildItems(game), {
+  list = ListMenu.new(game, Strings.source("ITEMS"), buildItems(game), {
     kind = "bag",
     -- StartMenu_Item zeroes wPrintItemPrices and draws no money box: the
     -- LIST_MENU_BOX floats over the map (engine/menus/start_sub_menus.asm)

--- a/src/ui/BoxMenu.lua
+++ b/src/ui/BoxMenu.lua
@@ -84,9 +84,9 @@ local function withdraw(game)
       if item.cancel then list:close() return end
       local mon = box[item.value]
       if not mon then return end
-      monSubmenu(game, "WITHDRAW", mon, function()
+      monSubmenu(game, Strings("WITHDRAW"), mon, function()
         if #game.save.party >= Party.MAX then
-          list.footer = "The party is full!"
+          list.footer = Strings("The party is full!")
           return
         end
         -- add_mon.asm _MoveMon's tail ("returning mon to party, compute
@@ -141,7 +141,7 @@ local function deposit(game)
           or Strings("There isn't any\nresponse...")))
         return
       end
-      monSubmenu(game, "DEPOSIT", mon, function()
+      monSubmenu(game, Strings("DEPOSIT"), mon, function()
         if #game.save.party <= 1 then
           list.footer = Strings("You need at least\none POKéMON!")
           return

--- a/src/ui/Credits.lua
+++ b/src/ui/Credits.lua
@@ -257,7 +257,11 @@ function Credits:drawPage(screen, xoff, shade)
   if not screen then return end
   love.graphics.setColor(0, 0, 0, shade)
   for i, line in ipairs(screen.lines or {}) do
-    Font.draw(line.text, xoff + (line.column or 0) * 8, 48 + (i - 1) * 16)
+    -- Credits strings are extracted ROM data, not Lua literals.  Keep the
+    -- source in field.credits for layout/parity and translate only as it is
+    -- drawn, like the dynamic labels in the other data-backed screens.
+    Font.draw(Strings(line.text), xoff + (line.column or 0) * 8,
+              48 + (i - 1) * 16)
   end
   love.graphics.setColor(1, 1, 1, 1)
   if screen.copyright then self:drawCopyright(xoff) end
@@ -332,7 +336,8 @@ function Credits:drawTheEnd()
     end
   else
     love.graphics.setColor(0, 0, 0, 1)
-    Font.draw((te and te.display) or Strings("T H E  E N D"), 32, 64)
+    local text = te and Strings(te.display) or Strings("T H E  E N D")
+    Font.draw(text, math.max(0, math.floor((160 - Font.width(text)) / 2)), 64)
     love.graphics.setColor(1, 1, 1, 1)
   end
 end

--- a/src/ui/Diploma.lua
+++ b/src/ui/Diploma.lua
@@ -140,11 +140,11 @@ function Diploma.render(game)
 
   -- 5. Congratulations text: hlcoord 2, 6 double-spaced lines (rows 6, 8, 10, 12, 14)
   local congrats = {
-    { text = "Congrats! This",     y = 48 },   -- hlcoord 2, 6
-    { text = "diploma certifies",  y = 64 },   -- hlcoord 2, 8
-    { text = "that you have",      y = 80 },   -- hlcoord 2, 10
-    { text = "completed your",     y = 96 },   -- hlcoord 2, 12
-    { text = "POKéDEX.",           y = 112 },  -- hlcoord 2, 14
+    { text = Strings.source("Congrats! This"),    y = 48 },  -- hlcoord 2, 6
+    { text = Strings.source("diploma certifies"), y = 64 },  -- hlcoord 2, 8
+    { text = Strings.source("that you have"),     y = 80 },  -- hlcoord 2, 10
+    { text = Strings.source("completed your"),    y = 96 },  -- hlcoord 2, 12
+    { text = Strings.source("POKéDEX."),          y = 112 }, -- hlcoord 2, 14
   }
   for _, line in ipairs(congrats) do
     Font.draw(Strings(line.text), 16, line.y)

--- a/src/ui/FlyMenu.lua
+++ b/src/ui/FlyMenu.lua
@@ -3,6 +3,7 @@
 
 local ListMenu = require("src.ui.ListMenu")
 local Map = require("src.world.Map")
+local Strings = require("src.core.Strings")
 
 local FlyMenu = {}
 
@@ -20,11 +21,11 @@ function FlyMenu.new(game)
       seen[mapId] = true
       table.insert(items, {
         value = mapId,
-        label = mapId:gsub("_", " "),
+        label = Strings(mapId:gsub("_", " ")),
       })
     end
   end
-  return ListMenu.new(game, "FLY TO?", items, {
+  return ListMenu.new(game, Strings.source("FLY TO?"), items, {
     onChoose = function(item, list)
       list:close()
       game.overworld:flyTo(item.value)

--- a/src/ui/HallOfFame.lua
+++ b/src/ui/HallOfFame.lua
@@ -306,10 +306,10 @@ function HallOfFame:drawMonInfo(mon)
   Font.draw(tostring(mon.level), 8 * 8, 7 * 8)
   -- PrintMonType at (3,9) / +2 rows for type 2
   if t1 then
-    Font.draw(TypeChart.displayName(t1), 3 * 8, 9 * 8)
+    Font.draw(TypeChart.displayName(t1, self.game.data), 3 * 8, 9 * 8)
   end
   if dual then
-    Font.draw(TypeChart.displayName(t2), 3 * 8, 11 * 8)
+    Font.draw(TypeChart.displayName(t2, self.game.data), 3 * 8, 11 * 8)
   end
 end
 

--- a/src/ui/OakSpeech.lua
+++ b/src/ui/OakSpeech.lua
@@ -443,7 +443,7 @@ function OakSpeech:runStep(step)
     self.picTrueColor = self.demoTrueColor
     self:revealPic("wipe", function()
       Sound.playCry(self.game.data, self.demoSpecies)
-      self:say(Strings("_OakSpeechText2A"), function() self:advance() end)
+      self:say("_OakSpeechText2A", function() self:advance() end)
     end)
   elseif kind == "name" then
     local who = step.who or "player"

--- a/src/ui/OptionsMenu.lua
+++ b/src/ui/OptionsMenu.lua
@@ -37,6 +37,15 @@ local OptionsMenu = {}
 OptionsMenu.__index = OptionsMenu
 OptionsMenu.isOpaque = true
 
+-- Shared by the three GameSpeed rows below (overworld/battle/menu): mirrors
+-- src/ui/gen2/OptionsMenu.lua's own speed row so the translated "NORMAL"/
+-- "%dX" catalog keys apply on both generations' options screens.
+local function gameSpeedLabel(v)
+  local speed = tonumber(v) or GameSpeed.DEFAULT
+  if speed == 1 then return Strings("NORMAL") end
+  return Strings("%dX", speed)
+end
+
 -- Opaque full-screen menu: own MEWMON so opening OPTION from the title
 -- (or over the overworld) does not inherit TitleState's LOGO1 band -- that
 -- zone covers UI rows 8-9, which is the third options box label line
@@ -399,7 +408,9 @@ local function buildRows(game)
       end },
     { id = "zoom", label = Strings("ZOOM"),
       value = function(g)
-        return Zoom.offsetLabel(g.save.options.zoom or 0)
+        local offset = math.floor(tonumber(g.save.options.zoom) or 0)
+        if offset == 0 then return Strings("FIT") end
+        return offset < 0 and Strings("OUT%d", -offset) or Strings("IN%d", offset)
       end,
       step = function(g, dir)
         Zoom.nudgeOptions(g.save.options, dir, Renderer:fitScale())
@@ -473,7 +484,13 @@ local function buildRows(game)
     -- is fixed-step off dt, so this touches presentation only.
     { id = "fpsCap", label = Strings("MAX FPS"),
       value = function(g)
-        return FrameCap.label(g.save.options.fpsCap)
+        local value = FrameCap.normalize(g.save.options.fpsCap)
+        if value == FrameCap.DISPLAY then
+          local label = FrameCap.label(value)
+          local hz = tonumber(label:match("^DISPLAY %((%d+)HZ%)$"))
+          return hz and Strings("DISPLAY (%dHZ)", hz) or Strings("DISPLAY")
+        end
+        return FrameCap.label(value)
       end,
       step = function(g, dir)
         local o = g.save.options
@@ -507,7 +524,7 @@ local function buildRows(game)
     -- source of truth for which three rows exist.
     { id = "speedOverworld", label = Strings("OVERWORLD SPEED"),
       value = function(g)
-        return GameSpeed.levelLabel(g.save.options.speedOverworld)
+        return gameSpeedLabel(g.save.options.speedOverworld)
       end,
       step = function(g, dir)
         local o = g.save.options
@@ -516,7 +533,7 @@ local function buildRows(game)
       end },
     { id = "speedBattle", label = Strings("BATTLE SPEED"),
       value = function(g)
-        return GameSpeed.levelLabel(g.save.options.speedBattle)
+        return gameSpeedLabel(g.save.options.speedBattle)
       end,
       step = function(g, dir)
         local o = g.save.options
@@ -525,7 +542,7 @@ local function buildRows(game)
       end },
     { id = "speedMenu", label = Strings("MENU SPEED"),
       value = function(g)
-        return GameSpeed.levelLabel(g.save.options.speedMenu)
+        return gameSpeedLabel(g.save.options.speedMenu)
       end,
       step = function(g, dir)
         local o = g.save.options

--- a/src/ui/SummaryMenu.lua
+++ b/src/ui/SummaryMenu.lua
@@ -166,10 +166,10 @@ function SummaryMenu:draw()
     -- TYPE1/TYPE2/IDNo/OT column (10,9) with values indented (11,10)
     drawLineBox(19, 9, 8, 6)
     Font.draw(Strings("TYPE1/"), 80, 72)
-    Font.draw(def.types[1] and TypeChart.displayName(def.types[1]) or "", 88, 80)
+    Font.draw(def.types[1] and TypeChart.displayName(def.types[1], data) or "", 88, 80)
     if def.types[2] then
       Font.draw(Strings("TYPE2/"), 80, 88)
-      Font.draw(TypeChart.displayName(def.types[2]), 88, 96)
+      Font.draw(TypeChart.displayName(def.types[2], data), 88, 96)
     end
     -- TypesIDNoOTText's third row is "<ID>№/" (status_screen.asm:205-210):
     -- two single-tile glyphs and a slash, three columns wide, not the five

--- a/src/ui/SurfingMinigame.lua
+++ b/src/ui/SurfingMinigame.lua
@@ -1642,7 +1642,8 @@ function SurfingMinigame:drawTitleScreen()
   if self.titleBg then
     love.graphics.draw(self.titleBg, 0, 0)
   else
-    Font.draw("PIKACHU'S BEACH", 20, 32)
+    local title = Strings("PIKACHU'S BEACH")
+    Font.draw(title, math.max(0, math.floor((160 - Font.width(title)) / 2)), 32)
   end
 
   -- 2. Intro Pikachu paddling out (SurfingPikachu1Graphics3 / surf_1c.png)

--- a/src/ui/TitleState.lua
+++ b/src/ui/TitleState.lua
@@ -727,9 +727,11 @@ function TitleState:draw()
     love.graphics.draw(self.logo, 16, 8 + scrollY)
   else
     love.graphics.setColor(0, 0, 0, 1)
-    local brand = self.yellow and "POKéMON YELLOW"
-               or (self.blue and "POKéMON BLUE" or Strings("POKéMON RED"))
-    Font.draw(brand, (160 - 12 * 8) / 2, 24 + scrollY)
+    local brand = self.yellow and Strings("POKéMON YELLOW")
+               or (self.blue and Strings("POKéMON BLUE")
+                             or Strings("POKéMON RED"))
+    Font.draw(brand, math.max(0, math.floor((160 - Font.width(brand)) / 2)),
+              24 + scrollY)
     love.graphics.setColor(1, 1, 1, 1)
   end
   if self.yellowLayout then
@@ -817,7 +819,8 @@ function TitleState:drawCopyright(y)
     return
   end
   love.graphics.setColor(0, 0, 0, 1)
-  Font.draw(self.title.copyrightText or Strings("GAME FREAK inc."), 16, y)
+  Font.draw(self.title.copyrightText and Strings(self.title.copyrightText)
+            or Strings("GAME FREAK inc."), 16, y)
   love.graphics.setColor(1, 1, 1, 1)
 end
 

--- a/src/ui/TownMap.lua
+++ b/src/ui/TownMap.lua
@@ -18,6 +18,7 @@ local GameVersion = require("src.core.GameVersion")
 local PaletteFX = require("src.render.PaletteFX")
 local Sound = require("src.core.Sound")
 local SpriteRenderer = require("src.render.SpriteRenderer")
+local Strings = require("src.core.Strings")
 local Theme = require("src.ui.Theme")
 
 local TownMap = {}
@@ -171,7 +172,22 @@ end
 -- the row-0 name banner; fly mode prefixes "To " like LoadTownMap_Fly
 -- (engine/menus/town_map.asm prints the destination as "To <NAME>")
 function TownMap:bannerText(loc)
-  return (self.fly and "To " or "") .. loc.name
+  local name = Strings(loc.name)
+  return self.fly and Strings("To %s", name) or name
+end
+
+-- The fly strip reserves its last two tiles for the up/down arrows.  Fit the
+-- composed translation as one unit so a wider/reordered prefix cannot collide
+-- with the destination or draw under those controls.
+local function fitFlyBanner(text)
+  local spans = Font.split(text)
+  local n = Font.spansFitting(spans, 144)
+  if n >= #spans then return text end
+  local out = {}
+  for i = 1, math.max(0, n - 1) do
+    out[#out + 1] = text:sub(spans[i].from, spans[i].to)
+  end
+  return table.concat(out) .. "."
 end
 
 -- Fly mode selection set (engine/menus/town_map.asm LoadTownMap_Fly): the
@@ -432,7 +448,7 @@ function TownMap:draw()
         -- engine/items/town_map.asm:403
         Font.drawBox(1, 7, 17, 4)
         love.graphics.setColor(0, 0, 0, 1)
-        Font.draw(" AREA UNKNOWN", 16, 72)
+        Font.draw(" " .. Strings("AREA UNKNOWN"), 16, 72)
         love.graphics.setColor(1, 1, 1, 1)
       end
       love.graphics.rectangle("fill", 0, 0, 160, 8)
@@ -440,7 +456,7 @@ function TownMap:draw()
       local def = self.game.data.pokemon[self.nestSpecies]
       local name = def and def.name or self.nestSpecies
       -- engine/items/town_map.asm:124
-      Font.draw(name .. "'s NEST", 8, 0)
+      Font.draw(Strings("%s's NEST", name), 8, 0)
       love.graphics.setColor(1, 1, 1, 1)
       return
     end
@@ -489,8 +505,9 @@ function TownMap:draw()
     love.graphics.setColor(0, 0, 0, 1)
     if self.fly then
       -- engine/items/town_map.asm:167, 176, 185
-      Font.draw("To", 0, 0)
-      if selected then Font.draw(selected.name, 24, 0) end
+      if selected then
+        Font.draw(fitFlyBanner(self:bannerText(selected)), 0, 0)
+      end
       self:drawFlyArrows()
     elseif selected then
       Font.draw(self:bannerText(selected), 8, 0)
@@ -541,18 +558,20 @@ function TownMap:draw()
       local loc = self.locs[first + i]
       if loc then
         local y = 40 + i * 16
+        local name = Strings(loc.name)
         -- cursor in list mode (Fly mode) is static in RBY (LoadTownMap_Fly)
         if first + i == self.sel then
           Font.drawCode(0xED, 8, y)  -- the "▶" cursor glyph
         end
-        Font.draw(loc.name, 24, y)
+        Font.draw(name, 24, y)
         -- player marker is static
         if loc == self.playerLoc then
           -- marker on the player's current town; force the palette-safe
           -- dark shade explicitly so the red-channel shade-remap keeps it
           -- visible regardless of Font.draw's leftover color (#152)
           love.graphics.setColor(0, 0, 0, 1)
-          love.graphics.rectangle("fill", 24 + #loc.name * 8 + 6, y + 2, 4, 4)
+          love.graphics.rectangle("fill", 24 + Font.width(name) + 6,
+                                  y + 2, 4, 4)
         end
       end
     end
@@ -561,7 +580,10 @@ function TownMap:draw()
   -- name banner across the top
   Font.drawBox(0, 0, 20, 3)
   love.graphics.setColor(0, 0, 0, 1)
-  if selected then Font.draw(self:bannerText(selected), 8, 8) end
+  if selected then
+    local text = self:bannerText(selected)
+    Font.draw(self.fly and fitFlyBanner(text) or text, 8, 8)
+  end
   love.graphics.setColor(1, 1, 1, 1)
 end
 

--- a/src/ui/TradeAnim.lua
+++ b/src/ui/TradeAnim.lua
@@ -736,14 +736,14 @@ end
 function TradeAnim:drawMonInfo(mon, ot, otId, boxTy)
   Font.drawBox(4, boxTy, 12, 8)
   local y0 = boxTy * 8
-  local no = ("No.%03d"):format(dexOf(self.game, mon))
+  local no = Strings("No.%03d", dexOf(self.game, mon))
   love.graphics.setColor(1, 1, 1, 1)
   love.graphics.rectangle("fill", 56, y0, Font.width(no), 8)
   love.graphics.setColor(0, 0, 0, 1)
   Font.draw(no, 56, y0)
   Font.draw(speciesName(self.game, mon), 40, y0 + 16)
   Font.draw(Strings("OT/%s", ot or "????"), 40, y0 + 32)
-  Font.draw(("IDNo.%05d"):format(otId or 0), 40, y0 + 48)
+  Font.draw(Strings("IDNo.%05d", otId or 0), 40, y0 + 48)
   love.graphics.setColor(1, 1, 1, 1)
 end
 

--- a/src/ui/TrainerCard.lua
+++ b/src/ui/TrainerCard.lua
@@ -139,10 +139,10 @@ function TrainerCard:draw()
   end
   love.graphics.setColor(0, 0, 0, 1)
   Font.draw(Strings("NAME/%s", save.player.name or "RED"), 16, 16)
-  Font.draw(("MONEY/¥%d"):format(save.money or 0), 16, 32)
+  Font.draw(Strings("MONEY/¥%d", save.money or 0), 16, 32)
   local t = math.floor(save.playTime or 0)
-  Font.draw(("TIME/%3d:%02d"):format(math.floor(t / 3600),
-                                     math.floor(t / 60) % 60), 16, 48)
+  Font.draw(Strings("TIME/%3d:%02d", math.floor(t / 3600),
+                    math.floor(t / 60) % 60), 16, 48)
 
   -- the circle-dotted BADGES banner (TrainerInfo_BadgesText)
   self:frameBox(0, 8, 20, 3)

--- a/src/ui/gen2/BankOfMom.lua
+++ b/src/ui/gen2/BankOfMom.lua
@@ -29,6 +29,7 @@
 
 local Chrome = require("src.ui.gen2.Chrome")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 
 local BankOfMom = {}
 BankOfMom.__index = BankOfMom
@@ -49,10 +50,10 @@ local PLACE_VALUES = { 100000, 10000, 1000, 100, 10, 1 }
 -- No line marker in any of these four (Mom_SavedString, Mon_WithdrawString,
 -- Mom_DepositString, Mom_HeldString are one word each), so they are plain
 -- literals here the way MartMenu's BUY/SELL/CANCEL labels are.
-local SAVED_LABEL = "SAVED"
-local HELD_LABEL = "HELD"
-local DEPOSIT_LABEL = "DEPOSIT"
-local WITHDRAW_LABEL = "WITHDRAW"
+local SAVED_LABEL = Strings.source("SAVED")
+local HELD_LABEL = Strings.source("HELD")
+local DEPOSIT_LABEL = Strings.source("DEPOSIT")
+local WITHDRAW_LABEL = Strings.source("WITHDRAW")
 
 -- charmap.asm: ¥ is the currency glyph, same one MartMenu's moneyText uses.
 local YEN = "\xc2\xa5"
@@ -127,11 +128,11 @@ end
 
 function BankOfMom:drawPanel()
   Chrome.box(BOX_X, BOX_Y, BOX_W, BOX_H)
-  Chrome.print(SAVED_LABEL, SAVED_LABEL_X, SAVED_Y)
+  Chrome.print(Strings(SAVED_LABEL), SAVED_LABEL_X, SAVED_Y)
   Chrome.print(moneyText(self.saved), MONEY_X, SAVED_Y)
-  Chrome.print(HELD_LABEL, HELD_LABEL_X, HELD_Y)
+  Chrome.print(Strings(HELD_LABEL), HELD_LABEL_X, HELD_Y)
   Chrome.print(moneyText(self.held), MONEY_X, HELD_Y)
-  Chrome.print(self.kind == "withdraw" and WITHDRAW_LABEL or DEPOSIT_LABEL,
+  Chrome.print(Strings(self.kind == "withdraw" and WITHDRAW_LABEL or DEPOSIT_LABEL),
     KIND_LABEL_X, KIND_Y)
   Chrome.print(moneyTextZeroed(self.amount), MONEY_X, KIND_Y)
   -- `hlcoord 13, 6 / ... / ld [hl], ' '` blanks the digit under the cursor

--- a/src/ui/gen2/BattleState.lua
+++ b/src/ui/gen2/BattleState.lua
@@ -44,6 +44,7 @@ local SpriteAnims = require("src.ui.gen2.SpriteAnims")
 local Sprites = require("src.pokemon.Sprites")
 local Strings = require("src.core.Strings")
 local SummaryMenu = require("src.ui.gen2.SummaryMenu")
+local TypeChart = require("src.battle.TypeChart")
 -- Only for TextBox.substitute: the {PLAYER} / {RIVAL} markers a map text
 -- carries into the battle box (PrintWinLossText, home/trainers.asm:230).
 local TextBox = require("src.render.TextBox")
@@ -95,11 +96,11 @@ local TEXT_ROW_STEP = 2
 function BattleState.battleStartText(name, battleType)
   local kind = Battle.battleTypeId(battleType)
   if kind == Battle.BATTLETYPE_FISH then
-    return "The hooked " .. name .. " attacked!"
+    return Strings("The hooked %s attacked!", name)
   elseif kind == Battle.BATTLETYPE_TREE then
-    return name .. " fell out of the tree!"
+    return Strings("%s fell out of the tree!", name)
   end
-  return "Wild " .. name .. " appeared!"
+  return Strings("Wild %s appeared!", name)
 end
 
 -- ../pokecrystal/engine/battle/core.asm:6422, :6251-6256
@@ -147,15 +148,17 @@ local FAINT_SLIDE_FRAMES_PER_ROW = 2
 -- BattleText_TheresNoWillToBattle / BattleText_AnEGGCantBattle, the two lines
 -- CheckIfCurPartyMonIsFitToFight prints before it returns zero
 -- (engine/battle/core.asm:3439-3466, data/text/battle.asm:241-249).
-local TEXT_NO_WILL_TO_FIGHT = "There's no will to battle!"
-local TEXT_EGG_CANT_BATTLE = "An EGG can't battle!"
+local TEXT_NO_WILL_TO_FIGHT = Strings.source("There's no will to battle!")
+local TEXT_EGG_CANT_BATTLE = Strings.source("An EGG can't battle!")
+local TEXT_ALREADY_OUT = Strings.source("%s is already out.")
+local TEXT_CANT_BE_RECALLED = Strings.source("%s can't be recalled!")
 -- data/text/battle.asm:207
-local TEXT_USE_NEXT_MON = "Use next POKéMON?"
+local TEXT_USE_NEXT_MON = Strings.source("Use next POKéMON?")
 
 -- BattleText_TheMoveIsDisabled / BattleText_TheresNoPPLeftForThisMove
 -- (data/text/battle.asm:315-322).
-local TEXT_NO_PP_LEFT = "There's no PP left for this move!"
-local TEXT_MOVE_DISABLED = "The move is DISABLED!"
+local TEXT_NO_PP_LEFT = Strings.source("There's no PP left for this move!")
+local TEXT_MOVE_DISABLED = Strings.source("The move is DISABLED!")
 
 -- _MoveAskForgetText, _MoveCantForgetHMText and _StopLearningMoveText
 -- (data/text/common_3.asm:124-134).
@@ -180,7 +183,10 @@ local TEXT_ASK_FORGET_MOVE = Strings.source(
 -- screen is FIGHT / PkMn on top and PACK / RUN below -- not the four-in-a-row
 -- Gen 1 uses.  The second label is the two-glyph <PK><MN> ligature (charmap
 -- $e1/$e2), which is what makes it fit a six-tile column.
-local MENU = { "FIGHT", "<PK><MN>", "PACK", "RUN" }
+local MENU = {
+  Strings.source("FIGHT"), Strings.source("<PK><MN>"),
+  Strings.source("PACK"), Strings.source("RUN"),
+}
 local MENU_ACTION = { FIGHT = "fight", ["<PK><MN>"] = "party",
   PACK = "item", RUN = "run" }
 local MENU_BOX_X = 8
@@ -192,11 +198,8 @@ local MENU_COL_SPACING = 6
 local CONTEST_MENU_BOX_X = 2
 local CONTEST_MENU_COL_SPACING = 12
 
--- PrintMoveType prints the type table's own names; only these two differ from
--- the constant (data/types/names.asm).
-local TYPE_NAMES = SummaryMenu.TYPE_NAMES
 -- charmap.asm's quantity glyph, spelled the way MartMenu spells it.
-local CONTEST_BALL_LABEL = "PARKBALL\xc3\x97"
+local CONTEST_BALL_LABEL = Strings.source("PARKBALL\xc3\x97%02d")
 
 -- data/items/heal_status.asm StatusHealingActions: the four rows whose status
 -- mask is %11111111.  HealStatus's `.not_full_heal` arm is what makes exactly
@@ -478,7 +481,7 @@ function BattleState.new(game, opts)
         or "Foe"
       -- WantsToBattleText (core.asm:8701), read against the trainer's own pic.
       self:push({ kind = "message",
-        text = trainerName .. " wants to battle!" })
+        text = Strings("%s wants to battle!", trainerName) })
       -- ResetEnemyBattleVars' SlideBattlePicOut at the head of EnemySwitch
       -- (core.asm:3027) pushes that pic off the right edge before the mon is
       -- announced.  Nothing to slide when the cache has no trainer pic.
@@ -489,7 +492,7 @@ function BattleState.new(game, opts)
       -- (core.asm:2978-2980, 3354): this is where the mon's frontpic first
       -- appears, where ANIM_SEND_OUT_MON plays and where the HUD comes up.
       self:push({ kind = "send", side = "enemy", mon = enemy,
-        text = trainerName .. " sent out " .. self:name(enemy) .. "!" })
+        text = Strings("%s sent out %s!", trainerName, self:name(enemy)) })
     end
   end
   local player = self.battle and self.battle.player
@@ -497,7 +500,7 @@ function BattleState.new(game, opts)
     -- ../pokecrystal/engine/battle/core.asm:82-84
     self:push({ kind = "backpic-slide" })
     self:push({ kind = "sendout",
-      text = "Go! " .. self:name(player) .. "!" })
+      text = Strings("Go! %s!", self:name(player)) })
   end
   -- What the HUD shows chases the real HP one tick at a time
   -- (engine/battle/anim_hp_bar.asm), re-armed by each damage/heal event as
@@ -1897,13 +1900,13 @@ function BattleState:advanceQueue()
     if self.battle and self.battle.wild then
       self.nextMonIndex = 1
       self.phase = "ask-next-mon"
-      self.message = TEXT_USE_NEXT_MON
+      self.message = Strings(TEXT_USE_NEXT_MON)
       self.messageTimer = 0
       return
     end
     -- A fainted lead: force a switch before anything else runs.
     self.phase = "forced-switch"
-    self.message = "Choose a POKéMON."
+    self.message = Strings("Choose a POKéMON.")
     return
   end
   -- LearnMove's full-moveset arm: the exp queue stops on ForgetMove's own text
@@ -2683,7 +2686,7 @@ function BattleState:update(_dt)
       end
       return
     end
-    self.message = "Choose a POKéMON."
+    self.message = Strings("Choose a POKéMON.")
     self.phase = "forced-switch"
     return
   end
@@ -2853,12 +2856,11 @@ function BattleState:openParty(forced)
       -- TryPlayerSwitch's own order, every arm ending on
       -- `jp BattleMenuPKMN_Loop` (engine/battle/core.asm:4863-4888).
       if not forced and mon == self.battle.player then
-        return self:refuseSwitch(false,
-          self:name(mon) .. " is already out.")
+        return self:refuseSwitch(false, TEXT_ALREADY_OUT, self:name(mon))
       end
       if not forced and self.battle:switchLocked() then
-        return self:refuseSwitch(false,
-          self:name(self.battle.player) .. " can't be recalled!")
+        return self:refuseSwitch(false, TEXT_CANT_BE_RECALLED,
+          self:name(self.battle.player))
       end
       -- CheckIfCurPartyMonIsFitToFight's `cp EGG` arm (core.asm:3450-3456).
       if mon.isEgg then
@@ -2899,24 +2901,24 @@ end
 -- The refusal itself: the line, then the same list again.  `forced` is carried
 -- so a faint's list comes back with no CANCEL of its own and a voluntary one
 -- keeps its own.
-function BattleState:refuseSwitch(forced, text)
+function BattleState:refuseSwitch(forced, source, ...)
   self.refuseForced = forced and true or false
   self.phase = "refuse-switch"
-  self.message = text or TEXT_NO_WILL_TO_FIGHT
+  self.message = Strings(source or TEXT_NO_WILL_TO_FIGHT, ...)
   self.typedText = nil
   self.messageTimer = MESSAGE_FRAMES
 end
 
 function BattleState:refuseMove(text)
   self.phase = "refuse-move"
-  self.message = text
+  self.message = Strings(text)
   self.typedText = nil
   self.messageTimer = MESSAGE_FRAMES
 end
 
 function BattleState:refuseMenu(text)
   self.phase = "refuse-menu"
-  self.message = text
+  self.message = Strings(text)
   self.typedText = nil
   self.messageTimer = MESSAGE_FRAMES
 end
@@ -3023,10 +3025,10 @@ local WOBBLE_LIMIT = 3
 -- The four failure lines, indexed by wThrownBallWobbleCount exactly the way
 -- item_effects.asm:414-428 indexes them (data/text/common_3.asm:239-258).
 local BALL_FAILURE_TEXT = {
-  "Oh no! The POKéMON broke free!",
-  "Aww! It appeared to be caught!",
-  "Aargh! Almost had it!",
-  "Shoot! It was so close too!",
+  Strings.source("Oh no! The POKéMON broke free!"),
+  Strings.source("Aww! It appeared to be caught!"),
+  Strings.source("Aargh! Almost had it!"),
+  Strings.source("Shoot! It was so close too!"),
 }
 
 -- Text_BallCaught's own sound_caught_mon (data/text/common_3.asm:265).
@@ -3090,7 +3092,8 @@ end
 -- older cache, or BATTLE SCENE off) nothing ever wobbled, so it is the first.
 function BattleState:ballFailureText()
   local wobble = (self.ballThrow and self.ballThrow.wobble) or 1
-  return BALL_FAILURE_TEXT[math.max(1, math.min(#BALL_FAILURE_TEXT, wobble))]
+  return Strings(BALL_FAILURE_TEXT[
+    math.max(1, math.min(#BALL_FAILURE_TEXT, wobble))])
 end
 
 -- UseBallInTrainerBattle (item_effects.asm:2579).  Not a bare refusal: the ball
@@ -3100,8 +3103,8 @@ end
 -- the turn goes with it.
 function BattleState:throwBallAtTrainer(itemId)
   self.queue = {}
-  self:push({ kind = "message", text = "The trainer blocked the BALL!" })
-  self:push({ kind = "message", text = "Don't be a thief!" })
+  self:push({ kind = "message", text = Strings("The trainer blocked the BALL!") })
+  self:push({ kind = "message", text = Strings("Don't be a thief!") })
   self:consumeItem(itemId)
   self:pushAll(self.battle:takeTurn({ kind = "item", item = itemId }))
   -- NO_ITEM is 0, the id BattleAnim_ThrowPokeBall's first row tests.
@@ -3181,7 +3184,7 @@ function BattleState:pushCaught(enemy, itemId)
   -- and TX_SOUND holds the text engine until the jingle is done
   -- (home/text.asm:834-835), so the line is not dismissable under it.
   self:push({ kind = "message", sfx = SFX_CAUGHT_MON, waitSfx = true,
-    text = "Gotcha! " .. self:name(enemy) .. " was caught!" })
+    text = Strings("Gotcha! %s was caught!", self:name(enemy)) })
   -- BATTLETYPE_TUTORIAL returns before every one of the steps below
   -- (`.FinishTutorial`, and `.return_from_capture: ret z`).
   if self.tutorial or not save then return end
@@ -3203,7 +3206,8 @@ function BattleState:pushCaught(enemy, itemId)
     -- data/text/common_3.asm:285
     self:push({ kind = "message",
       sfx = "Sfx_SlotMachineStart", waitSfx = true,
-      text = self:name(enemy) .. "'s data was newly added to the #DEX." })
+      text = Strings("%s's data was newly added to the #DEX.",
+        self:name(enemy)) })
     self:push({ kind = "dex-entry", species = enemy.species })
   end
   if self.contest then
@@ -3270,7 +3274,7 @@ function BattleState:pushCaught(enemy, itemId)
     -- BallSentToPCText, which .SendToPC prints AFTER the nickname prompt
     -- (item_effects.asm:672).
     self:push({ kind = "message",
-      text = self:name(enemy) .. " was sent to BILL's PC." })
+      text = Strings("%s was sent to BILL's PC.", self:name(enemy)) })
   end
   self:pushPayDay()
 end
@@ -3319,7 +3323,7 @@ end
 function BattleState:answerUseNextMon(yes)
   if yes then
     self.phase = "forced-switch"
-    self.message = "Choose a POKéMON."
+    self.message = Strings("Choose a POKéMON.")
     return
   end
   local battle = self.battle
@@ -3336,7 +3340,7 @@ function BattleState:answerUseNextMon(yes)
     return self:advanceQueue()
   end
   battle:takeEvents()
-  self.message = "Can't escape!"
+  self.message = Strings("Can't escape!")
   self.messageTimer = MESSAGE_FRAMES
   self.phase = "cant-escape-then-switch"
 end
@@ -3362,7 +3366,7 @@ function BattleState:openShiftParty()
     onChoose = function(index, mon)
       stack:pop()
       if mon == self.battle.player then
-        return self:refuseShift(self:name(mon) .. " is already out.")
+        return self:refuseShift(TEXT_ALREADY_OUT, self:name(mon))
       end
       if mon.isEgg then return self:refuseShift(TEXT_EGG_CANT_BATTLE) end
       if (mon.hp or 0) <= 0 then return self:refuseShift(nil) end
@@ -3375,9 +3379,9 @@ end
 
 -- PickSwitchMonInBattle loops on carry the way BattleMenuPKMN_Loop does
 -- (engine/battle/core.asm:2716-2728).
-function BattleState:refuseShift(text)
+function BattleState:refuseShift(source, ...)
   self.phase = "refuse-shift"
-  self.message = text or TEXT_NO_WILL_TO_FIGHT
+  self.message = Strings(source or TEXT_NO_WILL_TO_FIGHT, ...)
   self.messageTimer = MESSAGE_FRAMES
 end
 
@@ -3388,7 +3392,7 @@ function BattleState:askNickname(mon)
   -- YesNoBox opens on YES; YesNoMenuHeader sets no STATICMENU_DISABLE_B.
   self.nicknameIndex = 1
   self.phase = "ask-nickname"
-  self.message = "Give a nickname to " .. self:name(mon) .. "?"
+  self.message = Strings("Give a nickname to %s?", self:name(mon))
   self.messageTimer = MESSAGE_FRAMES
 end
 
@@ -3497,11 +3501,12 @@ function BattleState:contestCatch(mon)
   self:stampCaughtData(mon, true)
   local kind, stock, fresh = BugContest.catch(self.save, mon)
   if kind ~= BugContest.ASK_SWITCH then
-    self:push({ kind = "message", text = "Caught " .. self:name(mon) .. "!" })
+    self:push({ kind = "message",
+      text = Strings("Caught %s!", self:name(mon)) })
     return
   end
   self:push({ kind = "message",
-    text = "You already caught a " .. self:name(stock) .. "." })
+    text = Strings("You already caught a %s.", self:name(stock)) })
   self:push({ kind = "contest-switch", stock = stock, caught = fresh })
 end
 
@@ -3595,7 +3600,7 @@ function BattleState:useItem(itemId)
     if #((save and save.party) or {}) >= Boxes.PARTY_SIZE
         and Boxes.isFull(save, self:currentBox()) then
       -- BallBoxFullText (data/text/common_3.asm:427).
-      self.message = "The POKéMON BOX is full. That can't be used now."
+      self.message = Strings("The POKéMON BOX is full. That can't be used now.")
       self.messageTimer = MESSAGE_FRAMES
       self.phase = "resolving"
       return
@@ -3712,7 +3717,7 @@ function BattleState:useItem(itemId)
     end
   end
 
-  self.message = "That isn't going to help here."
+  self.message = Strings("That isn't going to help here.")
   self.messageTimer = MESSAGE_FRAMES
   self.phase = "resolving"
 end
@@ -3785,7 +3790,7 @@ function BattleState:cureBattleConfusion(itemId)
   self.queue = {}
   -- ConfusedNoMoreText (data/text/battle.asm).
   self:push({ kind = "message",
-    text = self:name(mon) .. "'s confused no more!" })
+    text = Strings("%s's confused no more!", self:name(mon)) })
   self:pushAll(self.battle:takeTurn({ kind = "item", item = itemId }))
   self.phase = "resolving"
   self:advanceQueue()
@@ -3827,7 +3832,7 @@ function BattleState:applyPartyItem(itemId, action, mon, slot, partySlot)
     if not result.used then
       -- PARTYMENUTEXT_HEAL_CONFUSION (_CameToItsSensesText).
       result = { used = true,
-        text = self:name(mon) .. " came to its senses." }
+        text = Strings("%s came to its senses.", self:name(mon)) }
     end
   end
   if not result.used then
@@ -4035,12 +4040,41 @@ end
 -- (PSN, BRN, FRZ, PAR, SLP).  Toxic is the PSN bit worn harder, so it shares
 -- the tag; confusion is a substatus on the cart and never reaches the HUD.
 local STATUS_TAGS = {
-  poison = "PSN", toxic = "PSN", burn = "BRN", freeze = "FRZ",
-  paralyze = "PAR", sleep = "SLP",
+  poison = Strings.source("PSN"), toxic = Strings.source("PSN"),
+  burn = Strings.source("BRN"), freeze = Strings.source("FRZ"),
+  paralyze = Strings.source("PAR"), sleep = Strings.source("SLP"),
 }
 
 function BattleState:statusTag(mon, side)
-  return mon and STATUS_TAGS[self:hudStatus(mon, side)] or nil
+  local status = mon and self:hudStatus(mon, side) or nil
+  if not status then return nil end
+  local data = (self.game and self.game.data)
+    or (self.battle and self.battle.data)
+  local merged = data and data.gen2Statuses
+  local authored = merged and merged[status]
+  local record = authored or Battle.STATUSES[status]
+  -- SUBSTATUS_CONFUSED and any modded equivalent are battle volatiles, not
+  -- the major status byte PlaceNonFaintStatus draws in the HUD.
+  if record and record.substatus then return nil end
+  -- Builtins.registerStatusesInto seeds gen2Statuses from Battle.STATUSES at
+  -- boot with no mod installed, so `authored` alone does not mean a real mod
+  -- wrote this record: Registry:register's "register" op (non-deep, what the
+  -- engine's own seeding uses) sets value = entry.value directly, so an
+  -- UNTOUCHED status's merged record is the exact same table Battle.STATUSES
+  -- holds -- its label is still the raw Strings.source() marker and needs
+  -- the same Strings() call the fallback below gets. A real mod's :patch()
+  -- or :register() of its own builds a NEW table (deepMerge, or a value that
+  -- was never Battle.STATUSES[status] to begin with), which this reference
+  -- check tells apart from the untouched case -- that one is already
+  -- complete authored content and must not be looked up a second time.
+  if authored then
+    if authored == Battle.STATUSES[status] then
+      return Strings(authored.hudLabel or authored.label)
+    end
+    return authored.hudLabel or authored.label
+  end
+  local tag = STATUS_TAGS[status]
+  return tag and Strings(tag) or nil
 end
 
 -- ♂ / ♀ after the level, or nil for a genderless species (PrintPlayerHUD
@@ -4070,10 +4104,13 @@ end
 -- carries the park ball count, which .PrintParkBallsRemaining writes with
 -- PRINTNUM_LEADINGZEROS over two digits.
 function BattleState:menuLabels()
-  if not self.contest then return MENU end
-  return { MENU[1], MENU[2],
-    CONTEST_BALL_LABEL .. ("%02d"):format(BugContest.ballsLeft(self.save)),
-    MENU[4] }
+  if not self.contest then
+    return { Strings(MENU[1]), Strings(MENU[2]),
+      Strings(MENU[3]), Strings(MENU[4]) }
+  end
+  return { Strings(MENU[1]), Strings(MENU[2]),
+    Strings(CONTEST_BALL_LABEL, BugContest.ballsLeft(self.save)),
+    Strings(MENU[4]) }
 end
 
 -- The message on the cart's own two rows: 14 and 16, with 15 blank between
@@ -4119,14 +4156,16 @@ function BattleState:drawMoveInfoBox(move)
   if not move then return end
   local fighter = self.battle and self.battle.player
   if fighter and self.battle:moveDisabled(fighter, move.id) then
-    Chrome.printThrough("Disabled!", 1, 10, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings("Disabled!"), 1, 10,
+      Chrome.DEFAULT_BOX_PALETTE)
     return
   end
   local def = self.game and self.game.data and self.game.data.moves
     and self.game.data.moves[move.id]
-  Chrome.printThrough("TYPE/", 1, 9, Chrome.DEFAULT_BOX_PALETTE)
+  Chrome.printThrough(Strings("TYPE/"), 1, 9, Chrome.DEFAULT_BOX_PALETTE)
   local moveType = def and def.type
-  Chrome.printThrough(moveType and (TYPE_NAMES[moveType] or moveType) or "",
+  Chrome.printThrough(moveType and TypeChart.displayName(moveType,
+      self.game and self.game.data) or "",
     2, 10, Chrome.DEFAULT_BOX_PALETTE)
   Chrome.printThrough(("%2d/%2d"):format(move.pp or 0, move.maxPp or 0),
     5, 11, Chrome.DEFAULT_BOX_PALETTE)
@@ -4138,7 +4177,8 @@ function BattleState:drawPanel()
   -- required there; everywhere else a missing side is a caller bug.
   local hasPlayer = self.battle and (self.battle.player or self.tutorial)
   if not (self.battle and hasPlayer and self.battle.enemy) then
-    Chrome.printThrough("NO BATTLE", 1, 1, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings("NO BATTLE"), 1, 1,
+      Chrome.DEFAULT_BOX_PALETTE)
     return
   end
   self:drawHud()
@@ -4228,8 +4268,10 @@ function BattleState:drawPanel()
       local left = (self.phase == "ask-shift" or self.phase == "ask-next-mon")
         and 1 or 14
       Chrome.box(left, 7, 6, 5)
-      Chrome.printThrough("YES", left + 2, 8, Chrome.DEFAULT_BOX_PALETTE)
-      Chrome.printThrough("NO", left + 2, 10, Chrome.DEFAULT_BOX_PALETTE)
+      Chrome.printThrough(Strings("YES"), left + 2, 8,
+        Chrome.DEFAULT_BOX_PALETTE)
+      Chrome.printThrough(Strings("NO"), left + 2, 10,
+        Chrome.DEFAULT_BOX_PALETTE)
       local index = self.phase == "ask-nickname" and self.nicknameIndex
         or self.phase == "ask-shift" and self.shiftIndex
         or self.phase == "ask-next-mon" and self.nextMonIndex

--- a/src/ui/gen2/BoxMenu.lua
+++ b/src/ui/gen2/BoxMenu.lua
@@ -43,6 +43,7 @@
 local Assets = require("src.render.Assets")
 local Boxes = require("src.core.gen2.Boxes")
 local Chrome = require("src.ui.gen2.Chrome")
+local CommonText = require("src.core.gen2.CommonText")
 local Font = require("src.render.Font")
 local GbcPalette = require("src.render.GbcPalette")
 local Mail = require("src.core.gen2.Mail")
@@ -50,6 +51,7 @@ local Palettes = require("src.world.gen2.Palettes")
 local PartyMenu = require("src.ui.gen2.PartyMenu")
 local Screens = require("src.ui.Screens")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 local Unown = require("src.core.gen2.Unown")
 
 local BoxMenu = {}
@@ -89,13 +91,21 @@ local PARTY_BOX = 0
 -- .MoveMonWOMailSubmenu's .MenuData, verbatim.  RELEASE is NOT one of these --
 -- it belongs to BillsPC_WithdrawMenu's four rows -- so nothing on this screen
 -- can destroy a mon.
-local MOVE_SUBMENU = { "MOVE", "STATS", "CANCEL" }
+local MOVE_SUBMENU = {
+  Strings.source("MOVE"), Strings.source("STATS"), Strings.source("CANCEL"),
+}
 
 -- engine/pokemon/bills_pc.asm:472-478: BillsPC_Withdraw's menu rows.
-local WITHDRAW_SUBMENU = { "WITHDRAW", "STATS", "RELEASE", "CANCEL" }
+local WITHDRAW_SUBMENU = {
+  Strings.source("WITHDRAW"), Strings.source("STATS"),
+  Strings.source("RELEASE"), Strings.source("CANCEL"),
+}
 
 -- BillsPCDepositMenuHeader's .MenuData (engine/pokemon/bills_pc.asm:234-240).
-local DEPOSIT_SUBMENU = { "DEPOSIT", "STATS", "RELEASE", "CANCEL" }
+local DEPOSIT_SUBMENU = {
+  Strings.source("DEPOSIT"), Strings.source("STATS"),
+  Strings.source("RELEASE"), Strings.source("CANCEL"),
+}
 
 function BoxMenu:submenuRows()
   if self.mode == "move" then return MOVE_SUBMENU end
@@ -107,11 +117,49 @@ end
 -- the mon is written into its new home.  It stays up here until a button
 -- clears it, because it is also the only confirmation the player gets that the
 -- mon moved and where it went.
-local SAVING_LEAVE_ON = "Saving\xe2\x80\xa6 Leave ON!"
+local SAVING_LEAVE_ON = Strings.source("Saving… Leave ON!")
 
 -- PCString_NoReleasingEGGS, printed by BillsPC_IsMonAnEgg with SFX_WRONG
 -- (engine/pokemon/bills_pc.asm:1615-1631, string at :2200).
-local NO_RELEASING_EGGS = "No releasing EGGS!"
+local NO_RELEASING_EGGS = Strings.source("No releasing EGGS!")
+local PARTY_TITLE = Strings.source("PARTY <PK><MN>")
+local DEFAULT_BOX_TITLE = Strings.source("BOX%d")
+local CHOOSE_PROMPT = Strings.source("Choose a <PK><MN>.")
+local WHATS_UP_PROMPT = Strings.source("What's up?")
+local MOVE_WHERE_PROMPT = Strings.source("Move to where?")
+local LAST_MON = Strings.source("It's your last <PK><MN>!")
+local NO_USABLE_MON = Strings.source("No more usable <PK><MN>!")
+local REMOVE_MAIL = Strings.source("Remove MAIL.")
+local NO_ROOM = Strings.source("There's no room!")
+local RELEASE_PROMPT = Strings.source("Release <PK><MN>?")
+local RELEASED = Strings.source("Released <PK><MN>.\fBye,\n%s!")
+local GOT_MON = Strings.source("Got %s!")
+local STORED_MON = Strings.source("Stored %s!")
+
+-- Boxes.lua owns the storage mutation, so its finite refusals arrive here as
+-- return values.  Mark their complete text for the catalog and look them up
+-- when they cross this UI boundary.
+local BOX_FAILURE_SOURCES = {
+  Strings.source("No save."),
+  Strings.source("There is no POKéMON there."),
+  Strings.source("The BOX is full."),
+  Strings.source("You can't deposit\nthe last POKéMON!"),
+  Strings.source("You can't take\nany more POKéMON."),
+  Strings.source("It's already there."),
+  -- CommonText.pages() (below) only treats \n as the box's second row, not
+  -- a page break: a THIRD line needs \f (or \v) like every other multi-page
+  -- message in this file, not a second bare \n -- which used to just glue
+  -- this line onto the one above with no separator.
+  Strings.source("You'll need a\nPOKéMON to call\fwith."),
+}
+
+-- \v (scroll-continue) needs the same page-break handling CommonText.pages
+-- already gives every other Gen 2 screen (PackMenu/PrizeMenu route their
+-- messages through it); this used to split only on \n/\f, so a translated
+-- message that needed a \v scroll break rendered wrong here.
+local function messagePages(text)
+  return CommonText.pages(text) or {}
+end
 
 function BoxMenu:wantsFillScale() return true end
 function BoxMenu:drawsWidescreen() return true end
@@ -172,8 +220,11 @@ end
 function BoxMenu:nameAt(index)
   -- .PartyPKMN is "PARTY <PK><MN>@" -- eight tiles, because <PK> and <MN> are
   -- one font glyph each.
-  if self:isParty(index) then return "PARTY <PK><MN>" end
-  return Boxes.name(self.save, index)
+  if self:isParty(index) then return Strings(PARTY_TITLE) end
+  local names = self.save and self.save.boxNames
+  local custom = names and names[index]
+  if type(custom) == "string" and custom ~= "" then return custom end
+  return Strings(DEFAULT_BOX_TITLE, index)
 end
 
 -- Which list this mode browses.
@@ -183,7 +234,7 @@ function BoxMenu:list()
 end
 
 function BoxMenu:title()
-  if self.mode == "deposit" then return "PARTY <PK><MN>" end
+  if self.mode == "deposit" then return Strings(PARTY_TITLE) end
   -- While the insert cursor is up the header names the DESTINATION: the whole
   -- screen has moved there (.PrepInsertCursor calls the same
   -- BillsPC_MoveMonWOMail_BoxNameAndArrows with the new wBillsPC_LoadedBox).
@@ -194,15 +245,15 @@ end
 -- is one row of 18 columns.
 function BoxMenu:prompt()
   -- engine/pokemon/bills_pc.asm:356-369: PrepSubmenu places PCString_WhatsUp.
-  if self.phase == "submenu" then return "What's up?" end
+  if self.phase == "submenu" then return Strings(WHATS_UP_PROMPT) end
   if self.mode == "move" then
     -- .Init and .PrepInsertCursor each place their own string.
-    if self.phase == "insert" then return "Move to where?" end
-    return "Choose a <PK><MN>."
+    if self.phase == "insert" then return Strings(MOVE_WHERE_PROMPT) end
+    return Strings(CHOOSE_PROMPT)
   end
   -- PCString_ChooseaPKMN: _DepositPKMN.Init and BillsPC_Withdraw.Init both
   -- place this exact string (engine/pokemon/bills_pc.asm:2185).
-  return "Choose a <PK><MN>."
+  return Strings(CHOOSE_PROMPT)
 end
 
 function BoxMenu:total()
@@ -260,7 +311,7 @@ function BoxMenu:checkMailPreventBlackout()
   local party = self.save.party or {}
   -- `cp $3 / jr c, .ItsYourLastPokemon`: a party of one or two may not send
   -- one away at all, however healthy the rest of it is.
-  if #party < 3 then return false, "It's your last <PK><MN>!" end
+  if #party < 3 then return false, LAST_MON end
   -- CheckCurPartyMonFainted (engine/pokemon/bills_pc_top.asm:171) walks the
   -- party skipping wCurPartyMon and answers carry when everything ELSE has
   -- fainted -- taking this one out would white the player out on the next step.
@@ -268,13 +319,13 @@ function BoxMenu:checkMailPreventBlackout()
   for i, mon in ipairs(party) do
     if i ~= self.index and (mon.hp or 0) > 0 then othersUsable = true break end
   end
-  if not othersUsable then return false, "No more usable <PK><MN>!" end
+  if not othersUsable then return false, NO_USABLE_MON end
   -- wBillsPC_MonHasMail, the byte PCMonInfo set while drawing the row.  The
   -- top menu already refused to open this screen at all while any party mon
   -- holds a letter (BillsPC_MovePKMNMenu's IsAnyMonHoldingMail,
   -- src/ui/gen2/PcMenu.lua), so this is the second of two nets.
   if Mail.monHoldsMail(party[self.index]) then
-    return false, "Remove MAIL."
+    return false, REMOVE_MAIL
   end
   return true
 end
@@ -290,7 +341,7 @@ function BoxMenu:beginMove()
     self.phase = nil
     -- engine/pokemon/bills_pc.asm:1607
     self:playRefusalSfx("Sfx_Wrong")
-    self.message = reason
+    self.message = Strings(reason)
     return
   end
   self.moveFrom = { box = self.boxIndex, slot = self.index }
@@ -319,28 +370,31 @@ function BoxMenu:doWithdraw()
   if not ok then
     -- engine/pokemon/bills_pc.asm:1845
     self:playRefusalSfx("Sfx_Wrong")
-    self.message = result
+    self.message = Strings(result)
     return
   end
   -- engine/pokemon/bills_pc.asm:1817
   self:playMonCry(result)
-  self.message = nil
+  local name = result.nickname or result.name or result.species or "?"
+  self.message = Strings(GOT_MON, name)
   self.phase = nil
   self:clampIndex()
 end
 
 -- engine/pokemon/bills_pc.asm:155 BillsPCDepositFuncDeposit
 function BoxMenu:doDeposit()
+  local mon = self:selected()
+  local name = mon and (mon.nickname or mon.name or mon.species) or "?"
   local ok, result = Boxes.deposit(self.save, self.index, self.boxIndex)
   if not ok then
     -- engine/pokemon/bills_pc.asm:1790
     self:playRefusalSfx("Sfx_Wrong")
-    self.message = result
+    self.message = Strings(result)
     return
   end
   -- engine/pokemon/bills_pc.asm:1762
   self:playMonCry(result)
-  self.message = nil
+  self.message = Strings(STORED_MON, name)
   self.phase = nil
   self.index, self.scroll = 1, 0
   self:clampIndex()
@@ -393,7 +447,7 @@ function BoxMenu:checkSpaceInDestination()
   local from = self.moveFrom
   if from and from.box == self.boxIndex then return true end
   if #self:listAt(self.boxIndex) >= self:capacityAt(self.boxIndex) then
-    return false, "There's no room!"
+    return false, NO_ROOM
   end
   return true
 end
@@ -437,7 +491,7 @@ function BoxMenu:insertMon()
   self.moveFrom, self.backup = nil, nil
   self.index, self.scroll = 1, 0
   self:clampIndex()
-  self.message = SAVING_LEAVE_ON
+  self.message = Strings(SAVING_LEAVE_ON)
 end
 
 -- .b_button_2: the backed-up scroll, cursor and loaded box all go back, and
@@ -470,7 +524,12 @@ function BoxMenu:update(_dt)
 
   if self.message then
     if input:wasPressed("a") or input:wasPressed("b") then
-      self.message = nil
+      local page = (self.messagePage or 1) + 1
+      if page <= #messagePages(self.message) then
+        self.messagePage = page
+      else
+        self.message, self.messagePage = nil, nil
+      end
     end
     return
   end
@@ -516,7 +575,7 @@ function BoxMenu:update(_dt)
         -- so the refusal leaves the cursor exactly where it was.
         -- engine/pokemon/bills_pc.asm:1567
         self:playRefusalSfx("Sfx_Wrong")
-        self.message = reason
+        self.message = Strings(reason)
       else
         self:insertMon()
       end
@@ -589,14 +648,14 @@ function BoxMenu:askRelease()
       self.phase = nil
       -- engine/pokemon/bills_pc.asm:1607
       self:playRefusalSfx("Sfx_Wrong")
-      self.message = refusal
+      self.message = Strings(refusal)
       return
     end
   end
   -- Both release paths run BillsPC_IsMonAnEgg first, so the question is never
   -- even asked over an egg (engine/pokemon/bills_pc.asm:186-187 and :427-428).
   if mon.isEgg then
-    self.message = NO_RELEASING_EGGS
+    self.message = Strings(NO_RELEASING_EGGS)
     self:playRefusalSfx("Sfx_Wrong")
     return
   end
@@ -604,7 +663,9 @@ function BoxMenu:askRelease()
   if not (game and game.stack) then return end
   local ChoiceBox = require("src.ui.ChoiceBox")
   local name = mon.nickname or mon.name or mon.species or "?"
+  self.message = Strings(RELEASE_PROMPT)
   game.stack:push(ChoiceBox.new(game, function(yes)
+    self.message = nil
     if not yes then return end
     local ok, err
     if self.mode == "deposit" then
@@ -613,12 +674,12 @@ function BoxMenu:askRelease()
       ok, err = Boxes.release(self.save, self.boxIndex, self.index)
     end
     if not ok then
-      self.message = err
+      self.message = Strings(err)
       return
     end
     -- engine/pokemon/bills_pc.asm:1866
     self:playMonCry(mon)
-    self.message = name .. " was released."
+    self.message = Strings(RELEASED, name)
     self.phase = nil
     self:clampIndex()
   end, { defaultNo = true }))
@@ -887,7 +948,7 @@ function BoxMenu:drawPanel()
       if i == self.index then self:drawInsertCursor(row) end
     elseif i == self:total() then
       if i == self.index then self:drawSelectionFrame(row) end
-      Chrome.print("CANCEL", LIST_X, ty)
+      Chrome.print(Strings("CANCEL"), LIST_X, ty)
     end
   end
 
@@ -922,10 +983,9 @@ function BoxMenu:drawPanel()
   if self.message then
     Chrome.box(0, 12, 20, 6)
     -- Two lines, two tile rows apart, the way every other text box lays out.
-    local line = 14
-    for part in (self.message .. "\n"):gmatch("(.-)\n") do
-      Chrome.print(part, 1, line)
-      line = line + 2
+    local page = messagePages(self.message)[self.messagePage or 1] or {}
+    for i, part in ipairs(page) do
+      Chrome.print(part, 1, 14 + (i - 1) * 2)
     end
   else
     Chrome.box(0, 15, 20, 3)
@@ -941,7 +1001,7 @@ function BoxMenu:drawPanel()
     for i, label in ipairs(self:submenuRows()) do
       local ty = 6 + (i - 1) * 2
       if i == self.submenuIndex then Chrome.cursor(10, ty) end
-      Chrome.print(label, 11, ty)
+      Chrome.print(Strings(label), 11, ty)
     end
   end
   love.graphics.setColor(1, 1, 1, 1)

--- a/src/ui/gen2/CardFlip.lua
+++ b/src/ui/gen2/CardFlip.lua
@@ -56,6 +56,7 @@
 local Chrome = require("src.ui.gen2.Chrome")
 local CoinCase = require("src.core.gen2.CoinCase")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 
 local CardFlip = {}
 CardFlip.__index = CardFlip
@@ -303,15 +304,39 @@ local TEXT_X, TEXT_Y, TEXT_LINE = 1, 14, 2
 -- data/text/common_3.asm; none of these are in the cache's text.lua, because no
 -- script bytecode the extractor walks points at them.
 CardFlip.TEXTS = {
-  playWithThree = { "Play with", "3 coins?" },
-  notEnough = { "Not enough", "coins." },
-  chooseACard = { "Choose a", "card." },
-  placeYourBet = { "Place", "your bet" },
-  playAgain = { "Play", "again?" },
-  shuffled = { "The cards", "shuffled." },
-  yeah = { "Yeah!" },
-  darn = { "Darn…" },
+  playWithThree = { "Play with", "3 coins?",
+    source = Strings.source("Play with\n3 coins?") },
+  notEnough = { "Not enough", "coins.",
+    source = Strings.source("Not enough\ncoins.") },
+  chooseACard = { "Choose a", "card.",
+    source = Strings.source("Choose a\ncard.") },
+  placeYourBet = { "Place", "your bet",
+    source = Strings.source("Place\nyour bet") },
+  playAgain = { "Play", "again?",
+    source = Strings.source("Play\nagain?") },
+  shuffled = { "The cards", "shuffled.",
+    source = Strings.source("The cards\nshuffled.") },
+  yeah = { "Yeah!", source = Strings.source("Yeah!") },
+  darn = { "Darn…", source = Strings.source("Darn…") },
 }
+
+-- Deliberately \n-only, unlike CommonText.pages/pagesOf elsewhere in Gen2
+-- UI: every entry in CardFlip.TEXTS above is a fixed two-line cart message,
+-- and the box it draws into (TEXT_BOX_H = 6, TEXT_LINE = 2) only has room
+-- for two printed lines before a third would land past its bottom edge. The
+-- draw loop has no page break at all, so a translation that needs a third
+-- line here would silently overflow instead of paginating -- route through
+-- CommonText.pages instead if that is ever needed.
+local function localizedLines(lines)
+  if not (lines and lines.source) then return lines or {} end
+  local translated = Strings(lines.source)
+  if translated == lines.source then return lines end
+  local out = {}
+  for line in (translated .. "\n"):gmatch("(.-)\n") do
+    out[#out + 1] = line
+  end
+  return out
+end
 
 local SFX_TRANSACTION = "Sfx_Transaction"
 local SFX_KINESIS = "Sfx_Kinesis"
@@ -935,14 +960,14 @@ function CardFlip:drawPanel()
   -- Dialogue / Message box at (0, 12), 10 wide, 6 tall (interior 8x4)
   if self.lines then
     Chrome.textbox(TEXT_BOX_X, TEXT_BOX_Y, 8, 4)
-    for i, line in ipairs(self.lines) do
+    for i, line in ipairs(localizedLines(self.lines)) do
       Chrome.print(line, TEXT_X, TEXT_Y + (i - 1) * TEXT_LINE)
     end
   end
 
   -- Coin box at (9, 15), 11 wide, 3 tall (interior 9x1)
   Chrome.textbox(COIN_BOX_X, COIN_BOX_Y, 9, 1)
-  Chrome.print("COIN", COIN_LABEL_X, COIN_LABEL_Y)
+  Chrome.print(Strings("COIN"), COIN_LABEL_X, COIN_LABEL_Y)
   Chrome.print(Chrome.number(self:coins(), 4, true), COIN_VALUE_X, COIN_VALUE_Y)
 
   if self.phase == "bet" then
@@ -956,8 +981,8 @@ function CardFlip:drawPanel()
   if self.phase == "ask" or self.phase == "again" then
     -- YesNoBox: a 6x5 box at (14,7) with YES at (16,8) and NO at (16,10).
     Chrome.textbox(14, 7, 4, 3)
-    Chrome.print("YES", 16, 8)
-    Chrome.print("NO", 16, 10)
+    Chrome.print(Strings("YES"), 16, 8)
+    Chrome.print(Strings("NO"), 16, 10)
     Chrome.cursor(15, 8 + (self.choice - 1) * 2)
   end
 end
@@ -978,4 +1003,3 @@ function CardFlip:drawWidescreen(winW, winH)
 end
 
 return CardFlip
-

--- a/src/ui/gen2/CenterPcMenu.lua
+++ b/src/ui/gen2/CenterPcMenu.lua
@@ -33,6 +33,33 @@ CenterPcMenu.isOpaque = false
 -- (World:setEngineFlag), so the same store answers here.
 local ENGINE_POKEDEX = 11
 
+-- Text owned by PokemonCenterPC/ProfOaksPC. Keep each cart message as one
+-- catalog key so a translation may reflow or reorder it without inheriting
+-- the English line fragments.
+local TEXT = {
+  -- data/text/common_2.asm:725 _PokecenterPCCantUseText ends in `cont`
+  -- (\v scrolls "have a #MON to" up and lands "use this!" under it), not a
+  -- third bare \n line (which pagesOf() renders as its own one-line page
+  -- instead of a scroll).
+  noMon = Strings.source("Bzzzzt! You must\nhave a #MON to\vuse this!"),
+  turnedOn = Strings.source("{PLAYER} turned on\nthe PC."),
+  billsPc = Strings.source("BILL's PC"),
+  playersPc = Strings.source("%s's PC"),
+  oaksPc = Strings.source("PROF.OAK's PC"),
+  hallOfFame = Strings.source("HALL OF FAME"),
+  turnOff = Strings.source("TURN OFF"),
+  oakClosed = Strings.source("The link to PROF.\nOAK's PC closed."),
+  linkClosed = Strings.source("…\nLink closed…"),
+  billsOpened = Strings.source(
+    "BILL's PC\naccessed.\n\n#MON Storage\nSystem opened."),
+  ownOpened = Strings.source(
+    "Accessed own PC.\n\nItem Storage\nSystem opened."),
+  oakOpened = Strings.source(
+    "PROF.OAK's PC\naccessed.\n\n#DEX Rating\nSystem opened."),
+  rateDex = Strings.source("Want to get your\n#DEX rated?"),
+  accessWhose = Strings.source("Access whose PC?"),
+}
+
 function CenterPcMenu:wantsFillScale() return true end
 
 -- `\f` = para (home/text.asm:403 Paragraph), `\v` = cont (home/text.asm:442
@@ -68,6 +95,10 @@ local function pagesOf(body)
   return pages
 end
 
+local function translatedPages(source, ...)
+  return pagesOf(Strings(source, ...))
+end
+
 -- opts: save, events, items (items.lua), onClose()
 function CenterPcMenu.new(game, opts)
   opts = opts or {}
@@ -90,13 +121,13 @@ function CenterPcMenu.new(game, opts)
     -- never boots (`ret c` before PC_PlayBootSound).
     -- data/text/common_2.asm:725 _PokecenterPCCantUseText ends in cont.
     self:playSfx("Sfx_ChoosePcOption")
-    self:say(pagesOf(Strings("Bzzzzt! You must\nhave a #MON to\vuse this!")),
+    self:say(translatedPages(TEXT.noMon),
       function() self:close() end)
   else
     -- PC_PlayBootSound + _PokecenterPCTurnOnText.
     self:playSfx("Sfx_BootPc")
     -- ../pokecrystal/engine/events/pokecenter_pc.asm:22
-    self:say({ { "{PLAYER} turned on", "the PC." } },
+    self:say(translatedPages(TEXT.turnedOn),
       function() self.booted = true end)
   end
   return self
@@ -123,16 +154,16 @@ function CenterPcMenu:buildEntries()
     and save.engineFlags[ENGINE_POKEDEX] == true
   local hofCount = (save and save.hallOfFame and save.hallOfFame.count) or 0
   local entries = {
-    { id = "bills", label = "BILL's PC" },
-    { id = "players", label = self:playerName() .. "'s PC" },
+    { id = "bills", label = Strings(TEXT.billsPc) },
+    { id = "players", label = Strings(TEXT.playersPc, self:playerName()) },
   }
   if hasDex then
-    entries[#entries + 1] = { id = "oaks", label = "PROF.OAK's PC" }
+    entries[#entries + 1] = { id = "oaks", label = Strings(TEXT.oaksPc) }
     if hofCount > 0 then
-      entries[#entries + 1] = { id = "hof", label = "HALL OF FAME" }
+      entries[#entries + 1] = { id = "hof", label = Strings(TEXT.hallOfFame) }
     end
   end
-  entries[#entries + 1] = { id = "turnoff", label = "TURN OFF" }
+  entries[#entries + 1] = { id = "turnoff", label = Strings(TEXT.turnOff) }
   self.entries = entries
 end
 
@@ -163,7 +194,7 @@ end
 -- ProfOaksPC's `.shutdown`: _OakPCText4 either way, then back to the menu
 -- loop (`jr nc, .loop` in PokemonCenterPC -- the OaksPC row answers nc).
 function CenterPcMenu:oakClosed()
-  self:say({ { "The link to PROF.", "OAK's PC closed." } })
+  self:say(translatedPages(TEXT.oakClosed))
 end
 
 -- ProfOaksPCBoot, inside a screen rather than a script: the counts, the
@@ -189,15 +220,14 @@ function CenterPcMenu:choose()
   local game = self.game
   if entry.id == "turnoff" then
     -- TurnOffPC: PokecenterPCOaksClosedText, then carry into .shutdown.
-    self:say({ { "\xe2\x80\xa6", "Link closed\xe2\x80\xa6" } },
+    self:say(translatedPages(TEXT.linkClosed),
       function() self:shutdown() end)
     return
   end
   -- PC_PlayChoosePCSound opens all four of the other rows.
   self:playSfx("Sfx_ChoosePcOption")
   if entry.id == "bills" then
-    self:say({ { "BILL's PC", "accessed." },
-               { "#MON Storage", "System opened." } }, function()
+    self:say(translatedPages(TEXT.billsOpened), function()
       if not (game and game.stack) then return end
       Screens.push(game, "Gen2PcMenu", {
         save = self.save,
@@ -206,8 +236,7 @@ function CenterPcMenu:choose()
       })
     end)
   elseif entry.id == "players" then
-    self:say({ { "Accessed own PC." },
-               { "Item Storage", "System opened." } }, function()
+    self:say(translatedPages(TEXT.ownOpened), function()
       if not (game and game.stack) then return end
       Screens.push(game, "Gen2ItemPcMenu", {
         save = self.save,
@@ -216,11 +245,10 @@ function CenterPcMenu:choose()
       })
     end)
   elseif entry.id == "oaks" then
-    self:say({ { "PROF.OAK's PC", "accessed." },
-               { "#DEX Rating", "System opened." } }, function()
+    self:say(translatedPages(TEXT.oakOpened), function()
       -- _OakPCText1's yes/no; NO is the same `.shutdown` as a finished rating.
       self.confirm = {
-        prompt = { "Want to get your", "#DEX rated?" },
+        prompt = translatedPages(TEXT.rateDex)[1],
         choice = 1,
         onYes = function() self:oakRate() end,
         onNo = function() self:oakClosed() end,
@@ -303,7 +331,11 @@ end
 
 function CenterPcMenu:drawPanel()
   if self.booted then
-    self:drawBottomLines({ "Access whose PC?" })
+    -- _PokecenterPCWhoseText stays up under the menu
+    -- (PC_DisplayTextWaitMenu leaves it there); the menu window is drawn on
+    -- top of it, the way the cart's windows stack.
+    self:drawBottomLines(translatedPages(TEXT.accessWhose)[1])
+    -- .TopMenu is menu_coords 0, 0, 15, 12.
     Chrome.box(0, 0, 16, math.max(12, #self.entries * 2 + 2))
     for i, entry in ipairs(self.entries) do
       local ty = i * 2
@@ -319,8 +351,8 @@ function CenterPcMenu:drawPanel()
   elseif self.confirm then
     self:drawBottomLines(self.confirm.prompt)
     Chrome.box(14, 7, 6, 5)
-    Chrome.print("YES", 16, 8)
-    Chrome.print("NO", 16, 10)
+    Chrome.print(Strings("YES"), 16, 8)
+    Chrome.print(Strings("NO"), 16, 10)
     Chrome.cursor(15, self.confirm.choice == 1 and 8 or 10)
   elseif not self.booted then
     self:drawBottomLines(nil)

--- a/src/ui/gen2/ContestMenu.lua
+++ b/src/ui/gen2/ContestMenu.lua
@@ -33,6 +33,7 @@
 
 local BugContest = require("src.core.gen2.BugContest")
 local Chrome = require("src.ui.gen2.Chrome")
+local Strings = require("src.core.Strings")
 
 local ContestMenu = {}
 ContestMenu.__index = ContestMenu
@@ -64,15 +65,20 @@ local TEXT_X, TEXT_Y = 1, 14
 -- and trailing spaces, and data/text/common_2.asm's _ContestAskSwitchText.
 -- <PK> and <MN> are one tile each, so "<PK><MN>" is two tiles and not seven.
 ContestMenu.TEXT = {
-  stock = " STOCK <PK><MN> ",
-  this = " THIS <PK><MN> ",
-  health = "HEALTH",
-  askSwitch = "Switch #MON?",
+  stock = Strings.source(" STOCK <PK><MN> "),
+  this = Strings.source(" THIS <PK><MN> "),
+  health = Strings.source("HEALTH"),
+  askSwitch = Strings.source("Switch #MON?"),
   -- _ContestCaughtMonText and _ContestAlreadyCaughtText, the two lines that
   -- bracket this screen in BugContest_SetCaughtContestMon.
-  caught = function(name) return { ("Caught %s!"):format(name) } end,
+  caught = function(name) return { Strings("Caught %s!", name) } end,
   alreadyCaught = function(name)
-    return { "You already caught", ("a %s."):format(name) }
+    local text = Strings("You already caught\na %s.", name)
+    local lines = {}
+    for line in (text .. "\n"):gmatch("(.-)\n") do
+      lines[#lines + 1] = line
+    end
+    return lines
   end,
 }
 
@@ -139,9 +145,10 @@ end
 
 function ContestMenu:drawMonBox(boxY, label, mon)
   Chrome.textbox(STOCK_BOX_X, boxY, BOX_INNER_W, BOX_INNER_H)
-  Chrome.print(label, LABEL_X, boxY)
+  Chrome.print(Strings(label), LABEL_X, boxY)
   Chrome.print(nameAndLevel(mon), NAME_X, boxY + NAME_ROW_OFFSET)
-  Chrome.print(ContestMenu.TEXT.health, HEALTH_X, boxY + HEALTH_ROW_OFFSET)
+  Chrome.print(Strings(ContestMenu.TEXT.health), HEALTH_X,
+    boxY + HEALTH_ROW_OFFSET)
   -- `lb bc, 2, 3`: two source bytes into a three-digit field, space padded
   -- because PRINTNUM_LEADINGZEROS is not set, laid down FROM hlcoord 11 --
   -- so the field starts at HP_X and the padding is part of the string.
@@ -155,8 +162,8 @@ function ContestMenu:drawYesNo()
   -- STATICMENU_CURSOR, and YesNoMenuHeader sets STATICMENU_NO_TOP_SPACING so
   -- there is no third row of padding -- YES at (16,8), NO at (16,10), cursor
   -- column 15.
-  Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-  Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+  Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+  Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
   Chrome.cursor(YESNO_X + 1, YESNO_Y + (self.choice == 1 and 1 or 3))
 end
 
@@ -165,7 +172,7 @@ function ContestMenu:drawPanel()
   self:drawMonBox(STOCK_BOX_Y, ContestMenu.TEXT.stock, self.stock)
   self:drawMonBox(THIS_BOX_Y, ContestMenu.TEXT.this, self.caught)
   Chrome.box(TEXT_BOX_X, TEXT_BOX_Y, TEXT_BOX_W, TEXT_BOX_H)
-  Chrome.print(ContestMenu.TEXT.askSwitch, TEXT_X, TEXT_Y)
+  Chrome.print(Strings(ContestMenu.TEXT.askSwitch), TEXT_X, TEXT_Y)
   self:drawYesNo()
   love.graphics.setColor(1, 1, 1, 1)
 end

--- a/src/ui/gen2/DayCareMenu.lua
+++ b/src/ui/gen2/DayCareMenu.lua
@@ -50,6 +50,7 @@ local Chrome = require("src.ui.gen2.Chrome")
 local CommonText = require("src.core.gen2.CommonText")
 local Screens = require("src.ui.Screens")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 local Typer = require("src.ui.gen2.Typer")
 
 local DayCareMenu = {}
@@ -550,8 +551,8 @@ end
 
 function DayCareMenu:drawYesNo(choice)
   Chrome.box(YESNO_X, YESNO_Y, YESNO_W, YESNO_H)
-  Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-  Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+  Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+  Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
   Chrome.cursor(YESNO_X + 1, YESNO_Y + (choice == 1 and 1 or 3))
 end
 

--- a/src/ui/gen2/EvolutionAnim.lua
+++ b/src/ui/gen2/EvolutionAnim.lua
@@ -36,6 +36,7 @@ local Music = require("src.core.Music")
 local Palettes = require("src.world.gen2.Palettes")
 local Sound = require("src.core.Sound")
 local SpriteAnims = require("src.ui.gen2.SpriteAnims")
+local Strings = require("src.core.Strings")
 
 local EvolutionAnim = {}
 EvolutionAnim.__index = EvolutionAnim
@@ -67,6 +68,29 @@ local BLACKOUT = Palettes.BLACKOUT
 -- full, so the balls of light cap out at ten on screen no matter how many
 -- .GenerateBallOfLight would like to make.
 local BALL_LIMIT = 10
+
+local EVOLVING_TEXT = Strings.source("What? %s\nis evolving!")
+local STOPPED_TEXT = Strings.source("Huh? %s\nstopped evolving!")
+local CONGRATS_TEXT = Strings.source("Congratulations!\nYour %s")
+local EVOLVED_TEXT = Strings.source("evolved into\n%s!")
+local LEARNED_TEXT = Strings.source("%s learned\n%s!")
+local WANTS_TO_LEARN_TEXT = Strings.source("%s wants to\nlearn %s!")
+
+-- Deliberately \n-only, unlike CommonText.pages/pagesOf elsewhere in Gen2
+-- UI: every template above is a fixed two-line cart message, and the box
+-- below (BOX_H = 6, TEXT_LINE = 2) only has room for two printed lines
+-- before a third would land past its bottom edge. self.lines is drawn as a
+-- flat list with no page break at all, so a translation that needs a third
+-- line here would silently overflow instead of paginating -- route through
+-- CommonText.pages instead if that is ever needed.
+local function messageLines(source, ...)
+  local translated = Strings(source, ...)
+  local out = {}
+  for line in (translated .. "\n"):gmatch("(.-)\n") do
+    out[#out + 1] = line
+  end
+  return out
+end
 
 --------------------------------------------------------------------------
 -- Construction
@@ -196,7 +220,7 @@ function EvolutionAnim:setPhase(phase)
     -- PrintText EvolvingText, then `ld c, 50 / call DelayFrames`.  The pics are
     -- not placed yet: on the cart the battle screen is still up behind this
     -- line and ClearBox only wipes rows 0..11 once the delay is over.
-    self.lines = { "What? " .. self.nick, "is evolving!" }
+    self.lines = messageLines(EVOLVING_TEXT, self.nick)
     self.timer = Evolution.EVOLVING_FRAMES
     return
   end
@@ -258,13 +282,13 @@ function EvolutionAnim:setPhase(phase)
 
   if phase == "stopped" then
     -- CancelEvolution: StoppedEvolvingText over the pic, then ClearTilemap.
-    self.lines = { "Huh? " .. self.nick, "stopped evolving!" }
+    self.lines = messageLines(STOPPED_TEXT, self.nick)
     self.timer = PROMPT_FRAMES
     return
   end
 
   if phase == "congrats" then
-    self.lines = { "Congratulations!", "Your " .. self.nick }
+    self.lines = messageLines(CONGRATS_TEXT, self.nick)
     self.timer = PROMPT_FRAMES
     return
   end
@@ -279,7 +303,7 @@ function EvolutionAnim:setPhase(phase)
   if phase == "evolved" then
     -- EvolvedIntoText, then MUSIC_NONE / SFX_CAUGHT_MON / WaitSFX and
     -- `ld c, 40 / call DelayFrames`.
-    self.lines = { "evolved into", self.newName .. "!" }
+    self.lines = messageLines(EVOLVED_TEXT, self.newName)
     Music.stop()
     self:playSfx("Sfx_CaughtMon")
     self.timer = Evolution.CONGRATS_FRAMES
@@ -336,7 +360,7 @@ function EvolutionAnim:nextLearn()
   local ok, reason = Mon.learnMove(self.evolved, moveId, self.data)
   if ok then
     self.learned[#self.learned + 1] = moveId
-    self.lines = { self.nick .. " learned", moveName .. "!" }
+    self.lines = messageLines(LEARNED_TEXT, self.nick, moveName)
   elseif reason == "full" then
     if self.game and self.game.learnMoveOn then
       self.phase = "waitingLearn"
@@ -350,7 +374,7 @@ function EvolutionAnim:nextLearn()
       end)
     end
     self.full[#self.full + 1] = moveId
-    self.lines = { self.nick .. " wants to", "learn " .. moveName .. "!" }
+    self.lines = messageLines(WANTS_TO_LEARN_TEXT, self.nick, moveName)
   else
     return self:nextLearn()
   end

--- a/src/ui/gen2/GenderSelect.lua
+++ b/src/ui/gen2/GenderSelect.lua
@@ -14,8 +14,8 @@ GenderSelect.isOpaque = true
 -- .MenuData's two items (../pokecrystal/engine/menus/init_gender.asm:50-53),
 -- and the wPlayerGender byte each writes (`ld a, [wMenuCursorY] / dec a`).
 GenderSelect.OPTIONS = {
-  { label = "Boy", gender = "male" },
-  { label = "Girl", gender = "female" },
+  { label = Strings.source("Boy"), gender = "male" },
+  { label = Strings.source("Girl"), gender = "female" },
 }
 
 -- menu_coords 6, 4, 12, 9 -- inclusive, so 7 columns by 6 rows.
@@ -114,7 +114,7 @@ function GenderSelect:drawPanel()
   Chrome.box(BOX_X, BOX_Y, BOX_W, BOX_H)
   for i, option in ipairs(GenderSelect.OPTIONS) do
     local row = TEXT_Y + (i - 1) * ROW_STEP
-    Chrome.print(option.label, TEXT_X, row)
+    Chrome.print(Strings(option.label), TEXT_X, row)
     if i == self.cursor then Chrome.cursor(CURSOR_X, row) end
   end
 end

--- a/src/ui/gen2/HeldItemMenu.lua
+++ b/src/ui/gen2/HeldItemMenu.lua
@@ -32,6 +32,7 @@ local Chrome = require("src.ui.gen2.Chrome")
 local CommonText = require("src.core.gen2.CommonText")
 local Mail = require("src.core.gen2.Mail")
 local Screens = require("src.ui.Screens")
+local Strings = require("src.core.Strings")
 
 local HeldItemMenu = {}
 HeldItemMenu.__index = HeldItemMenu
@@ -49,8 +50,8 @@ local DOWN_ARROW = "\xe2\x96\xbc"
 local ARROW_X, ARROW_Y = 18, 17
 
 local ENTRIES = {
-  { id = "give", label = "GIVE" },
-  { id = "take", label = "TAKE" },
+  { id = "give", label = Strings.source("GIVE") },
+  { id = "take", label = Strings.source("TAKE") },
 }
 
 local function page(...) return { ... } end
@@ -359,8 +360,8 @@ end
 
 function HeldItemMenu:drawYesNo(choice)
   Chrome.box(YESNO_X, YESNO_Y, YESNO_W, YESNO_H)
-  Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-  Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+  Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+  Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
   Chrome.cursor(YESNO_X + 1, YESNO_Y + (choice == 1 and 1 or 3))
 end
 
@@ -387,7 +388,7 @@ function HeldItemMenu:drawPanel()
   for row, entry in ipairs(ENTRIES) do
     local ty = MENU_LABEL_Y + (row - 1) * 2
     if row == self.index then Chrome.cursor(MENU_LABEL_X - 1, ty) end
-    Chrome.print(entry.label, MENU_LABEL_X, ty)
+    Chrome.print(Strings(entry.label), MENU_LABEL_X, ty)
   end
   love.graphics.setColor(1, 1, 1, 1)
 end

--- a/src/ui/gen2/InitClock.lua
+++ b/src/ui/gen2/InitClock.lua
@@ -346,8 +346,8 @@ function InitClock:drawPanel()
   Chrome.printWrapped(self:pageText(), 1, 14, 18, 3)
   if self:confirming() then
     Chrome.box(14, 6, 6, 5)
-    Chrome.print("YES", 16, 7)
-    Chrome.print("NO", 16, 9)
+    Chrome.print(Strings("YES"), 16, 7)
+    Chrome.print(Strings("NO"), 16, 9)
     Chrome.cursor(15, self.yesNo == 1 and 7 or 9)
   end
 end

--- a/src/ui/gen2/ItemPcMenu.lua
+++ b/src/ui/gen2/ItemPcMenu.lua
@@ -32,6 +32,7 @@ local PcItems = require("src.core.gen2.PcItems")
 local Runtime = require("src.mods.Runtime")
 local Screens = require("src.ui.Screens")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 local Typer = require("src.ui.gen2.Typer")
 local WaitPlaySFX = require("src.ui.gen2.WaitPlaySFX")
 
@@ -54,14 +55,51 @@ local function stacksFor(n) return math.ceil((n or 0) / MAX_STACK) end
 -- which rows a caller sees: PLAYERSPC_NORMAL ends on LOG OFF, PLAYERSPC_HOUSE
 -- carries DECORATION and ends on TURN OFF.
 local ENTRIES = {
-  { id = "withdraw", label = "WITHDRAW ITEM" },
-  { id = "deposit", label = "DEPOSIT ITEM" },
-  { id = "toss", label = "TOSS ITEM" },
-  { id = "mailbox", label = "MAIL BOX" },
+  { id = "withdraw", label = Strings.source("WITHDRAW ITEM"), builtin = true },
+  { id = "deposit", label = Strings.source("DEPOSIT ITEM"), builtin = true },
+  { id = "toss", label = Strings.source("TOSS ITEM"), builtin = true },
+  { id = "mailbox", label = Strings.source("MAIL BOX"), builtin = true },
 }
-local LOG_OFF = { id = "logoff", label = "LOG OFF" }
-local DECORATION = { id = "decoration", label = "DECORATION" }
-local TURN_OFF = { id = "turnoff", label = "TURN OFF" }
+local LOG_OFF = {
+  id = "logoff", label = Strings.source("LOG OFF"), builtin = true,
+}
+local DECORATION = {
+  id = "decoration", label = Strings.source("DECORATION"), builtin = true,
+}
+local TURN_OFF = {
+  id = "turnoff", label = Strings.source("TURN OFF"), builtin = true,
+}
+
+-- _PlayersPC's player-facing text. Dynamic item names are format arguments,
+-- not catalog keys, so registry-provided names remain untouched while a
+-- language may reorder the quantity/name around them.
+local TEXT = {
+  turnedOn = Strings.source("{PLAYER} turned on\nthe PC."),
+  noBagRoom = Strings.source("There's no room\nfor more items."),
+  withdrew = Strings.source("Withdrew %d\n%s(S)."),
+  withdrawHowMany = Strings.source("How many do you\nwant to withdraw?"),
+  noPcRoom = Strings.source("There's no room to\nstore items."),
+  deposited = Strings.source("Deposited %d\n%s(S)."),
+  noItems = Strings.source("No items here!"),
+  depositHowMany = Strings.source("How many do you\nwant to deposit?"),
+  tooImportant = Strings.source("That's too impor-\ntant to toss out!"),
+  tossHowMany = Strings.source("Toss out how many\n%s(S)?"),
+  throwAway = Strings.source("Throw away %d\n%s(S)?"),
+  discarded = Strings.source("Discarded\n%s(S)."),
+  whatDo = Strings.source("What do you want\nto do?"),
+}
+
+local function translatedLines(source, ...)
+  local lines = {}
+  for line in (Strings(source, ...) .. "\n"):gmatch("(.-)\n") do
+    lines[#lines + 1] = line
+  end
+  return lines
+end
+
+local function translatedPages(source, ...)
+  return { translatedLines(source, ...) }
+end
 
 -- ui.pc.items identity: an unhooked build hands its own list back.
 local function sameItems(_, items) return items end
@@ -130,7 +168,7 @@ function ItemPcMenu.new(game, opts)
   if self.house then
     -- _PlayersHousePC: PC_PlayBootSound, then PlayersPCTurnOnText.
     self:playPcSfx("Sfx_BootPc")
-    self:say({ { "{PLAYER} turned on", "the PC." } })
+    self:say(translatedPages(TEXT.turnedOn))
   end
   return self
 end
@@ -302,12 +340,12 @@ function ItemPcMenu:withdraw(row, qty)
   -- PlayerWithdrawItemMenu .withdraw: ReceiveItem into the bag first; only a
   -- carry tosses the stack out of the PC.
   if not Bag.add(self.save, row.id, qty, self.data) then
-    self:say({ { "There's no room", "for more items." } })
+    self:say(translatedPages(TEXT.noBagRoom))
     return
   end
   self:pcRemove(row.id, qty)
   self:rebuild()
-  self:say({ { ("Withdrew %d"):format(qty), row.name .. "(S)." } })
+  self:say(translatedPages(TEXT.withdrew, qty, row.name))
 end
 
 function ItemPcMenu:chooseWithdraw()
@@ -323,24 +361,24 @@ function ItemPcMenu:chooseWithdraw()
     return
   end
   self:askQuantity(row.count,
-    { "How many do you", "want to withdraw?" },
+    translatedLines(TEXT.withdrawHowMany),
     function(qty) self:withdraw(row, qty) end)
 end
 
 function ItemPcMenu:deposit(id, name, qty)
   if not self:pcAdd(id, qty) then
-    self:say({ { "There's no room to", "store items." } })
+    self:say(translatedPages(TEXT.noPcRoom))
     return
   end
   Bag.remove(self.save, id, qty)
   if self.pack then self.pack:rebuild() end
-  self:say({ { ("Deposited %d"):format(qty), name .. "(S)." } })
+  self:say(translatedPages(TEXT.deposited, qty, name))
 end
 
 function ItemPcMenu:enterDeposit()
   -- .CheckItemsInBag: an empty bag never opens the PACK.
   if bagIsEmpty(self.save) then
-    self:say({ { "No items here!" } })
+    self:say(translatedPages(TEXT.noItems))
     return
   end
   self:setPhase("deposit")
@@ -371,7 +409,7 @@ function ItemPcMenu:offerToDeposit(id, count)
     return
   end
   self:askQuantity(count,
-    { "How many do you", "want to deposit?" },
+    translatedLines(TEXT.depositHowMany),
     function(qty) self:deposit(id, name, qty) end)
 end
 
@@ -383,20 +421,20 @@ function ItemPcMenu:chooseToss()
   end
   -- TossItemFromPC .key_item -> .CantToss.
   if self:cantToss(row.id) then
-    self:say({ { "That's too impor-", "tant to toss out!" } })
+    self:say(translatedPages(TEXT.tooImportant))
     return
   end
   self:askQuantity(row.count,
-    { "Toss out how many", row.name .. "(S)?" },
+    translatedLines(TEXT.tossHowMany, row.name),
     function(qty)
       -- .ItemsThrowAwayText's yes/no sits between the count and the toss.
       self.confirm = {
-        prompt = { ("Throw away %d"):format(qty), row.name .. "(S)?" },
+        prompt = translatedLines(TEXT.throwAway, qty, row.name),
         choice = 1,
         onYes = function()
           self:pcRemove(row.id, qty)
           self:rebuild()
-          self:say({ { "Discarded", row.name .. "(S)." } })
+          self:say(translatedPages(TEXT.discarded, row.name))
         end,
       }
     end)
@@ -640,7 +678,7 @@ function ItemPcMenu:drawList()
       end
     elseif i == self:listTotal() then
       if i == self.listIndex then Chrome.cursor(LIST_X - 1, ty, picked) end
-      Chrome.print("CANCEL", LIST_X, ty)
+      Chrome.print(Strings("CANCEL"), LIST_X, ty)
     end
   end
   -- UpdateItemDescription under the list.
@@ -670,14 +708,14 @@ function ItemPcMenu:drawPanel()
     -- _PlayersPCAskWhatDoText, printed under the list the whole time.  The
     -- box goes down first: the menu window overlays it where the house's
     -- six-row list runs past row 12, the way the cart's windows stack.
-    self:drawBottomLines({ "What do you want", "to do?" })
+    self:drawBottomLines(translatedLines(TEXT.whatDo))
     -- PlayersPCMenuData is menu_coords 0, 0, 15, 12; the house list is one
     -- row taller than that box, so size it to the entries.
     Chrome.box(0, 0, 16, math.max(12, #self.entries * 2 + 2))
     for i, entry in ipairs(self.entries) do
       local ty = i * 2
       if i == self.index then Chrome.cursor(1, ty) end
-      Chrome.print(entry.label, 2, ty)
+      Chrome.print(entry.builtin and Strings(entry.label) or entry.label, 2, ty)
     end
   end
 
@@ -691,8 +729,8 @@ function ItemPcMenu:drawPanel()
   elseif self.confirm then
     self:drawBottomLines(self.confirm.prompt)
     Chrome.box(14, 7, 6, 5)
-    Chrome.print("YES", 16, 8)
-    Chrome.print("NO", 16, 10)
+    Chrome.print(Strings("YES"), 16, 8)
+    Chrome.print(Strings("NO"), 16, 10)
     Chrome.cursor(15, self.confirm.choice == 1 and 8 or 10)
   elseif self.message then
     self:drawBottomLines(

--- a/src/ui/gen2/MailCompose.lua
+++ b/src/ui/gen2/MailCompose.lua
@@ -31,6 +31,7 @@ local Assets = require("src.render.Assets")
 local Chrome = require("src.ui.gen2.Chrome")
 local Font = require("src.render.Font")
 local Mail = require("src.core.gen2.Mail")
+local Strings = require("src.core.Strings")
 
 local MailCompose = {}
 MailCompose.__index = MailCompose
@@ -73,8 +74,12 @@ local MAIL_INPUT_LOWER = {
 -- labels land on columns 1, 8 and 14.  The cursor is a sprite on the cart
 -- (.CaseDelEnd's $00/$30/$60 x offsets); here it is the same ▶ the naming
 -- screen falls back to, one column left of each label.
-local BOTTOM_LABELS = { "lower", "DEL", "END" }
-local BOTTOM_UPPER_LABELS = { "UPPER", "DEL", "END" }
+local BOTTOM_LABELS = {
+  Strings.source("lower"), Strings.source("DEL"), Strings.source("END"),
+}
+local BOTTOM_UPPER_LABELS = {
+  Strings.source("UPPER"), Strings.source("DEL"), Strings.source("END"),
+}
 local BOTTOM_LABEL_TX = { 1, 8, 14 }
 local BOTTOM_CURSOR_TX = { 0, 7, 13 }
 
@@ -311,7 +316,7 @@ function MailCompose:drawPanel()
   local labels = self.lower and BOTTOM_UPPER_LABELS or BOTTOM_LABELS
   local bottomY = KEYBOARD_TOP + BOTTOM_ROW * 2
   for i, label in ipairs(labels) do
-    Chrome.print(label, BOTTOM_LABEL_TX[i], bottomY)
+    Chrome.print(Strings(label), BOTTOM_LABEL_TX[i], bottomY)
   end
 
   local cursorTx, cursorTy

--- a/src/ui/gen2/MailMenu.lua
+++ b/src/ui/gen2/MailMenu.lua
@@ -29,6 +29,7 @@ local Chrome = require("src.ui.gen2.Chrome")
 local CommonText = require("src.core.gen2.CommonText")
 local Mail = require("src.core.gen2.Mail")
 local Screens = require("src.ui.Screens")
+local Strings = require("src.core.Strings")
 
 local MailMenu = {}
 MailMenu.__index = MailMenu
@@ -51,9 +52,9 @@ local ARROW_X, ARROW_Y = 18, 17
 
 -- .MenuData's three rows, verbatim.
 local ENTRIES = {
-  { id = "read", label = "READ" },
-  { id = "take", label = "TAKE" },
-  { id = "quit", label = "QUIT" },
+  { id = "read", label = Strings.source("READ") },
+  { id = "take", label = Strings.source("TAKE") },
+  { id = "quit", label = Strings.source("QUIT") },
 }
 
 local function page(...) return { ... } end
@@ -275,8 +276,8 @@ end
 
 function MailMenu:drawYesNo(choice)
   Chrome.box(YESNO_X, YESNO_Y, YESNO_W, YESNO_H)
-  Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-  Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+  Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+  Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
   Chrome.cursor(YESNO_X + 1, YESNO_Y + (choice == 1 and 1 or 3))
 end
 
@@ -303,7 +304,7 @@ function MailMenu:drawPanel()
   for row, entry in ipairs(ENTRIES) do
     local ty = MENU_LABEL_Y + (row - 1) * 2
     if row == self.index then Chrome.cursor(MENU_LABEL_X - 1, ty) end
-    Chrome.print(entry.label, MENU_LABEL_X, ty)
+    Chrome.print(Strings(entry.label), MENU_LABEL_X, ty)
   end
   love.graphics.setColor(1, 1, 1, 1)
 end

--- a/src/ui/gen2/MailboxMenu.lua
+++ b/src/ui/gen2/MailboxMenu.lua
@@ -33,6 +33,7 @@ local Chrome = require("src.ui.gen2.Chrome")
 local CommonText = require("src.core.gen2.CommonText")
 local Mail = require("src.core.gen2.Mail")
 local Screens = require("src.ui.Screens")
+local Strings = require("src.core.Strings")
 
 local MailboxMenu = {}
 MailboxMenu.__index = MailboxMenu
@@ -54,10 +55,10 @@ local ARROW_X, ARROW_Y = 18, 17
 
 -- .SubMenuData, verbatim.
 local SUB_ENTRIES = {
-  { id = "read", label = "READ MAIL" },
-  { id = "pack", label = "PUT IN PACK" },
-  { id = "attach", label = "ATTACH MAIL" },
-  { id = "cancel", label = "CANCEL" },
+  { id = "read", label = Strings.source("READ MAIL") },
+  { id = "pack", label = Strings.source("PUT IN PACK") },
+  { id = "attach", label = Strings.source("ATTACH MAIL") },
+  { id = "cancel", label = Strings.source("CANCEL") },
 }
 
 local function page(...) return { ... } end
@@ -353,8 +354,8 @@ end
 
 function MailboxMenu:drawYesNo(choice)
   Chrome.box(YESNO_X, YESNO_Y, YESNO_W, YESNO_H)
-  Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-  Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+  Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+  Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
   Chrome.cursor(YESNO_X + 1, YESNO_Y + (choice == 1 and 1 or 3))
 end
 
@@ -380,7 +381,7 @@ function MailboxMenu:drawSubmenu()
   for row, entry in ipairs(SUB_ENTRIES) do
     local ty = SUB_LABEL_Y + (row - 1) * 2
     if row == self.submenu.index then Chrome.cursor(SUB_LABEL_X - 1, ty) end
-    Chrome.print(entry.label, SUB_LABEL_X, ty)
+    Chrome.print(Strings(entry.label), SUB_LABEL_X, ty)
   end
 end
 

--- a/src/ui/gen2/MainMenu.lua
+++ b/src/ui/gen2/MainMenu.lua
@@ -40,6 +40,7 @@ MainMenu.isOpaque = true
 -- InitClock.lua's DAYS), so this screen's clock box cannot drift from the
 -- Pokegear's own.
 local DAYS = Clock.DAY_NAMES
+local DAY_LABEL = Strings.source("DAY")
 
 -- MUSIC_MAIN_MENU; resolved by name so a cache without it just stays quiet.
 local MENU_MUSIC = "Music_MainMenu"
@@ -176,7 +177,7 @@ function MainMenu:drawClockBox()
   -- ../pokecrystal/engine/menus/main_menu.asm:286
   Chrome.textbox(0, 14, 18, 2)
   local hour, minute, weekday = self:clockParts()
-  Chrome.print(Clock.weekdayName(weekday) or "DAY", 1, 15)
+  Chrome.print(Clock.weekdayName(weekday) or Strings(DAY_LABEL), 1, 15)
   Chrome.print(MainMenu.timeString(hour, minute), 4, 16)
 end
 

--- a/src/ui/gen2/MapRadio.lua
+++ b/src/ui/gen2/MapRadio.lua
@@ -36,6 +36,8 @@ local STATIONS = {
   [8] = "ROCKET_RADIO",
 }
 
+local POKEGEAR_ONLY_STATIONS = { "POKE_FLUTE_RADIO", "EVOLUTION_RADIO" }
+
 -- The same eight as the `radio_channels` registry sees them (src/mods/
 -- Schemas.lua), one of the Gen 2-only six: Red has no radio, so the name is
 -- gated under Gen 1 and routed to data.gen2RadioChannels under Gen 2.  Id =
@@ -54,6 +56,13 @@ function MapRadio.registerInto(registry, _, owner)
                                  name = Pokegear.STATION_NAMES[station] }, owner)
     count = count + 1
   end
+  -- Two Pokegear-only signals have no MAPRADIO_* index.  They still belong in
+  -- the same registry because the tuner resolves their display names by id;
+  -- leaving `channel` absent keeps wall-radio lookup unambiguous.
+  for _, station in ipairs(POKEGEAR_ONLY_STATIONS) do
+    registry:register(station, { name = Pokegear.STATION_NAMES[station] }, owner)
+    count = count + 1
+  end
   return count
 end
 
@@ -68,6 +77,7 @@ function MapRadio.channelRecord(data, channel)
         return record, station
       end
     end
+    return nil
   end
   local station = STATIONS[channel]
   if not station then return nil end
@@ -150,11 +160,12 @@ function MapRadio:resolveStation(channel)
   return "OAKS_POKEMON_TALK"
 end
 
--- The name quoted in the text box: the registry record's own where it has one,
--- the Pokegear's STATION_NAMES row otherwise (which is where the vanilla eight
--- get theirs, so this is the same string the cart prints).
+-- The name quoted in the text box.  A loaded game resolves it through the
+-- same registry as the Pokegear; STATION_NAMES is only the loader-free fallback.
 function MapRadio:name()
-  return self.stationName or Pokegear.STATION_NAMES[self.station]
+  if self.stationName then return self.stationName end
+  return self.gear and self.gear:stationName(self.station)
+    or Pokegear.STATION_NAMES[self.station]
 end
 
 function MapRadio:close()

--- a/src/ui/gen2/MartMenu.lua
+++ b/src/ui/gen2/MartMenu.lua
@@ -68,6 +68,7 @@ local CommonText = require("src.core.gen2.CommonText")
 local Save = require("src.core.gen2.Save")
 local Screens = require("src.ui.Screens")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 local Typer = require("src.ui.gen2.Typer")
 
 -- PlayTransactionSound (engine/items/mart.asm): `call WaitSFX` then
@@ -528,7 +529,9 @@ function MartMenu:updateConfirm(input)
 end
 
 -- ---------------------------------------------------------------- top menu
-local TOP_ITEMS = { "BUY", "SELL", "QUIT" }
+local TOP_ITEMS = {
+  Strings.source("BUY"), Strings.source("SELL"), Strings.source("QUIT"),
+}
 
 -- .TopMenu copies MenuHeader_BuySell fresh every pass, and its `db 1 ; default
 -- option` means the cursor is back on BUY each time the loop returns here.
@@ -885,7 +888,7 @@ function MartMenu:drawTopMenu()
   for i, label in ipairs(TOP_ITEMS) do
     local ty = TOP_LABEL_Y + (i - 1) * TOP_SPACING
     if i == self.topIndex then Chrome.cursor(TOP_LABEL_X - 1, ty) end
-    Chrome.print(label, TOP_LABEL_X, ty)
+    Chrome.print(Strings(label), TOP_LABEL_X, ty)
   end
 end
 
@@ -931,7 +934,7 @@ function MartMenu:drawBuyList()
       printPriceOpaque(entry.price, ty + 1)
     elseif i == self:total() then
       if i == self.index then Chrome.cursor(LIST_X - 1, ty) end
-      Chrome.print("CANCEL", LIST_X, ty)
+      Chrome.print(Strings("CANCEL"), LIST_X, ty)
     end
   end
   -- SCROLLINGMENU_DISPLAY_ARROWS: the ▲ only appears once the list has been
@@ -968,8 +971,8 @@ end
 
 function MartMenu:drawYesNo(choice)
   Chrome.box(YESNO_X, YESNO_Y, YESNO_W, YESNO_H)
-  Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-  Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+  Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+  Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
   Chrome.cursor(YESNO_X + 1, YESNO_Y + (choice == 1 and 1 or 3))
 end
 

--- a/src/ui/gen2/MoveDeleter.lua
+++ b/src/ui/gen2/MoveDeleter.lua
@@ -16,6 +16,7 @@
 local Chrome = require("src.ui.gen2.Chrome")
 local ForgetMoveList = require("src.ui.gen2.ForgetMoveList")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 
 local MoveDeleter = {}
 MoveDeleter.__index = MoveDeleter
@@ -111,7 +112,7 @@ function MoveDeleter:draw()
     local entry = self.list[slot]
     if entry then
       Chrome.print(self:moveName(entry), 2, nameY)
-      Chrome.print("PP", 10, ppY)
+      Chrome.print(Strings("PP"), 10, ppY)
       Chrome.print(Chrome.number(entry.pp, 2, true), 13, ppY)
       Chrome.print("/", 15, ppY)
       Chrome.print(Chrome.number(entry.maxPp or entry.pp, 2, true), 16, ppY)

--- a/src/ui/gen2/NamePick.lua
+++ b/src/ui/gen2/NamePick.lua
@@ -29,6 +29,7 @@ local Chrome = require("src.ui.gen2.Chrome")
 local Font = require("src.render.Font")
 local GbcPalette = require("src.render.GbcPalette")
 local Screens = require("src.ui.Screens")
+local Strings = require("src.core.Strings")
 
 local NamePick = {}
 NamePick.__index = NamePick
@@ -60,7 +61,8 @@ local BOX_X1, BOX_Y1, BOX_X2, BOX_Y2 = 0, 0, 10, 11
 -- GetMenuTextStartCoord's answer for this header's flags.
 local TEXT_X, TEXT_Y = 2, 2
 local CURSOR_X = TEXT_X - 1
-local TITLE, TITLE_X, TITLE_Y = "NAME", 2, 0
+local TITLE, TITLE_X, TITLE_Y = Strings.source("NAME"), 2, 0
+local NEW_NAME = Strings.source("NEW NAME")
 
 -- Intro_PrepTrainerPic puts the 7x7 pic at hlcoord 6,4; MovePlayerPic walks
 -- it to 13,4 one tile per frame.
@@ -79,7 +81,7 @@ function NamePick.new(game, opts)
   self.onDone = opts.onDone
   self.gender = opts.gender
     or (game and game.save and game.save.player and game.save.player.gender)
-  self.items = { "NEW NAME" }
+  self.items = { NEW_NAME }
   for _, name in ipairs(opts.presets or presetsFor(self.gender)) do
     self.items[#self.items + 1] = name
   end
@@ -212,7 +214,8 @@ function NamePick:drawPanel()
     G.setColor(0, 0, 0, 1)
     for index, label in ipairs(self.items) do
       local prefix = (index == self.cursor) and "> " or "  "
-      G.print(prefix .. label, TEXT_X * 8, (TEXT_Y + (index - 1) * 2) * 8)
+      G.print(prefix .. (index == 1 and Strings(label) or label), TEXT_X * 8,
+        (TEXT_Y + (index - 1) * 2) * 8)
     end
     G.setColor(1, 1, 1, 1)
     return
@@ -224,10 +227,12 @@ function NamePick:drawPanel()
   -- on the box's top border -- so the border tiles under it have to go, or
   -- the letters sit on a line the cart does not draw there.
   G.setColor(1, 1, 1, 1)
-  G.rectangle("fill", TITLE_X * 8, TITLE_Y * 8, #TITLE * 8, 8)
-  Chrome.print(TITLE, TITLE_X, TITLE_Y)
+  local title = Strings(TITLE)
+  G.rectangle("fill", TITLE_X * 8, TITLE_Y * 8, #Font.split(title) * 8, 8)
+  Chrome.print(title, TITLE_X, TITLE_Y)
   for index, label in ipairs(self.items) do
-    Chrome.print(label, TEXT_X, TEXT_Y + (index - 1) * 2)
+    Chrome.print(index == 1 and Strings(label) or label,
+      TEXT_X, TEXT_Y + (index - 1) * 2)
   end
   Chrome.cursor(CURSOR_X, TEXT_Y + (self.cursor - 1) * 2)
   G.setColor(1, 1, 1, 1)

--- a/src/ui/gen2/OptionsMenu.lua
+++ b/src/ui/gen2/OptionsMenu.lua
@@ -32,11 +32,40 @@ OptionsMenu.__index = OptionsMenu
 OptionsMenu.isOpaque = true
 
 -- Music.setFilterLevel's ladder.
-local FILTERS = { "OFF", "1X", "2X", "3X" }
+local FILTERS = {
+  Strings.source("OFF"), Strings.source("1X"), Strings.source("2X"),
+  Strings.source("3X"),
+}
+
+-- Values returned by shared helper modules are dynamic at this callsite, so
+-- declare their finite labels explicitly for tools/modkit.py's catalog
+-- harvester.  Player palette names and shader filenames are deliberately not
+-- in this list: those are user content and stay verbatim.
+local FINITE_VALUE_SOURCES = {
+  Strings.source("AUTO"), Strings.source("HIGH"),
+  Strings.source("BALANCED"), Strings.source("LOW"),
+  Strings.source("NORMAL"), Strings.source("FIT"),
+  Strings.source("OUT%d"), Strings.source("IN%d"),
+  Strings.source("WATER"), Strings.source("TREES"), Strings.source("FADE "),
+  Strings.source("GEN 2"), Strings.source("DMG"), Strings.source("CLASSIC"),
+  Strings.source("GREEN"), Strings.source("LIME"), Strings.source("OLIVE"),
+  Strings.source("AMBER"), Strings.source("ORANGE"), Strings.source("RED"),
+  Strings.source("ROSE"), Strings.source("MAGENTA"),
+  Strings.source("PURPLE"), Strings.source("INDIGO"), Strings.source("BLUE"),
+  Strings.source("CYAN"), Strings.source("TEAL"), Strings.source("MINT"),
+  Strings.source("SAND"), Strings.source("BROWN"), Strings.source("SILVER"),
+  Strings.source("MONO"),
+  Strings.source("PALETTE"), Strings.source("FULL"),
+  Strings.source("WINDOWED"), Strings.source("CENTER"),
+  Strings.source("UPPER"), Strings.source("TOP"), Strings.source("SKIN"),
+  Strings.source("LIGHT"), Strings.source("STRONG"),
+  Strings.source("ADAPTIVE"), Strings.source("UNAVAILABLE"),
+  Strings.source("DISPLAY"), Strings.source("DISPLAY (%dHZ)"),
+}
 
 local function volLabel(v)
   v = v or 7
-  return v == 0 and "OFF" or tostring(v)
+  return v == 0 and Strings("OFF") or tostring(v)
 end
 
 local function stepVolume(v, delta)
@@ -170,7 +199,7 @@ local ROWS = {
       require("src.core.Music").setFilterLevel(options.musicFilter)
     end,
     text = function(options)
-      return FILTERS[(options.musicFilter or 0) + 1]
+      return Strings(FILTERS[(options.musicFilter or 0) + 1])
     end },
   -- Heads the port's display group, same spot src/ui/OptionsMenu.lua's own
   -- PERFORMANCE row occupies relative to ZOOM/VOID FILL/TILT/SHADER FX below
@@ -180,7 +209,7 @@ local ROWS = {
   -- `row.value` -- both written for exactly this kind of shared mod row.
   { id = "performance", label = Strings.source("PERFORMANCE"), port = true,
     value = function(g)
-      return Performance.label(g.options and g.options.performance)
+      return Strings(Performance.label(g.options and g.options.performance))
     end,
     step = function(g, dir)
       local o = g.options
@@ -194,7 +223,9 @@ local ROWS = {
       options.speed = GameSpeed.cycle(options.speed, delta)
     end,
     text = function(options)
-      return require("src.core.GameSpeed").levelLabel(options.speed)
+      local speed = tonumber(options.speed) or 1
+      if speed == 1 then return Strings("NORMAL") end
+      return Strings("%dX", speed)
     end },
   { label = Strings.source("ZOOM"), key = "zoom", port = true,
     cycle = function(options, delta, game)
@@ -206,7 +237,10 @@ local ROWS = {
       Zoom.nudgeOptions(options, delta, scale)
     end,
     text = function(options)
-      return require("src.render.Zoom").offsetLabel(options.zoom or 0)
+      local offset = math.floor(tonumber(options.zoom) or 0)
+      if offset == 0 then return Strings("FIT") end
+      return offset < 0 and Strings("OUT%d", -offset)
+        or Strings("IN%d", offset)
     end },
   -- VOID FILL: FADE is each map's own border block with the dissolve across
   -- a boundary; WATER / TREES force one outdoor block; BLACK is a flat void.
@@ -219,7 +253,7 @@ local ROWS = {
       options.voidFill = BorderFill.cycle(delta)
     end,
     text = function(options)
-      return require("src.world.gen2.BorderFill").voidFillLabel(options.voidFill)
+      return Strings(require("src.world.gen2.BorderFill").voidFillLabel(options.voidFill))
     end },
   { label = Strings.source("TILT"), key = "tilt", port = true,
     cycle = function(options, delta)
@@ -230,13 +264,19 @@ local ROWS = {
       Tilt.setLevel(level)
     end,
     text = function(options)
-      return require("src.render.Tilt").levelLabel(options.tilt or 0)
+      return Strings(require("src.render.Tilt").levelLabel(options.tilt or 0))
     end },
   { label = Strings.source("COLOR"), key = "color", port = true,
     text = function(options)
-      local name = Palette.label(options.palette)
-      if name then return name end
-      return require("src.render.GbcPalette").modeLabel(options.color or "gbc")
+      local palette = options.palette
+      local name = Palette.label(palette)
+      if name then
+        -- m: is the engine's finite monochrome ladder; p: is a named user
+        -- palette pack and its filename is user content.
+        return type(palette) == "string" and palette:sub(1, 2) == "m:"
+          and Strings(name) or name
+      end
+      return Strings(require("src.render.GbcPalette").modeLabel(options.color or "gbc"))
     end,
     activate = function(game)
       require("src.ui.Screens").push(game, "PaletteScreen", colorPickerOpts(game))
@@ -260,7 +300,7 @@ local ROWS = {
     text = function(options)
       local ShaderFX = require("src.render.ShaderFX")
       local entry = ShaderFX.activeEntry("main")
-      if not entry then return "OFF" end
+      if not entry then return Strings("OFF") end
       return (entry.name:gsub("%.slangp$", "")):upper()
     end,
     activate = function(game)
@@ -273,7 +313,7 @@ local ROWS = {
     text = function(options)
       local ShaderFX = require("src.render.ShaderFX")
       local entry = ShaderFX.activeEntry("secondary")
-      if not entry then return "OFF" end
+      if not entry then return Strings("OFF") end
       return (entry.name:gsub("%.slangp$", "")):upper()
     end,
     activate = function(game)
@@ -288,7 +328,7 @@ local ROWS = {
     text = function(options)
       local VideoMode = require("src.core.VideoMode")
       return VideoMode.normalize(options.videoMode) == "borderless"
-        and "FULL" or "WINDOWED"
+        and Strings("FULL") or Strings("WINDOWED")
     end },
   { label = Strings.source("SCREEN POS"), key = "screenPos", port = true,
     cycle = function(options, delta)
@@ -343,7 +383,14 @@ local ROWS = {
       FrameCap.apply(options.fpsCap)
     end,
     text = function(options)
-      return require("src.core.FrameCap").label(options.fpsCap)
+      local FrameCap = require("src.core.FrameCap")
+      local value = FrameCap.normalize(options.fpsCap)
+      if value == FrameCap.DISPLAY then
+        local label = FrameCap.label(value)
+        local hz = tonumber(label:match("^DISPLAY %((%d+)HZ%)$"))
+        return hz and Strings("DISPLAY (%dHZ)", hz) or Strings("DISPLAY")
+      end
+      return FrameCap.label(value)
     end },
   { label = Strings.source("VSYNC"), key = "vsync", port = true,
     cycle = function(options, delta)
@@ -365,11 +412,16 @@ local ROWS = {
     end },
   { label = Strings.source("BATTLE SIZE"), key = "battleFit", port = true,
     values = { "fixed", "fill" },
-    display = { fixed = "FIXED", fill = "FILL " } },
+    display = {
+      fixed = Strings.source("FIXED"), fill = Strings.source("FILL "),
+    } },
   -- BATTLE BG (#1709): the void around the battle screen.
   { label = Strings.source("BATTLE BG"), key = "battleBg", port = true,
     values = { "white", "black", "world" },
-    display = { white = "WHITE", black = "BLACK", world = "WORLD" } },
+    display = {
+      white = Strings.source("WHITE"), black = Strings.source("BLACK"),
+      world = Strings.source("WORLD"),
+    } },
   { label = Strings.source("BACK"), cancel = true },
 }
 

--- a/src/ui/gen2/PackMenu.lua
+++ b/src/ui/gen2/PackMenu.lua
@@ -12,6 +12,7 @@
 
 local Bag = require("src.inventory.Bag")
 local Chrome = require("src.ui.gen2.Chrome")
+local CommonText = require("src.core.gen2.CommonText")
 local GameVersion = require("src.core.GameVersion")
 local Gen2Save = require("src.core.gen2.Save")
 local PackGfx = require("src.ui.gen2.PackGfx")
@@ -40,10 +41,10 @@ local LIST_SPACING = 2
 -- Display order and titles.  The cart shows the pocket name in a tab strip
 -- across the top; these are the strings it uses.
 local POCKETS = {
-  { id = "ITEM", label = "ITEMS" },
-  { id = "BALL", label = "POKé BALLS" },
-  { id = "KEY_ITEM", label = "KEY ITEMS" },
-  { id = "TM_HM", label = "TM/HM" },
+  { id = "ITEM", label = Strings.source("ITEMS") },
+  { id = "BALL", label = Strings.source("POKé BALLS") },
+  { id = "KEY_ITEM", label = Strings.source("KEY ITEMS") },
+  { id = "TM_HM", label = Strings.source("TM/HM") },
 }
 
 -- Five item rows fit under the tab strip, two lines each.
@@ -70,20 +71,22 @@ local VISIBLE_ROWS = 5
 -- Without this menu a TOSS is unreachable and the PACK is a one-verb screen,
 -- which is what "the pack only offers USE" is.
 local SUBMENU_LABEL = {
-  use = "USE", give = "GIVE", toss = "TOSS", sel = "SEL", quit = "QUIT",
+  use = Strings.source("USE"), give = Strings.source("GIVE"),
+  toss = Strings.source("TOSS"), sel = Strings.source("SEL"),
+  quit = Strings.source("QUIT"),
 }
 
 -- _AskThrowAwayText / _AskQuantityThrowAwayText / _ThrewAwayText
 -- (data/text/common_2.asm), the three lines TossMenu prints in order.
-local TOSS_HOW_MANY = { "Throw away how", "many?" }
+local TOSS_HOW_MANY = Strings.source("Throw away how\nmany?")
 
 -- _AskItemMoveText (data/text/common_2.asm:322), printed while wSwitchItem
 -- holds a row and the cursor is looking for its new home.
-local ASK_ITEM_MOVE = { "Where should this", "be moved to?" }
+local ASK_ITEM_MOVE = Strings.source("Where should this\nbe moved to?")
 
 -- _YouDontHaveAMonText and .AnEggCantHoldAnItemText, GiveItem's two refusals.
-local NO_POKEMON = { "You don't have a", "#MON!" }
-local EGG_CANT_HOLD = { "An EGG can't hold", "an item." }
+local NO_POKEMON = Strings.source("You don't have a\n#MON!")
+local EGG_CANT_HOLD = Strings.source("An EGG can't hold\nan item.")
 
 -- _CGB_PackPals' .KrisPackPals arm, and the BATTLETYPE_TUTORIAL test above it
 -- that forces the DUDE's (../pokecrystal/engine/gfx/cgb_layouts.asm:770-786).
@@ -122,8 +125,24 @@ end
 -- home/text.asm:424
 local PAGE, SCROLL, LINE = "\f", "\v", "\n"
 
+local function messageTokens(text)
+  if type(text) ~= "string" then return text end
+  local out, start = {}, 1
+  while start <= #text + 1 do
+    local marker = text:find("[\n\f\v]", start)
+    out[#out + 1] = text:sub(start, (marker or (#text + 1)) - 1)
+    if not marker then break end
+    local code = text:sub(marker, marker)
+    if code == PAGE then out[#out + 1] = PAGE
+    elseif code == SCROLL then out[#out + 1] = SCROLL end
+    start = marker + 1
+  end
+  return out
+end
+
 -- home/text.asm:397
 local function messagePages(lines)
+  if type(lines) == "string" then return CommonText.pages(lines) or {} end
   local pages, rows = {}, {}
   local function flush(scroll)
     if #rows > 0 then pages[#pages + 1] = rows end
@@ -139,24 +158,16 @@ local function messagePages(lines)
 end
 
 -- data/text/common_2.asm:627
-local OAK_THIS_ISNT_THE_TIME = {
-  "OAK: {PLAYER}!",
-  "This isn't the",
-  SCROLL,
-  "time to use that!",
-}
+local OAK_THIS_ISNT_THE_TIME = Strings.source(
+  "OAK: {PLAYER}!\nThis isn't the\vtime to use that!")
 
 -- RepelUsedEarlierIsStillInEffectText (data/text/common_3.asm): static, and
 -- names REPEL no matter which of the three repel items is the one actually
 -- still ticking down -- the cart never reads the active item back out to
 -- print it.
 -- ../pokecrystal/data/text/common_3.asm:1270 -- `cont` again, so two pages.
-local REPEL_STILL_ACTIVE = {
-  "The REPEL used",
-  "earlier is still",
-  SCROLL,
-  "in effect.",
-}
+local REPEL_STILL_ACTIVE = Strings.source(
+  "The REPEL used\nearlier is still\vin effect.")
 
 function PackMenu:wantsFillScale() return true end
 function PackMenu:drawsWidescreen() return true end
@@ -352,6 +363,7 @@ function PackMenu:tickRepeatSfx()
 end
 
 function PackMenu:showMessage(lines)
+  lines = messageTokens(lines)
   self.message, self.messagePage = lines, 1
   self.pagesSource, self.pages = lines, messagePages(lines)
 end
@@ -444,7 +456,7 @@ function PackMenu:useSelected()
   if self:inBattle() then
     local def = self.items and self.items[row.id]
     if def and def.battleMenu == "ITEMMENU_NOUSE" then
-      self:showMessage(OAK_THIS_ISNT_THE_TIME)
+      self:showMessage(Strings(OAK_THIS_ISNT_THE_TIME))
       return
     end
     if self.onChoose then
@@ -458,29 +470,30 @@ function PackMenu:useSelected()
   if world and world.useFieldItem then result, extra = world:useFieldItem(row.id) end
   if result then
     if result == "nowhere" then
-      self:showMessage(OAK_THIS_ISNT_THE_TIME)
+      self:showMessage(Strings(OAK_THIS_ISNT_THE_TIME))
     elseif result == "coin_case" then
       -- _CoinCaseCountText (data/text/common_3.asm:336): "Coins:" then the
       -- count, text_decimal 4 digits with PRINTNUM_LEFTALIGN_F so no padding.
-      self:showMessage({ "Coins:", tostring(extra or 0) })
+      self:showMessage(Strings(Strings.source("Coins:\n%d"), extra or 0))
     elseif result == "blue_card" then
       -- _BlueCardBalanceText (../pokecrystal/data/text/common_3.asm:1297).
-      self:showMessage({ "You now have", tostring(extra or 0) .. " points." })
+      self:showMessage(Strings(Strings.source("You now have\n%d points."),
+        extra or 0))
     elseif result == "repel_used" then
       -- ItemUsedText (data/text/common_3.asm): "<PLAYER> used the\n<ITEM>."
       -- World already wrote the counter and took the item out of the bag, so
       -- the row list is rebuilt under the message the way a TOSS would.
-      self:showMessage({ Strings("{PLAYER} used the"), row.name .. "." })
+      self:showMessage(Strings(Strings.source("{PLAYER} used the\n%s."), row.name))
       self:rebuild()
     elseif result == "repel_active" then
-      self:showMessage(REPEL_STILL_ACTIVE)
+      self:showMessage(Strings(REPEL_STILL_ACTIVE))
     elseif result == "trophy_sent" then
       -- ../pokecrystal/data/text/common_3.asm:1338
       if world.playSfxNamed then
         world:playSfxNamed("Sfx_DexFanfare5079", SFX_DEX_FANFARE_50_79)
       end
-      self:showMessage({ "There was a trophy", "inside!", PAGE,
-                         "{PLAYER} sent the", "trophy home." })
+      self:showMessage(Strings(Strings.source(
+        "There was a trophy\ninside!\f{PLAYER} sent the\ntrophy home.")))
       self:rebuild()
     else
       self:exitToField()
@@ -505,7 +518,7 @@ function PackMenu:useSelected()
       return
     end
     if def and def.fieldMenu == "ITEMMENU_NOUSE" then
-      self:showMessage(OAK_THIS_ISNT_THE_TIME)
+      self:showMessage(Strings(OAK_THIS_ISNT_THE_TIME))
       return
     end
   end
@@ -645,7 +658,7 @@ end
 -- -- the item is untouched and the PACK is exactly where it was.
 function PackMenu:tossItem(row)
   if not row then return end
-  self:showMessage(TOSS_HOW_MANY)
+  self:showMessage(Strings(TOSS_HOW_MANY))
   self.qtyState = {
     row = row,
     qty = 1,
@@ -659,13 +672,14 @@ function PackMenu:confirmToss()
   self.qtyState = nil
   local row, qty = state.row, state.qty
   self.confirm = {
-    prompt = { ("Throw away %d"):format(qty), row.name .. "(S)?" },
+    prompt = messageTokens(Strings(Strings.source(
+      "Throw away %d\n%s(S)?"), qty, row.name)),
     -- YesNoBox opens on YES; B and NO are the same `jr c, .finish`.
     choice = 1,
     onYes = function()
       Bag.remove(self.save, row.id, qty)
       self:rebuild()
-      self:showMessage({ "Threw away", row.name .. "(S)." })
+      self:showMessage(Strings(Strings.source("Threw away\n%s(S)."), row.name))
     end,
   }
 end
@@ -682,7 +696,7 @@ function PackMenu:giveItem(row)
   local game = self.game
   local party = (self.save and self.save.party) or {}
   if #party == 0 then
-    self:showMessage(NO_POKEMON)
+    self:showMessage(Strings(NO_POKEMON))
     return
   end
   if not (game and game.stack) then return end
@@ -721,7 +735,8 @@ function PackMenu:giveToSlot(slot, row)
   if mon.isEgg then
     -- `cp EGG / jr nz, .give`: the refusal prints over the party list, which
     -- stays up (`jr .loop`) for another pick.
-    held:say({ EGG_CANT_HOLD }, function() game.stack:pop() end)
+    held:say(CommonText.pages(Strings(EGG_CANT_HOLD)),
+      function() game.stack:pop() end)
     return
   end
   held:giveItem(row.id)
@@ -732,7 +747,7 @@ function PackMenu:openTeachParty(row)
   local game = self.game
   local party = (self.save and self.save.party) or {}
   if #party == 0 then
-    self:showMessage(NO_POKEMON)
+    self:showMessage(Strings(NO_POKEMON))
     return
   end
   if not (game and game.stack) then return end
@@ -766,7 +781,7 @@ function PackMenu:openTeachParty(row)
           world:playSfxNamed("Sfx_Wrong", SFX_WRONG)
         end
         if game.say then
-          game:say(("%s can't learn %s!"):format(
+          game:say(Strings(Strings.source("%s can't learn %s!"),
             require("src.battle.gen2.Mon").displayName(mon), moveName))
         end
         return
@@ -774,7 +789,7 @@ function PackMenu:openTeachParty(row)
       for _, move in ipairs(mon.moves or {}) do
         if move.id == moveId then
           if game.say then
-            game:say(("%s already knows %s!"):format(
+            game:say(Strings(Strings.source("%s already knows %s!"),
               require("src.battle.gen2.Mon").displayName(mon), moveName))
           end
           return
@@ -893,7 +908,7 @@ function PackMenu:armSwitch()
   if self:isCancel() then return end
   if not self.rows[self.index] then return end
   self.switching = self.index
-  self:showMessage(ASK_ITEM_MOVE)
+  self:showMessage(Strings(ASK_ITEM_MOVE))
 end
 
 -- `.switching_item` (engine/items/pack.asm:1297): A or SELECT places, B backs
@@ -1009,10 +1024,10 @@ function PackMenu:registerSelected()
     -- engine/items/pack.asm:551
     self:playSfx("Sfx_FullHeal")
     -- RegisteredItemText: "Registered the\n<item>."
-    self:showMessage({ Strings("Registered the"), row.name .. "." })
+    self:showMessage(Strings(Strings.source("Registered the\n%s."), row.name))
   else
     -- CantRegisterText: "You can't register\nthat item."
-    self:showMessage({ Strings("You can't register"), Strings("that item.") })
+    self:showMessage(Strings(Strings.source("You can't register\nthat item.")))
   end
 end
 
@@ -1093,7 +1108,7 @@ function PackMenu:drawList(listX, listY)
       end
     elseif i == self:total() then
       if i == self.index then self:cursorAt(listX - 1, ty, picked) end
-      Chrome.printThrough("CANCEL", listX, ty, Chrome.DEFAULT_BOX_PALETTE)
+      Chrome.printThrough(Strings("CANCEL"), listX, ty, Chrome.DEFAULT_BOX_PALETTE)
     end
   end
 end
@@ -1145,7 +1160,8 @@ function PackMenu:drawSubmenu()
   for i, id in ipairs(menu.rows) do
     local ty = top + 1 + (i - 1) * 2
     if i == menu.index then Chrome.cursorThrough(x + 1, ty, Chrome.DEFAULT_BOX_PALETTE) end
-    Chrome.printThrough(SUBMENU_LABEL[id] or id, x + 2, ty, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings(SUBMENU_LABEL[id] or id), x + 2, ty,
+      Chrome.DEFAULT_BOX_PALETTE)
   end
 end
 
@@ -1159,8 +1175,8 @@ end
 -- YesNoBox's own coords, the same box every other Gen 2 screen here draws.
 function PackMenu:drawYesNo()
   Chrome.box(14, 7, 6, 5)
-  Chrome.printThrough("YES", 16, 8, Chrome.DEFAULT_BOX_PALETTE)
-  Chrome.printThrough("NO", 16, 10, Chrome.DEFAULT_BOX_PALETTE)
+  Chrome.printThrough(Strings("YES"), 16, 8, Chrome.DEFAULT_BOX_PALETTE)
+  Chrome.printThrough(Strings("NO"), 16, 10, Chrome.DEFAULT_BOX_PALETTE)
   Chrome.cursorThrough(15, self.confirm.choice == 1 and 8 or 10, Chrome.DEFAULT_BOX_PALETTE)
 end
 
@@ -1188,7 +1204,8 @@ function PackMenu:drawPanel()
   -- boxes, the layout this screen shipped with.
   Chrome.clear()
   Chrome.box(0, 0, 20, 3)
-  Chrome.printThrough(self:pocket().label, 2, 1, Chrome.DEFAULT_BOX_PALETTE)
+  Chrome.printThrough(Strings(self:pocket().label), 2, 1,
+    Chrome.DEFAULT_BOX_PALETTE)
   Chrome.box(0, 3, 20, 12)
   self:drawList(5, 4)
   Chrome.box(0, 12, 20, 6)

--- a/src/ui/gen2/PartyMenu.lua
+++ b/src/ui/gen2/PartyMenu.lua
@@ -28,6 +28,7 @@ local Mon = require("src.battle.gen2.Mon")
 local Runtime = require("src.mods.Runtime")
 local Screens = require("src.ui.Screens")
 local Sound = require("src.core.Sound")
+local Status = require("src.battle.Status")
 local Strings = require("src.core.Strings")
 
 local PartyMenu = {}
@@ -39,14 +40,19 @@ PartyMenu.isOpaque = true
 -- is both faithful and two tiles narrower than spelling POKéMON out -- which
 -- is what keeps "Use on which <PK><MN>?" inside its 18-column text box.
 PartyMenu.PROMPTS = {
-  choose = "Choose a POKéMON.",
-  useItem = "Use on which <PK><MN>?",
-  which = "Which <PK><MN>?",
-  teach = "Teach which <PK><MN>?",
-  moveTo = "Move to where?",
-  toWhich = "To which <PK><MN>?",
-  none = "You have no <PK><MN>!",
+  choose = Strings.source("Choose a POKéMON."),
+  useItem = Strings.source("Use on which <PK><MN>?"),
+  which = Strings.source("Which <PK><MN>?"),
+  teach = Strings.source("Teach which <PK><MN>?"),
+  moveTo = Strings.source("Move to where?"),
+  toWhich = Strings.source("To which <PK><MN>?"),
+  none = Strings.source("You have no <PK><MN>!"),
 }
+
+local FAINTED_LABEL = Strings.source("FNT")
+local EGG_LABEL = Strings.source("EGG")
+local ABLE_LABEL = Strings.source("ABLE")
+local NOT_ABLE_LABEL = Strings.source("NOT ABLE")
 
 -- The icon's two frames swap every 16 logic steps, close to the cart's
 -- SPRITE_ANIM cadence.
@@ -68,6 +74,22 @@ PartyMenu.FIELD_MOVES = {
 -- STATS, SWITCH, MOVE and then ITEM (or MAIL, when the held item is mail),
 -- and only appends CANCEL while the list is still under NUM_MONMENU_ITEMS.
 local NUM_MONMENU_ITEMS = 8
+
+-- MonMenuOptionStrings are engine-owned labels.  Translate them while the
+-- built-in rows are assembled so hook-injected rows keep their authored text;
+-- the stable id remains the value every action branch consumes.
+local ACTION_LABELS = {
+  STATS = Strings.source("STATS"),
+  SWITCH = Strings.source("SWITCH"),
+  MOVE = Strings.source("MOVE"),
+  ITEM = Strings.source("ITEM"),
+  MAIL = Strings.source("MAIL"),
+  CANCEL = Strings.source("CANCEL"),
+}
+
+local function actionLabel(id)
+  return Strings(ACTION_LABELS[id] or id)
+end
 
 -- MonSubmenu's .MenuHeader is `menu_coords 6, 0, SCREEN_WIDTH - 1,
 -- SCREEN_HEIGHT - 1`, and .GetTopCoord then pulls the top edge up to
@@ -122,12 +144,15 @@ function PartyMenu.new(game, opts)
   self.icons = opts.icons or data.gen2Icons
   self.palettes = opts.palettes or data.gen2Palettes
   self.pokemon = opts.pokemon or data.pokemon
-  self.prompt = PartyMenu.PROMPTS[opts.prompt or "choose"] or opts.prompt
+  local promptKey = opts.prompt or "choose"
+  self.promptIsBuiltin = PartyMenu.PROMPTS[promptKey] ~= nil
+  self.prompt = PartyMenu.PROMPTS[promptKey] or opts.prompt
     or PartyMenu.PROMPTS.choose
   -- engine/pokemon/party_menu.asm:297
   self.tmhm = opts.tmhm
   if self.tmhm and (opts.prompt == nil or opts.prompt == "teach") then
     self.prompt = PartyMenu.PROMPTS.teach
+    self.promptIsBuiltin = true
   end
   self.onChoose = opts.onChoose
   self.onCancel = opts.onCancel
@@ -203,9 +228,9 @@ local function buildSubmenuItems(self, mon)
   -- test is `cp EGG`).
   if mon and mon.isEgg then
     return {
-      { id = "STATS", label = "STATS" },
-      { id = "SWITCH", label = "SWITCH" },
-      { id = "CANCEL", label = "CANCEL" },
+      { id = "STATS", label = actionLabel("STATS") },
+      { id = "SWITCH", label = actionLabel("SWITCH") },
+      { id = "CANCEL", label = actionLabel("CANCEL") },
     }
   end
   local items = {}
@@ -221,17 +246,18 @@ local function buildSubmenuItems(self, mon)
       }
     end
   end
-  items[#items + 1] = { id = "STATS", label = "STATS" }
-  items[#items + 1] = { id = "SWITCH", label = "SWITCH" }
-  items[#items + 1] = { id = "MOVE", label = "MOVE" }
+  items[#items + 1] = { id = "STATS", label = actionLabel("STATS") }
+  items[#items + 1] = { id = "SWITCH", label = actionLabel("SWITCH") }
+  items[#items + 1] = { id = "MOVE", label = actionLabel("MOVE") }
   -- ItemIsMail, not a pocket test: mail lives in the ordinary ITEM pocket
   -- (ItemAttributes gives FLOWER_MAIL pocketId 1), so the only thing that
   -- says "this is mail" is data/items/mail_items.asm's own list.
   local isMail = Mail.monHoldsMail(mon)
-  items[#items + 1] = isMail and { id = "MAIL", label = "MAIL" }
-    or { id = "ITEM", label = "ITEM" }
+  items[#items + 1] = isMail
+    and { id = "MAIL", label = actionLabel("MAIL") }
+    or { id = "ITEM", label = actionLabel("ITEM") }
   if #items < NUM_MONMENU_ITEMS then
-    items[#items + 1] = { id = "CANCEL", label = "CANCEL" }
+    items[#items + 1] = { id = "CANCEL", label = actionLabel("CANCEL") }
   end
   return items
 end
@@ -240,9 +266,9 @@ end
 -- (engine/pokemon/mon_submenu.asm:286-292).
 local function buildBattleSubmenuItems()
   return {
-    { id = "SWITCH", label = "SWITCH" },
-    { id = "STATS", label = "STATS" },
-    { id = "CANCEL", label = "CANCEL" },
+    { id = "SWITCH", label = actionLabel("SWITCH") },
+    { id = "STATS", label = actionLabel("STATS") },
+    { id = "CANCEL", label = actionLabel("CANCEL") },
   }
 end
 
@@ -878,13 +904,22 @@ end
 
 -- PlaceStatusString (engine/pokemon/mon_stats.asm): three letters, and a mon
 -- with no HP reads FNT whatever its status byte says.
-local function statusString(mon, hp)
+local function statusString(mon, hp, statuses)
   if hp == nil then hp = mon.hp end
-  if (hp or 0) <= 0 then return "FNT" end
+  if (hp or 0) <= 0 then return Strings(FAINTED_LABEL) end
   local status = mon.status
   if not status then return nil end
-  local class = ItemEffects.STATUS_CLASS[tostring(status):lower()]
-  return class and class:upper()
+  local key = tostring(status):lower()
+  if statuses and statuses[key] then
+    return Strings(Status.hudLabelFor(statuses, key))
+  end
+  local class = ItemEffects.STATUS_CLASS[key]
+  if not class then return nil end
+  if not statuses then return class:upper() end
+  -- Gen 2's registry is keyed by effect ids (poison/burn/freeze/...), while
+  -- save and field code may still carry their three-letter spellings.
+  local id = Status.GEN2_ID_ALIASES[key] or key
+  return Strings(Status.hudLabelFor(statuses, id))
 end
 
 -- One list row's strings, exactly what WritePartyMenuTilemap's quality
@@ -893,14 +928,14 @@ end
 -- name and an icon alone: no HP digits, no bar, no level, no FNT.  The name
 -- itself is String_Egg -- GiveEgg writes "EGG" over the nickname slot -- so
 -- it never reads as the species hiding inside.
-function PartyMenu.rowFor(mon, hp)
-  if mon.isEgg then return { name = "EGG" } end
+function PartyMenu.rowFor(mon, hp, statuses)
+  if mon.isEgg then return { name = Strings(EGG_LABEL) } end
   local maxHp = mon.maxHp or (mon.stats and mon.stats.hp) or 0
   if hp == nil then hp = mon.hp end
   return {
     name = mon.nickname or mon.name or mon.species or "?",
     hp = num3(hp) .. "/" .. num3(maxHp),
-    status = statusString(mon, hp),
+    status = statusString(mon, hp, statuses),
     -- <LV> is one font glyph ($6e), not the two characters ":L".
     level = "<LV>" .. tostring(mon.level or 1),
   }
@@ -913,9 +948,9 @@ function PartyMenu:tmhmAble(mon)
   if not move then return nil end
   local species = self.pokemon and self.pokemon[mon.species]
   for _, id in ipairs((species and species.tmhm) or {}) do
-    if id == move then return "ABLE" end
+    if id == move then return Strings(ABLE_LABEL) end
   end
-  return "NOT ABLE"
+  return Strings(NOT_ABLE_LABEL)
 end
 
 -- WritePartyMenuTilemap, jumptable entry by jumptable entry.  Every coordinate
@@ -955,7 +990,8 @@ function PartyMenu:drawPanel()
     end
     self:drawIcon(mon, self:iconX(i), 4 + (i - 1) * 16 + self:iconBob(i))
     local hp = self:shownHpFor(i, mon)
-    local row = PartyMenu.rowFor(mon, hp)
+    local row = PartyMenu.rowFor(mon, hp,
+      self.game and self.game.data and self.game.data.gen2Statuses)
     Chrome.print(row.name, 3, nameY)
     if self.tmhm then
       local able = self:tmhmAble(mon)
@@ -972,7 +1008,7 @@ function PartyMenu:drawPanel()
   -- starts two columns left of where the nicknames do.
   local cancelY = 1 + #self.party * 2
   if self:isCancel() then Chrome.cursor(0, cancelY) end
-  Chrome.print("CANCEL", 1, cancelY)
+  Chrome.print(actionLabel("CANCEL"), 1, cancelY)
 
   -- PlacePartyMenuText: Textbox at (0,14) with a 2x18 interior, string at (1,16).
   -- ReturnToMapWithSpeechTextbox restores the normal font afterwards, and so
@@ -989,9 +1025,11 @@ function PartyMenu:drawPanel()
   else
     Chrome.box(0, 14, 20, 4)
     -- ../pokecrystal/engine/items/item_effects.asm:2016
-    local prompt = self.switchFrom and PartyMenu.PROMPTS.moveTo
-      or (self.softboiledFrom and PartyMenu.PROMPTS.useItem) or self.prompt
-    Chrome.print(#self.party == 0 and PartyMenu.PROMPTS.none or prompt, 1, 16)
+    local prompt = self.switchFrom and Strings(PartyMenu.PROMPTS.moveTo)
+      or (self.softboiledFrom and Strings(PartyMenu.PROMPTS.useItem))
+      or (self.promptIsBuiltin and Strings(self.prompt) or self.prompt)
+    Chrome.print(#self.party == 0 and Strings(PartyMenu.PROMPTS.none) or prompt,
+      1, 16)
   end
   -- PokemonActionSubmenu clears (1,15) 2x18 before MonSubmenu draws, so the
   -- prompt is gone behind the box rather than showing through it.

--- a/src/ui/gen2/PcMenu.lua
+++ b/src/ui/gen2/PcMenu.lua
@@ -58,16 +58,16 @@ PcMenu.isOpaque = true
 -- draws two tiles rather than seven -- which is the only reason "MOVE <PK><MN>
 -- W/O MAIL" fits inside a 20-tile screen.
 local ENTRIES = {
-  { id = "withdraw", label = "WITHDRAW <PK><MN>" },
-  { id = "deposit", label = "DEPOSIT <PK><MN>" },
-  { id = "changebox", label = "CHANGE BOX" },
-  { id = "move", label = "MOVE <PK><MN> W/O MAIL" },
+  { id = "withdraw", label = Strings.source("WITHDRAW <PK><MN>"), builtin = true },
+  { id = "deposit", label = Strings.source("DEPOSIT <PK><MN>"), builtin = true },
+  { id = "changebox", label = Strings.source("CHANGE BOX"), builtin = true },
+  { id = "move", label = Strings.source("MOVE <PK><MN> W/O MAIL"), builtin = true },
   -- PLAYERSPCITEM_MAIL_BOX (engine/events/pokecenter_pc.asm), which BOTH
   -- .WhichPC lists carry: the MAILBOX is on the item PC in a Pokecenter and in
   -- the bedroom alike, unlike DECORATION below.  It sits here because this
   -- port folds the item PC's menu into the storage one.
-  { id = "mailbox", label = "MAIL BOX" },
-  { id = "seeya", label = "SEE YA!" },
+  { id = "mailbox", label = Strings.source("MAIL BOX"), builtin = true },
+  { id = "seeya", label = Strings.source("SEE YA!"), builtin = true },
 }
 
 -- PLAYERSPCITEM_DECORATION, the one row the bedroom's PC has that a
@@ -75,7 +75,9 @@ local ENTRIES = {
 -- carries it, PLAYERSPC_NORMAL does not).  It belongs to the item PC's menu on
 -- the cart, which this port folds into the storage menu the same way both PCs
 -- are folded -- so it hangs off the same list, gated on `house`.
-local DECORATION = { id = "decoration", label = "DECORATION" }
+local DECORATION = {
+  id = "decoration", label = Strings.source("DECORATION"), builtin = true,
+}
 
 -- The exit row.  It is a member of ENTRIES (it is one of _BillsPC's five), but
 -- the list is assembled without it and it is put back on the end AFTER the
@@ -155,8 +157,21 @@ function PcMenu.new(game, opts)
   -- .CheckCanUsePC: an empty party gets the "You'll need a POKéMON" line and
   -- the PC never opens.  Kept here rather than at the call site so every route
   -- into the PC (the overworld script, a driver, a mod) gets the same gate.
+  -- Boxes.lua's own \f is the same catalog key BoxMenu.lua's
+  -- BOX_FAILURE_SOURCES already declares for this string; split the
+  -- translated result on it into notice()'s page-per-string shape rather
+  -- than calling notice() itself, which would also reset messageCloses to
+  -- false -- this refusal closes the PC, the mail-holding one does not.
   local ok, reason = Boxes.canUsePc(self.save)
-  if not ok then self.message = reason end
+  if not ok then
+    local pages = {}
+    for page in (Strings(reason) .. "\f"):gmatch("(.-)\f") do
+      pages[#pages + 1] = page
+    end
+    self.message = pages[1]
+    self.messagePages = pages
+    self.messagePage = 1
+  end
   return self
 end
 
@@ -441,7 +456,7 @@ function PcMenu:drawPanel()
       return
     end
     Chrome.box(0, 14, 20, 4)
-    Chrome.print("Which BOX?", 1, 16)
+    Chrome.print(Strings("Which BOX?"), 1, 16)
     love.graphics.setColor(1, 1, 1, 1)
     return
   end
@@ -452,7 +467,7 @@ function PcMenu:drawPanel()
   -- the way the cart's windows stack (src/ui/gen2/ItemPcMenu.lua does the
   -- same with the house's six-row item list).
   Chrome.box(0, 12, 20, 6)
-  Chrome.print("What?", 1, 14)
+  Chrome.print(Strings("What?"), 1, 14)
 
   -- ClearPCItemScreen: Textbox at (0,0) with a 10x18 interior, and a second
   -- at (0,12) with a 4x18 one.  GetMenuTextStartCoord then puts the first
@@ -466,7 +481,7 @@ function PcMenu:drawPanel()
   for i, entry in ipairs(self.entries) do
     local ty = i * 2
     if i == self.index then Chrome.cursor(1, ty) end
-    Chrome.print(entry.label, 2, ty)
+    Chrome.print(entry.builtin and Strings(entry.label) or entry.label, 2, ty)
   end
   love.graphics.setColor(1, 1, 1, 1)
 end

--- a/src/ui/gen2/PokedexMenu.lua
+++ b/src/ui/gen2/PokedexMenu.lua
@@ -40,12 +40,30 @@ local Sound = require("src.core.Sound")
 local Unown = require("src.core.gen2.Unown")
 local Strings = require("src.core.Strings")
 local MenuRepeat = require("src.ui.MenuRepeat")
+local TypeChart = require("src.battle.TypeChart")
 
 -- `db $3b, " OPTION ", $3c` / `db $3b, " SEARCH ", $3c"`: the panel titles
 -- drawn by drawOption/drawSearch below, declared here (rather than inline)
 -- so Strings.source puts them in the catalog harvest.
 local OPTION_LABEL = Strings.source(" OPTION ")
 local SEARCH_LABEL = Strings.source(" SEARCH ")
+local MODE_LABELS = {
+  NEW = Strings.source("NEW"),
+  OLD = Strings.source("OLD"),
+  ["A-Z"] = Strings.source("A-Z"),
+}
+local SEEN_LABEL = Strings.source("SEEN")
+local OWN_LABEL = Strings.source("OWN")
+local HEIGHT_LABEL = Strings.source("HT")
+local WEIGHT_LABEL = Strings.source("WT")
+local SEARCH_TYPE1_LABEL = Strings.source("TYPE1")
+local SEARCH_TYPE2_LABEL = Strings.source("TYPE2")
+local BEGIN_SEARCH_LABEL = Strings.source("BEGIN SEARCH!!")
+local CANCEL_LABEL = Strings.source("CANCEL")
+local NO_SEARCH_RESULTS = Strings.source("No <PK><MN> found!")
+local ENTRY_ACTION_LABEL = Strings.source(" PAGE AREA CRY PRNT")
+local POUND_LABEL = Strings.source("lb")
+local NEST_TITLE = Strings.source("%s'S NEST")
 
 local LIST_DIRS = { "up", "down" }
 
@@ -655,9 +673,9 @@ function PokedexMenu:drawMainBackground()
   self:border(0, 9, 6, 7)
 
   local seen, caught = self:totals()
-  self:text("SEEN", 1, 11)
+  self:text(Strings(SEEN_LABEL), 1, 11)
   self:text(printNumString(seen, 3), 5, 12)
-  self:text("OWN", 1, 14)
+  self:text(Strings(OWN_LABEL), 1, 14)
   self:text(printNumString(caught, 3), 5, 15)
 
   for i, id in ipairs(BOTTOM_CAPTION) do self:tile(id, i, 17) end
@@ -930,7 +948,7 @@ function PokedexMenu:drawArea()
     self:drawTilemap(cells)
   end
 
-  self:drawAreaHeader(self:monName(row.species) .. "'S NEST")
+  self:drawAreaHeader(Strings(NEST_TITLE, self:monName(row.species)))
 
   -- engine/pokegear/pokegear.asm:2385
   local on = ((self.areaBlink or 0) % 32) < 16
@@ -977,7 +995,7 @@ function PokedexMenu:drawEntryBody(row, entry)
   self:tile(0x3b, 0, 17)
   -- _NewPokedexEntry ByteFills the action row away (pokedex.asm:2540-2545).
   if not self.newEntry then
-    self:text(" PAGE AREA CRY PRNT", 1, 17)
+    self:text(Strings(ENTRY_ACTION_LABEL), 1, 17)
     -- Pokedex_InitArrowCursor parks an arrow on the selected action; without it
     -- the four words are decoration and there is no way to tell what A will do.
     --
@@ -1010,10 +1028,10 @@ function PokedexMenu:drawEntryBody(row, entry)
 
   -- .Height / .Weight are placeholder strings until the mon is caught:
   -- "HT  ?'??"" at (9,7) and "WT   ???lb" at (9,9).
-  self:text("HT", 9, 7)
-  self:text("WT", 9, 9)
+  self:text(Strings(HEIGHT_LABEL), 9, 7)
+  self:text(Strings(WEIGHT_LABEL), 9, 9)
   self:tile(TILE_FOOT, 14, 7)
-  self:text("lb", 17, 9)
+  self:text(Strings(POUND_LABEL), 17, 9)
 
   if not row.caught then
     self:text("  ?", 11, 7)
@@ -1085,8 +1103,10 @@ function PokedexMenu:drawPlain()
       Chrome.print(("%s  %s"):format(
         Chrome.number(entry.dex or 0, 3, true), self:monName(row.species)), 1, 1)
       Chrome.print(entry.kind or "", 1, 3)
-      Chrome.print("HT " .. printNumString(entry.height or 0, 4, false, 2), 1, 5)
-      Chrome.print("WT " .. printNumString(entry.weight or 0, 5, false, 4), 1, 7)
+      Chrome.print(Strings(HEIGHT_LABEL) .. " "
+        .. printNumString(entry.height or 0, 4, false, 2), 1, 5)
+      Chrome.print(Strings(WEIGHT_LABEL) .. " "
+        .. printNumString(entry.weight or 0, 5, false, 4), 1, 7)
       self:drawPic(row, 12, 1, true)
       Chrome.box(0, 10, 20, 8)
       local ty = 11
@@ -1113,10 +1133,10 @@ function PokedexMenu:drawPlain()
   self:drawPic(self:current(), 13, 1)
   Chrome.box(13, 11, 7, 7)
   local seen, caught = self:totals()
-  Chrome.print(self:mode(), 14, 12)
-  Chrome.print("SEEN", 14, 14)
+  Chrome.print(Strings(MODE_LABELS[self:mode()] or self:mode()), 14, 12)
+  Chrome.print(Strings(SEEN_LABEL), 14, 14)
   Chrome.printRight(tostring(seen), 19, 15)
-  Chrome.print("OWN", 14, 16)
+  Chrome.print(Strings(OWN_LABEL), 14, 16)
   Chrome.printRight(tostring(caught), 19, 17)
 end
 
@@ -1139,14 +1159,18 @@ PokedexMenu.SEARCH_TYPES = {
 -- `#` is the compression byte for POKé, four tiles either way, so the label
 -- is spelled out here the way every other Gen 2 screen in the port spells it.
 PokedexMenu.OPTION_MODES = {
-  { label = "NEW POKéDEX MODE", mode = "NEW",
-    lines = { "<PK><MN> are listed by", "evolution type." } },
-  { label = "OLD POKéDEX MODE", mode = "OLD",
-    lines = { "<PK><MN> are listed by", "official type." } },
-  { label = "A to Z MODE", mode = "A-Z",
-    lines = { "<PK><MN> are listed", "alphabetically." } },
-  { label = "UNOWN MODE", mode = "UNOWN", unown = true,
-    lines = { "UNOWN are listed", "in catching order." } },
+  { label = Strings.source("NEW POKéDEX MODE"), mode = "NEW",
+    lines = { Strings.source("<PK><MN> are listed by"),
+      Strings.source("evolution type.") } },
+  { label = Strings.source("OLD POKéDEX MODE"), mode = "OLD",
+    lines = { Strings.source("<PK><MN> are listed by"),
+      Strings.source("official type.") } },
+  { label = Strings.source("A to Z MODE"), mode = "A-Z",
+    lines = { Strings.source("<PK><MN> are listed"),
+      Strings.source("alphabetically.") } },
+  { label = Strings.source("UNOWN MODE"), mode = "UNOWN", unown = true,
+    lines = { Strings.source("UNOWN are listed"),
+      Strings.source("in catching order.") } },
 }
 
 -- Pokedex_CheckUnlockedUnownMode: `ld a, [wStatusFlags] / bit
@@ -1378,15 +1402,24 @@ end
 function PokedexMenu:searchTypeName(slot)
   local index = self.searchType[slot] or 0
   if index == 0 then return "-----" end
-  return PokedexMenu.SEARCH_TYPES[index] or "-----"
+  local id = PokedexMenu.SEARCH_TYPES[index]
+  return id and TypeChart.displayName(id, self.data) or "-----"
+end
+
+-- Search compares internal type ids, never their translated display names.
+-- Keeping this separate from searchTypeName lets a registry rename and even
+-- reorder the visible label without changing which species the wheel finds.
+function PokedexMenu:searchTypeId(slot)
+  local index = self.searchType[slot] or 0
+  return index ~= 0 and PokedexMenu.SEARCH_TYPES[index] or nil
 end
 
 -- Pokedex_SearchForMons: a mon matches when its two types cover both of the
 -- wanted ones, in either order; "-----" matches anything.  Only SEEN mon are
 -- searched, which is what makes the count meaningful.
 function PokedexMenu:beginSearch()
-  local want1 = self.searchType[1] ~= 0 and self:searchTypeName(1) or nil
-  local want2 = self.searchType[2] ~= 0 and self:searchTypeName(2) or nil
+  local want1 = self:searchTypeId(1)
+  local want2 = self:searchTypeId(2)
   local results = {}
   for _, entry in ipairs(self.rows) do
     if entry.seen then
@@ -1403,7 +1436,7 @@ function PokedexMenu:beginSearch()
   if #results == 0 then
     -- .MenuAction_BeginSearch redraws the search screen and stays put when
     -- nothing matched.
-    self.searchMessage = "No <PK><MN> found!"
+    self.searchMessage = NO_SEARCH_RESULTS
     return
   end
   self.searchMessage = nil
@@ -1426,13 +1459,13 @@ function PokedexMenu:drawOption()
   self:tile(0x3c, 9, 1)
   local rows = self:optionRows()
   for i, row in ipairs(rows) do
-    self:text(row.label, 3, 2 + i * 2)
+    self:text(Strings(row.label), 3, 2 + i * 2)
     if i == self.optionIndex then self:text("\xe2\x96\xb6", 2, 2 + i * 2) end
   end
   local current = rows[self.optionIndex]
   if current then
-    self:text(current.lines[1], 1, 14)
-    self:text(current.lines[2], 1, 15)
+    self:text(Strings(current.lines[1]), 1, 14)
+    self:text(Strings(current.lines[2]), 1, 15)
   end
 end
 
@@ -1444,8 +1477,8 @@ function PokedexMenu:drawSearch()
   self:tile(0x3b, 0, 1)
   self:text(Strings(SEARCH_LABEL), 1, 1)
   self:tile(0x3c, 9, 1)
-  self:text("TYPE1", 3, 4)
-  self:text("TYPE2", 3, 6)
+  self:text(Strings(SEARCH_TYPE1_LABEL), 3, 4)
+  self:text(Strings(SEARCH_TYPE2_LABEL), 3, 6)
   self:text(self:searchTypeName(1), 10, 4)
   self:text(self:searchTypeName(2), 10, 6)
   -- `.TypeLeftRightArrows: db $3d, "        ", $3e` -- two of the dex sheet's
@@ -1454,9 +1487,9 @@ function PokedexMenu:drawSearch()
     self:tile(0x3d, 8, y)
     self:tile(0x3e, 17, y)
   end
-  self:text("BEGIN SEARCH!!", 3, 13)
-  self:text("CANCEL", 3, 15)
-  if self.searchMessage then self:text(self.searchMessage, 3, 10) end
+  self:text(Strings(BEGIN_SEARCH_LABEL), 3, 13)
+  self:text(Strings(CANCEL_LABEL), 3, 15)
+  if self.searchMessage then self:text(Strings(self.searchMessage), 3, 10) end
   local rows = { 4, 6, 13, 15 }
   local y = rows[self.searchIndex] or 4
   self:text("\xe2\x96\xb6", 2, y)

--- a/src/ui/gen2/Pokegear.lua
+++ b/src/ui/gen2/Pokegear.lua
@@ -49,21 +49,28 @@ local BLANK_TILE = 0x4f
 -- by wPokegearCard.  Listing RADIO before PHONE made the arrow jump column 2 ->
 -- 6 -> 4.
 local CARDS = {
-  { id = "clock", label = "CLOCK", icon = 0x46, iconX = 0 },
-  { id = "map", label = "MAP", flag = "map", icon = 0x40, iconX = 2 },
-  { id = "phone", label = "PHONE", flag = "phone", icon = 0x44, iconX = 4 },
-  { id = "radio", label = "RADIO", flag = "radio", icon = 0x42, iconX = 6 },
+  { id = "clock", label = Strings.source("CLOCK"), icon = 0x46, iconX = 0 },
+  { id = "map", label = Strings.source("MAP"), flag = "map", icon = 0x40, iconX = 2 },
+  { id = "phone", label = Strings.source("PHONE"), flag = "phone", icon = 0x44, iconX = 4 },
+  { id = "radio", label = Strings.source("RADIO"), flag = "radio", icon = 0x42, iconX = 6 },
 }
 
 -- _FlyMap draws the SAME town map, but it is not the MAP card: it is its own
 -- screen (LoadTownMapGFX / FlyMap / TownMapBubble), with no card strip and no
 -- ENGINE_MAP_CARD gate, which is why FLY works before the Guide Gent hands the
 -- card over.  One row, so `#self.cards` stays 1 and nothing pages.
-local FLY_MAP_CARD = { id = "map", label = "FLY" }
+local FLY_MAP_CARD = { id = "map", label = Strings.source("FLY") }
 
 -- ../pokecrystal/engine/events/specials.asm:102 OverworldTownMap -> _TownMap
 -- (:1757): the wall map and the DECO_TOWN_MAP poster, no strip and no card gate.
-local TOWN_MAP_CARD = { id = "map", label = "MAP" }
+local TOWN_MAP_CARD = { id = "map", label = Strings.source("MAP") }
+local AM_LABEL = Strings.source("AM")
+local PM_LABEL = Strings.source("PM")
+local DAY_LABEL = Strings.source("DAY")
+
+local function meridiem(hour)
+  return Strings(hour < 12 and AM_LABEL or PM_LABEL)
+end
 
 -- ---------------------------------------------------------------- the radio
 --
@@ -129,39 +136,49 @@ local STATION_NAMES = {
 -- OaksPKMNTalk8.Adverbs, in table order: `maskbits 16` makes every roll valid,
 -- which is why there is no retry loop around it.
 local OPT_ADVERBS = {
-  "sweet and adorably", "wiggly and slickly", "aptly named and",
-  "undeniably kind of", "so, so unbearably", "wow, impressively",
-  "almost poisonously", "ooh, so sensually", "so mischievously",
-  "so very topically", "sure addictively", "looks in water is",
-  "evolution must be", "provocatively", "so flipped out and",
-  "heart-meltingly",
+  Strings.source("sweet and adorably"), Strings.source("wiggly and slickly"),
+  Strings.source("aptly named and"), Strings.source("undeniably kind of"),
+  Strings.source("so, so unbearably"), Strings.source("wow, impressively"),
+  Strings.source("almost poisonously"), Strings.source("ooh, so sensually"),
+  Strings.source("so mischievously"), Strings.source("so very topically"),
+  Strings.source("sure addictively"), Strings.source("looks in water is"),
+  Strings.source("evolution must be"), Strings.source("provocatively"),
+  Strings.source("so flipped out and"), Strings.source("heart-meltingly"),
 }
 
 -- OaksPKMNTalk9.Adjectives.
 local OPT_ADJECTIVES = {
-  "cute.", "weird.", "pleasant.", "bold, sort of.", "frightening.",
-  "suave & debonair!", "powerful.", "exciting.", "now!", "inspiring.",
-  "friendly.", "hot, hot, hot!", "stimulating.", "guarded.", "lovely.",
-  "speedy.",
+  Strings.source("cute."), Strings.source("weird."),
+  Strings.source("pleasant."), Strings.source("bold, sort of."),
+  Strings.source("frightening."), Strings.source("suave & debonair!"),
+  Strings.source("powerful."), Strings.source("exciting."),
+  Strings.source("now!"), Strings.source("inspiring."),
+  Strings.source("friendly."), Strings.source("hot, hot, hot!"),
+  Strings.source("stimulating."), Strings.source("guarded."),
+  Strings.source("lovely."), Strings.source("speedy."),
 }
 
 -- PeoplePlaces5.Adjectives and PeoplePlaces7.Adjectives are the same sixteen
 -- rows in the same order, so one table serves both.
 local PNP_ADJECTIVES = {
-  "is cute.", "is sort of lazy.", "is always happy.", "is quite noisy.",
-  "is precocious.", "is somewhat bold.", "is too picky!", "is sort of OK.",
-  "is just so-so.", "is actually great.", "is just my type.",
-  "is so cool, no?", "is inspiring!", "is kind of weird.",
-  "is right for me?", "is definitely odd!",
+  Strings.source("is cute."), Strings.source("is sort of lazy."),
+  Strings.source("is always happy."), Strings.source("is quite noisy."),
+  Strings.source("is precocious."), Strings.source("is somewhat bold."),
+  Strings.source("is too picky!"), Strings.source("is sort of OK."),
+  Strings.source("is just so-so."), Strings.source("is actually great."),
+  Strings.source("is just my type."), Strings.source("is so cool, no?"),
+  Strings.source("is inspiring!"), Strings.source("is kind of weird."),
+  Strings.source("is right for me?"), Strings.source("is definitely odd!"),
 }
 
 -- RocketRadioText1..10.  The text_pause bytes inside 7-10 only stall the
 -- printer, so the port carries the words either side of them as one line.
 local ROCKET_LINES = {
-  "… …Ahem, we are", "TEAM ROCKET!", "After three years",
-  "of preparation, we", "have risen again", "from the ashes!",
-  "GIOVANNI! Can you", "hear? We did it!", "Where is our Boss?",
-  "Is he listening?",
+  Strings.source("… …Ahem, we are"), Strings.source("TEAM ROCKET!"),
+  Strings.source("After three years"), Strings.source("of preparation, we"),
+  Strings.source("have risen again"), Strings.source("from the ashes!"),
+  Strings.source("GIOVANNI! Can you"), Strings.source("hear? We did it!"),
+  Strings.source("Where is our Boss?"), Strings.source("Is he listening?"),
 }
 
 -- data/radio/oaks_pkmn_talk_routes.asm: the fifteen maps Oak's Pokemon Talk
@@ -201,8 +218,10 @@ local PNP_HIDDEN_BEAT_KANTO = 14 -- first index of PnP_HiddenPeople_BeatKanto
 -- TextCommand_DAY's .Days table, plus its "DAY" suffix.  GetWeekday counts
 -- from Sunday = 0, which is NOT os.date's 1-based wday.
 local RADIO_DAYS = {
-  [0] = "SUNDAY", "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY",
-  "SATURDAY",
+  [0] = Strings.source("SUNDAY"), Strings.source("MONDAY"),
+  Strings.source("TUESDAY"), Strings.source("WEDNESDAY"),
+  Strings.source("THURSDAY"), Strings.source("FRIDAY"),
+  Strings.source("SATURDAY"),
 }
 
 -- macros/data.asm: `percent` is `* $ff / 100`, so these are the two literal
@@ -395,15 +414,15 @@ end
 RadioJumptable["OAKS_POKEMON_TALK"] = function(R)
   R.vars.segmentCounter = 5
   R:startStation()
-  R:nextLine("MARY: PROF.OAK'S", "OAKS_POKEMON_TALK_2")
+  R:nextLine(Strings("MARY: PROF.OAK'S"), "OAKS_POKEMON_TALK_2")
 end
 
 RadioJumptable["OAKS_POKEMON_TALK_2"] = function(R)
-  R:nextLine("POKéMON TALK!", "OAKS_POKEMON_TALK_3")
+  R:nextLine(Strings("POKéMON TALK!"), "OAKS_POKEMON_TALK_3")
 end
 
 RadioJumptable["OAKS_POKEMON_TALK_3"] = function(R)
-  R:nextLine("With me, MARY!", "OAKS_POKEMON_TALK_4")
+  R:nextLine(Strings("With me, MARY!"), "OAKS_POKEMON_TALK_4")
 end
 
 -- OaksPKMNTalk4: roll a route, roll a time of day, roll one of the middle
@@ -441,27 +460,29 @@ RadioJumptable["OAKS_POKEMON_TALK_4"] = function(R)
   R.vars.landmark = R.data.mapLandmark and R.data.mapLandmark[map]
   -- _OPT_OakText1 is "OAK: @" plus the mon name, with no punctuation: the
   -- sentence is finished by the next two segments.
-  R:printLine("OAK: " .. tostring(species or ""), "OAKS_POKEMON_TALK_5")
+  R:printLine(Strings("OAK: %s", tostring(species or "")),
+    "OAKS_POKEMON_TALK_5")
 end
 
 RadioJumptable["OAKS_POKEMON_TALK_5"] = function(R)
-  R:nextLine("may be seen around", "OAKS_POKEMON_TALK_6")
+  R:nextLine(Strings("may be seen around"), "OAKS_POKEMON_TALK_6")
 end
 
 RadioJumptable["OAKS_POKEMON_TALK_6"] = function(R)
   -- _OPT_OakText3 is the landmark name with a full stop welded on.
   local entry = R.data.landmarks and R.data.landmarks[R.vars.landmark]
-  R:nextLine(flatName(entry and entry.name) .. ".", "OAKS_POKEMON_TALK_7")
+  R:nextLine(Strings("%s.", flatName(entry and entry.name)),
+    "OAKS_POKEMON_TALK_7")
 end
 
 RadioJumptable["OAKS_POKEMON_TALK_7"] = function(R)
-  R:nextLine("MARY: " .. tostring(R.vars.species or "") .. "'s",
+  R:nextLine(Strings("MARY: %s's", tostring(R.vars.species or "")),
     "OAKS_POKEMON_TALK_8")
 end
 
 RadioJumptable["OAKS_POKEMON_TALK_8"] = function(R)
   local adverb = OPT_ADVERBS[R:random() % 16 + 1]
-  R:nextLine(adverb, "OAKS_POKEMON_TALK_9")
+  R:nextLine(Strings(adverb), "OAKS_POKEMON_TALK_9")
 end
 
 -- OaksPKMNTalk9 rolls the adjective FIRST and only then spends the segment
@@ -474,7 +495,7 @@ RadioJumptable["OAKS_POKEMON_TALK_9"] = function(R)
     R.vars.segmentCounter = 5
     nextLine = "OAKS_POKEMON_TALK_10"
   end
-  R:nextLine(adjective, nextLine)
+  R:nextLine(Strings(adjective), nextLine)
 end
 
 -- The Pokemon Channel jingle.  OaksPKMNTalk10 calls PrintText rather than
@@ -483,7 +504,7 @@ end
 -- rest in over 100 frames each.
 RadioJumptable["OAKS_POKEMON_TALK_10"] = function(R)
   R.music = "Music_PokemonChannel" -- RadioMusicRestartPokemonChannel
-  R.top, R.bottom = "POKéMON", ""
+  R.top, R.bottom = Strings("POKéMON"), ""
   R.log[#R.log + 1] = R.top
   R.cur = "OAKS_POKEMON_TALK_11"
   R.delay = RADIO_LINE_FRAMES
@@ -494,7 +515,8 @@ end
 RadioJumptable["OAKS_POKEMON_TALK_11"] = function(R)
   R.delay = R.delay - 1
   if R.delay ~= 0 then return end
-  R.top = R.top .. string.rep(" ", math.max(0, 8 - tileWidth(R.top))) .. "POKéMON"
+  R.top = R.top .. string.rep(" ", math.max(0, 8 - tileWidth(R.top)))
+    .. Strings("POKéMON")
   R.log[#R.log + 1] = R.top
   R:placeString("OAKS_POKEMON_TALK_12")
 end
@@ -502,7 +524,7 @@ end
 RadioJumptable["OAKS_POKEMON_TALK_12"] = function(R)
   R.delay = R.delay - 1
   if R.delay ~= 0 then return end
-  R.bottom = "POKéMON Channel" -- hlcoord 1, 16
+  R.bottom = Strings("POKéMON Channel") -- hlcoord 1, 16
   R.log[#R.log + 1] = R.bottom
   R:placeString("OAKS_POKEMON_TALK_13")
 end
@@ -592,42 +614,44 @@ end
 
 RadioJumptable["POKEMON_MUSIC"] = function(R)
   startPokemonMusicChannel(R)
-  R:nextLine("BEN: POKéMON MUSIC", "POKEMON_MUSIC_2")
+  R:nextLine(Strings("BEN: POKéMON MUSIC"), "POKEMON_MUSIC_2")
 end
 
 RadioJumptable["POKEMON_MUSIC_2"] = function(R)
-  R:nextLine("CHANNEL!", "POKEMON_MUSIC_3")
+  R:nextLine(Strings("CHANNEL!"), "POKEMON_MUSIC_3")
 end
 
 RadioJumptable["POKEMON_MUSIC_3"] = function(R)
-  R:nextLine("It's me, DJ BEN!", "POKEMON_MUSIC_4")
+  R:nextLine(Strings("It's me, DJ BEN!"), "POKEMON_MUSIC_4")
 end
 
 RadioJumptable["LETS_ALL_SING"] = function(R)
   startPokemonMusicChannel(R)
-  R:nextLine("FERN: POKéMUSIC!", "LETS_ALL_SING_2")
+  R:nextLine(Strings("FERN: POKéMUSIC!"), "LETS_ALL_SING_2")
 end
 
 -- FernMonMusic2 names POKEMON_MUSIC_4, not a LETS_ALL_SING segment: this is
 -- the handoff, and from here Kanto's station is running Johto's code.
 RadioJumptable["LETS_ALL_SING_2"] = function(R)
-  R:nextLine("With DJ FERN!", "POKEMON_MUSIC_4")
+  R:nextLine(Strings("With DJ FERN!"), "POKEMON_MUSIC_4")
 end
 
 RadioJumptable["POKEMON_MUSIC_4"] = function(R)
-  local day = RADIO_DAYS[(R.data.weekday or 0) % 7] or ""
-  R:nextLine("Today's " .. day .. ",", "POKEMON_MUSIC_5")
+  local day = Strings(RADIO_DAYS[(R.data.weekday or 0) % 7] or "")
+  R:nextLine(Strings("Today's %s,", day), "POKEMON_MUSIC_5")
 end
 
 RadioJumptable["POKEMON_MUSIC_5"] = function(R)
   local odd = (R.data.weekday or 0) % 2 == 1
-  R:nextLine(odd and "so chill out to" or "so let us jam to",
+  R:nextLine(odd and Strings("so chill out to")
+    or Strings("so let us jam to"),
     "POKEMON_MUSIC_6")
 end
 
 RadioJumptable["POKEMON_MUSIC_6"] = function(R)
   local odd = (R.data.weekday or 0) % 2 == 1
-  R:nextLine(odd and "POKéMON Lullaby!" or "POKéMON March!", "POKEMON_MUSIC_7")
+  R:nextLine(odd and Strings("POKéMON Lullaby!")
+    or Strings("POKéMON March!"), "POKEMON_MUSIC_7")
 end
 
 -- BenFernMusic7 is a bare `ret`.  Both music stations really do stop talking
@@ -640,31 +664,32 @@ RadioJumptable["POKEMON_MUSIC_7"] = function() end
 -- of REED admitting he is bored before he starts over.
 
 local LUCKY_LINES = {
-  LUCKY_CHANNEL = { "REED: Yeehaw! How", "LUCKY_NUMBER_SHOW_2" },
-  LUCKY_NUMBER_SHOW_2 = { "y'all doin' now?", "LUCKY_NUMBER_SHOW_3" },
-  LUCKY_NUMBER_SHOW_3 = { "Whether you're up", "LUCKY_NUMBER_SHOW_4" },
-  LUCKY_NUMBER_SHOW_4 = { "or way down low,", "LUCKY_NUMBER_SHOW_5" },
-  LUCKY_NUMBER_SHOW_5 = { "don't you miss the", "LUCKY_NUMBER_SHOW_6" },
-  LUCKY_NUMBER_SHOW_6 = { "LUCKY NUMBER SHOW!", "LUCKY_NUMBER_SHOW_7" },
-  LUCKY_NUMBER_SHOW_7 = { "This week's Lucky", "LUCKY_NUMBER_SHOW_8" },
-  LUCKY_NUMBER_SHOW_9 = { "I'll repeat that!", "LUCKY_NUMBER_SHOW_10" },
+  LUCKY_CHANNEL = { Strings.source("REED: Yeehaw! How"), "LUCKY_NUMBER_SHOW_2" },
+  LUCKY_NUMBER_SHOW_2 = { Strings.source("y'all doin' now?"), "LUCKY_NUMBER_SHOW_3" },
+  LUCKY_NUMBER_SHOW_3 = { Strings.source("Whether you're up"), "LUCKY_NUMBER_SHOW_4" },
+  LUCKY_NUMBER_SHOW_4 = { Strings.source("or way down low,"), "LUCKY_NUMBER_SHOW_5" },
+  LUCKY_NUMBER_SHOW_5 = { Strings.source("don't you miss the"), "LUCKY_NUMBER_SHOW_6" },
+  LUCKY_NUMBER_SHOW_6 = { Strings.source("LUCKY NUMBER SHOW!"), "LUCKY_NUMBER_SHOW_7" },
+  LUCKY_NUMBER_SHOW_7 = { Strings.source("This week's Lucky"), "LUCKY_NUMBER_SHOW_8" },
+  LUCKY_NUMBER_SHOW_9 = { Strings.source("I'll repeat that!"), "LUCKY_NUMBER_SHOW_10" },
   -- LC_Text7 and LC_Text8 again: REED reads the number out a second time.
-  LUCKY_NUMBER_SHOW_10 = { "This week's Lucky", "LUCKY_NUMBER_SHOW_11" },
-  LUCKY_NUMBER_SHOW_12 = { "Match it and go to", "LUCKY_NUMBER_SHOW_13" },
-  LUCKY_NUMBER_SHOW_14 = { "…Repeating myself", "LUCKY_NUMBER_SHOW_15" },
-  LUCKY_NUMBER_SHOW_15 = { "gets to be a drag…", "LUCKY_CHANNEL" },
+  LUCKY_NUMBER_SHOW_10 = { Strings.source("This week's Lucky"), "LUCKY_NUMBER_SHOW_11" },
+  LUCKY_NUMBER_SHOW_12 = { Strings.source("Match it and go to"), "LUCKY_NUMBER_SHOW_13" },
+  LUCKY_NUMBER_SHOW_14 = { Strings.source("…Repeating myself"), "LUCKY_NUMBER_SHOW_15" },
+  LUCKY_NUMBER_SHOW_15 = { Strings.source("gets to be a drag…"), "LUCKY_CHANNEL" },
 }
 for segment, row in pairs(LUCKY_LINES) do
   RadioJumptable[segment] = function(R)
     if segment == "LUCKY_CHANNEL" then R:startStation() end
-    R:nextLine(row[1], row[2])
+    R:nextLine(Strings(row[1]), row[2])
   end
 end
 
 -- LuckyNumberShow8 prints wLuckyIDNumber with PRINTNUM_LEADINGZEROS over five
 -- digits, so a low number reads as "00042".
 local function luckyNumberLine(R)
-  return ("Number is %05d!"):format(math.floor(R.data.luckyNumber or 0) % 100000)
+  return Strings("Number is %05d!",
+    math.floor(R.data.luckyNumber or 0) % 100000)
 end
 
 RadioJumptable["LUCKY_NUMBER_SHOW_8"] = function(R)
@@ -679,7 +704,7 @@ end
 -- complains about once every 256 times round.
 RadioJumptable["LUCKY_NUMBER_SHOW_13"] = function(R)
   local roll = R:random()
-  R:nextLine("the RADIO TOWER!",
+  R:nextLine(Strings("the RADIO TOWER!"),
     roll ~= 0 and "LUCKY_CHANNEL" or "LUCKY_NUMBER_SHOW_14")
 end
 
@@ -690,11 +715,11 @@ end
 
 RadioJumptable["PLACES_AND_PEOPLE"] = function(R)
   R:startStation()
-  R:nextLine("PLACES AND PEOPLE!", "PLACES_AND_PEOPLE_2")
+  R:nextLine(Strings("PLACES AND PEOPLE!"), "PLACES_AND_PEOPLE_2")
 end
 
 RadioJumptable["PLACES_AND_PEOPLE_2"] = function(R)
-  R:nextLine("Brought to you by", "PLACES_AND_PEOPLE_3")
+  R:nextLine(Strings("Brought to you by"), "PLACES_AND_PEOPLE_3")
 end
 
 -- `cp 49 percent - 1` with `jr c` taking People, so the split is 123/256 to
@@ -705,7 +730,7 @@ local function peopleOrPlaces(R)
 end
 
 RadioJumptable["PLACES_AND_PEOPLE_3"] = function(R)
-  R:nextLine("me, DJ LILY!", peopleOrPlaces(R))
+  R:nextLine(Strings("me, DJ LILY!"), peopleOrPlaces(R))
 end
 
 -- PeoplePlaces4: roll a trainer class, reject the ones the hidden list is
@@ -728,7 +753,8 @@ RadioJumptable["PLACES_AND_PEOPLE_4"] = function(R)
   R.vars.trainer = class.trainer
   R.vars.classIndex = index
   -- _PnP_Text4 is the class name and the trainer name with one space between.
-  R:nextLine(tostring(class.name or "") .. " " .. tostring(class.trainer or ""),
+  R:nextLine(Strings("%s %s", tostring(class.name or ""),
+    tostring(class.trainer or "")),
     "PLACES_AND_PEOPLE_5")
 end
 
@@ -738,7 +764,7 @@ RadioJumptable["PLACES_AND_PEOPLE_5"] = function(R)
   local adjective = PNP_ADJECTIVES[R:random() % 16 + 1]
   local nextLine = "PLACES_AND_PEOPLE"
   if R:random() >= PNP_RESTART_CHANCE then nextLine = peopleOrPlaces(R) end
-  R:nextLine(adjective, nextLine)
+  R:nextLine(Strings(adjective), nextLine)
 end
 
 -- PeoplePlaces6: roll one of the nine PnP_Places maps and name its landmark.
@@ -761,7 +787,7 @@ RadioJumptable["PLACES_AND_PEOPLE_7"] = function(R)
   local adjective = PNP_ADJECTIVES[R:random() % 16 + 1]
   local nextLine = "PLACES_AND_PEOPLE"
   if R:random() >= PNP_RESTART_CHANCE then nextLine = peopleOrPlaces(R) end
-  R:printLine(adjective, nextLine)
+  R:printLine(Strings(adjective), nextLine)
 end
 
 -- ------------------------------------------------------------ Rocket Radio
@@ -770,11 +796,11 @@ end
 
 RadioJumptable["ROCKET_RADIO"] = function(R)
   R:startStation()
-  R:nextLine(ROCKET_LINES[1], "ROCKET_RADIO_2")
+  R:nextLine(Strings(ROCKET_LINES[1]), "ROCKET_RADIO_2")
 end
 for index = 2, 10 do
   RadioJumptable["ROCKET_RADIO_" .. index] = function(R)
-    R:nextLine(ROCKET_LINES[index],
+    R:nextLine(Strings(ROCKET_LINES[index]),
       index < 10 and ("ROCKET_RADIO_" .. (index + 1)) or "ROCKET_RADIO")
   end
 end
@@ -856,18 +882,18 @@ local PHONE_ROWS = 4
 -- "bank:addr" key their extracted form will have -- Pokegear:phoneText prefers
 -- the extracted string and only falls back to the transcription.
 local PHONE_TEXT = {
-  GearEllipse = { key = "66:4066", body = "……" },
+  GearEllipse = { key = "66:4066", body = Strings.source("……") },
   GearOutOfService = { key = "66:4069",
-    body = "You're out of the service area." },
-  AskWhoCall = { key = "66:4089", body = "Whom do you want to call?" },
+    body = Strings.source("You're out of the service area.") },
+  AskWhoCall = { key = "66:4089", body = Strings.source("Whom do you want to call?") },
   -- _PokegearPressButtonText, the CLOCK card's bottom-box prompt.
-  PressButton = { key = "66:40a4", body = "Press any button to exit." },
-  AskDelete = { key = "66:40bf", body = "Delete this stored phone number?" },
-  WrongNumber = { key = "66:40e1", body = "Huh? Sorry, wrong number!" },
-  Click = { key = "66:40fc", body = "Click!" },
-  PhoneEllipse = { key = "66:4104", body = "……" },
-  OutOfArea = { key = "66:4107", body = "That number is out of the area." },
-  JustTalkToThem = { key = "66:4128", body = "Just go talk to that person!" },
+  PressButton = { key = "66:40a4", body = Strings.source("Press any button to exit.") },
+  AskDelete = { key = "66:40bf", body = Strings.source("Delete this stored phone number?") },
+  WrongNumber = { key = "66:40e1", body = Strings.source("Huh? Sorry, wrong number!") },
+  Click = { key = "66:40fc", body = Strings.source("Click!") },
+  PhoneEllipse = { key = "66:4104", body = Strings.source("……") },
+  OutOfArea = { key = "66:4107", body = Strings.source("That number is out of the area.") },
+  JustTalkToThem = { key = "66:4128", body = Strings.source("Just go talk to that person!") },
 }
 
 function Pokegear:wantsFillScale() return true end
@@ -1052,6 +1078,11 @@ function Pokegear:card()
   return self.cards[self.cardIndex]
 end
 
+function Pokegear:cardLabel(card)
+  card = card or self:card()
+  return card and Strings(card.label) or ""
+end
+
 -- PokegearClock_Init / UpdateClock read hHours, hMinutes and GetWeekday right
 -- after UpdateTime, so the CLOCK card shows the GAME clock: the RTC through the
 -- save's wStartHour / wStartMinute base.  The gear is pushed over a live world,
@@ -1112,7 +1143,7 @@ function Pokegear:phoneText(name)
     or (self.game and self.game.world and self.game.world.text)
   local extracted = text and text[entry.key]
   if extracted and extracted ~= "" then return extracted end
-  return entry.body
+  return Strings(entry.body)
 end
 
 -- GetCallerClassAndName: a trainer contact is "<name>:" over the class name, a
@@ -1250,6 +1281,22 @@ function Pokegear:radioContext()
   }
 end
 
+-- LoadStation_* display names come from the radio_channels registry.  The
+-- station id remains the show-machine key; only its presentation is patched.
+-- Falling back to STATION_NAMES keeps pure-module tests and loader-free boots
+-- faithful.  A registry value is already authored display text, so it is not
+-- fed through Strings a second time.
+function Pokegear:stationName(station)
+  if not station then return nil end
+  local data = self.game and self.game.data
+  local rows = data and data.gen2RadioChannels
+  if type(rows) == "table" then
+    local record = rows[station]
+    return record and record.name or nil
+  end
+  return STATION_NAMES[station]
+end
+
 -- Every RadioChannels row, with the station its test resolves to right now
 -- (nil where NoRadioStation would fire).
 function Pokegear:stations()
@@ -1259,7 +1306,7 @@ function Pokegear:stations()
     local station = row.signal(ctx)
     out[index] = {
       knob = row.knob, frequency = row.frequency, station = station,
-      name = station and STATION_NAMES[station] or nil,
+      name = self:stationName(station),
     }
   end
   return out
@@ -1523,6 +1570,12 @@ local PHONE_SUBMENUS = {
     entries = { "CALL", "DELETE", "CANCEL" } },
   callCancel = { x = 9, y = 6, rows = 2, textX = 11, textY = 8,
     entries = { "CALL", "CANCEL" } },
+}
+
+local PHONE_SUBMENU_LABELS = {
+  CALL = Strings.source("CALL"),
+  DELETE = Strings.source("DELETE"),
+  CANCEL = Strings.source("CANCEL"),
 }
 
 Pokegear.PHONE_SUBMENUS = PHONE_SUBMENUS
@@ -1978,7 +2031,7 @@ function Pokegear:drawClock()
   local hour, minute, weekday = self:clockParts()
   self:drawTilemap(self.gfx and self.gfx.cards and self.gfx.cards.clock)
   self:drawStrip()
-  self:text(" SWITCH", 12, 1)
+  self:text(" " .. Strings("SWITCH"), 12, 1)
   self:cursor(19, 1)
 
   -- Pokegear_UpdateClock: ClearBox(3,5) 5x14, the day at (6,6) and
@@ -1990,7 +2043,7 @@ function Pokegear:drawClock()
   self:text(Chrome.number(display, 2), 6, 8)
   self:text(":", 8, 8)
   self:text(Chrome.number(minute, 2, true), 9, 8)
-  self:text(Strings(hour < 12 and "AM" or "PM"), 12, 8)
+  self:text(meridiem(hour), 12, 8)
 
   -- The bottom Textbox is part of the card (lb bc, 4, 18 at (0,12)), and
   -- PokegearClock_Init prints PokegearPressButtonText straight into it
@@ -2094,7 +2147,7 @@ function Pokegear:drawFlyBubble()
   self:tile(0x32, 1, 2)
   for x = 2, 17 do self:tile(SPACE_TILE, x, 2) end
   self:tile(0x33, 18, 2)
-  self:text("Where?", 2, 0)
+  self:text(Strings("Where?"), 2, 0)
   local row = self:flyRow()
   self:text(flatName(row and row.name), 2, 1)
   self:tile(0x34, 18, 1)
@@ -2358,7 +2411,7 @@ function Pokegear:drawPhoneSubmenu()
   self:textbox(menu.x, menu.y, 8, menu.rows * 2)
   for index, label in ipairs(menu.entries) do
     local ty = menu.textY + (index - 1) * 2
-    self:text(label, menu.textX, ty)
+    self:text(Strings(PHONE_SUBMENU_LABELS[label] or label), menu.textX, ty)
   end
   self:cursor(menu.textX - 1, menu.textY + self.phoneSubmenuCursor * 2)
 end
@@ -2371,7 +2424,7 @@ function Pokegear:drawPlain()
     -- No town-map art in this cache, so the bubble's "Where?" and the rows it
     -- scrolls between are the whole screen.
     Chrome.box(0, 0, 20, 4)
-    Chrome.print("Where?", 2, 1)
+    Chrome.print(Strings("Where?"), 2, 1)
     Chrome.box(0, 4, 20, 14)
     local rows = self.fly
     local top = math.max(1, math.min((self.flyIndex or 1) - 3, #rows - 5))
@@ -2396,18 +2449,18 @@ function Pokegear:drawPlain()
   end
   Chrome.box(0, 0, 20, 4)
   local card = self:card()
-  Chrome.print(card and card.label or "", 2, 1)
+  Chrome.print(self:cardLabel(card), 2, 1)
   if #self.cards > 1 then Chrome.cursor(17, 1) end
   local id = card and card.id
   if id == "clock" then
     local hour, minute, weekday = self:clockParts()
     Chrome.box(1, 5, 18, 7)
-    Chrome.print(Clock.weekdayName(weekday) or "DAY", 3, 7)
+    Chrome.print(Clock.weekdayName(weekday) or Strings(DAY_LABEL), 3, 7)
     local display = hour % 12
     if display == 0 then display = 12 end
     Chrome.print(("%s:%s %s"):format(
       Chrome.number(display, 2), Chrome.number(minute, 2, true),
-      Strings(hour < 12 and "AM" or "PM")), 5, 9)
+      meridiem(hour)), 5, 9)
     Chrome.print(Clock.daytimeLabel(hour), 5, 11)
   elseif id == "radio" then
     -- Without the gear sheet there is no dial art, so the frequencies go down
@@ -2440,7 +2493,7 @@ function Pokegear:drawPlain()
     self:drawPhoneSubmenu()
   else
     Chrome.box(0, 4, 20, 14)
-    Chrome.print("NO CARD DATA", 2, 6)
+    Chrome.print(Strings("NO CARD DATA"), 2, 6)
   end
 end
 

--- a/src/ui/gen2/PrizeMenu.lua
+++ b/src/ui/gen2/PrizeMenu.lua
@@ -45,8 +45,11 @@
 local Bag = require("src.inventory.Bag")
 local Chrome = require("src.ui.gen2.Chrome")
 local CoinCase = require("src.core.gen2.CoinCase")
+local CommonText = require("src.core.gen2.CommonText")
+local Font = require("src.render.Font")
 local Save = require("src.core.gen2.Save")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 
 local PrizeMenu = {}
 PrizeMenu.__index = PrizeMenu
@@ -93,44 +96,52 @@ end
 --
 -- The Goldenrod Pokemon counter branches on `checkver`: Gold sells EKANS where
 -- Silver sells SANDSHREW, which is the only version difference in the room.
--- The labels are the menu data's literal strings, spaces and all, because their
--- padding is what right-aligns the price column.
+-- The item/mon counters keep name and cost as separate fields (rather than
+-- one hand-padded label) and `priceRight` says which tile column the price's
+-- last digit lands on, so a translated name of a different length than the
+-- English original still leaves the price column right-aligned (#1642-adjacent:
+-- a translated name used to shift or overlap the padded price that followed it
+-- in the same literal).
 PrizeMenu.COUNTERS = {
   CELADON_TM = {
     kind = "item",
     menu = { x = 0, y = 2, w = 16, h = 10 },
+    priceRight = 13,
     prizes = {
-      { id = "TM_DOUBLE_TEAM", label = "TM32    1500", cost = 1500 },
-      { id = "TM_PSYCHIC_M",   label = "TM29    3500", cost = 3500 },
-      { id = "TM_HYPER_BEAM",  label = "TM15    7500", cost = 7500 },
+      { id = "TM_DOUBLE_TEAM", name = Strings.source("TM32"), cost = 1500 },
+      { id = "TM_PSYCHIC_M",   name = Strings.source("TM29"), cost = 3500 },
+      { id = "TM_HYPER_BEAM",  name = Strings.source("TM15"), cost = 7500 },
     },
   },
   CELADON_MON = {
     kind = "mon",
     menu = { x = 0, y = 2, w = 18, h = 10 },
+    priceRight = 16,
     prizes = {
-      { id = "MR__MIME", label = "MR.MIME    3333", cost = 3333, level = 15 },
-      { id = "EEVEE",    label = "EEVEE      6666", cost = 6666, level = 15 },
-      { id = "PORYGON",  label = "PORYGON    9999", cost = 9999, level = 20 },
+      { id = "MR__MIME", name = Strings.source("MR.MIME"), cost = 3333, level = 15 },
+      { id = "EEVEE",    name = Strings.source("EEVEE"),   cost = 6666, level = 15 },
+      { id = "PORYGON",  name = Strings.source("PORYGON"), cost = 9999, level = 20 },
     },
   },
   GOLDENROD_TM = {
     kind = "item",
     menu = { x = 0, y = 2, w = 16, h = 10 },
+    priceRight = 13,
     prizes = {
-      { id = "TM_THUNDER",    label = "TM25    5500", cost = 5500 },
-      { id = "TM_BLIZZARD",   label = "TM14    5500", cost = 5500 },
-      { id = "TM_FIRE_BLAST", label = "TM38    5500", cost = 5500 },
+      { id = "TM_THUNDER",    name = Strings.source("TM25"), cost = 5500 },
+      { id = "TM_BLIZZARD",   name = Strings.source("TM14"), cost = 5500 },
+      { id = "TM_FIRE_BLAST", name = Strings.source("TM38"), cost = 5500 },
     },
   },
   GOLDENROD_MON = {
     kind = "mon",
     menu = { x = 0, y = 2, w = 18, h = 10 },
+    priceRight = 16,
     prizes = {
-      { id = "ABRA",    label = "ABRA        200", cost = 200,  level = 10 },
-      { id = "EKANS",   label = "EKANS       700", cost = 700,  level = 10,
-        silver = { id = "SANDSHREW", label = "SANDSHREW   700" } },
-      { id = "DRATINI", label = "DRATINI    2100", cost = 2100, level = 10 },
+      { id = "ABRA",    name = Strings.source("ABRA"),    cost = 200,  level = 10 },
+      { id = "EKANS",   name = Strings.source("EKANS"),   cost = 700,  level = 10,
+        silver = { id = "SANDSHREW", name = Strings.source("SANDSHREW") } },
+      { id = "DRATINI", name = Strings.source("DRATINI"), cost = 2100, level = 10 },
     },
   },
   -- GameCornerCoinVendorScript's own menu: `menu_coords 0, 4, 15, TEXTBOX_Y - 1`
@@ -140,8 +151,10 @@ PrizeMenu.COUNTERS = {
     kind = "coins",
     menu = { x = 0, y = 4, w = 16, h = 8 },
     prizes = {
-      { amount = 50,  cost = 1000,  label = " 50 :  \xc2\xa51000" },
-      { amount = 500, cost = 10000, label = "500 : \xc2\xa510000" },
+      { amount = 50,  cost = 1000,
+        label = Strings.source(" 50 :  \xc2\xa51000") },
+      { amount = 500, cost = 10000,
+        label = Strings.source("500 : \xc2\xa510000") },
     },
   },
 }
@@ -152,52 +165,92 @@ PrizeMenu.COUNTERS = {
 -- five beats, and the coin vendor a third set again.  All three are transcribed
 -- from the map scripts / data/text/std_text.asm; none are in the cache's
 -- text.lua, because no script bytecode the extractor walks points at them.
-local function page(...) return { ... } end
-local function pages(...) return { ... } end
+local function sourcedPages(source, ...)
+  local args = { ... }
+  local rendered = #args > 0 and source:format(unpack(args)) or source
+  local value = CommonText.pages(rendered)
+  value.source, value.args = source, args
+  return value
+end
+
+local function sourcedPage(source, ...)
+  local value = sourcedPages(source, ...)
+  local first = value[1] or {}
+  first.source, first.args = value.source, value.args
+  return first
+end
+
+local function localizedPages(value)
+  if not (value and value.source) then return value or {} end
+  local translated = #value.args > 0
+    and Strings(value.source, unpack(value.args)) or Strings(value.source)
+  return CommonText.pages(translated) or {}
+end
+
+local function localizedPage(value)
+  if not (value and value.source) then return value or {} end
+  return localizedPages(value)[1] or {}
+end
 
 PrizeMenu.TEXTS = {
   CELADON = {
-    intro = pages(page("Welcome!"),
-      page("We exchange your", "coins for fabulous"),
-      page("prizes!")),
-    which = page("Which prize would", "you like?"),
+    -- gs.CeladonGameCornerPrizeRoom.CeladonPrizeRoom_PrizeVendorIntroText:
+    -- <PARA> then <LINE> then <CONT> -- the last transition scrolls, it does
+    -- not clear to a fresh page.
+    intro = sourcedPages(Strings.source(
+      "Welcome!\fWe exchange your\ncoins for fabulous\vprizes!")),
+    which = sourcedPage(Strings.source("Which prize would\nyou like?")),
     confirm = function(name)
-      return pages(page("OK, so you wanted", ("a %s?"):format(name)))
+      return sourcedPages(Strings.source("OK, so you wanted\na %s?"), name)
     end,
-    hereYouGo = pages(page("Here you go!")),
-    notEnoughCoins = pages(page("You don't have", "enough coins.")),
-    noRoom = pages(page("You have no room", "for it.")),
-    comeAgain = pages(page("Oh. Please come", "back with coins!")),
-    noCoinCase = pages(page("Oh? You don't have", "a COIN CASE.")),
+    hereYouGo = sourcedPages(Strings.source("Here you go!")),
+    notEnoughCoins = sourcedPages(Strings.source(
+      "You don't have\nenough coins.")),
+    noRoom = sourcedPages(Strings.source("You have no room\nfor it.")),
+    comeAgain = sourcedPages(Strings.source(
+      "Oh. Please come\nback with coins!")),
+    noCoinCase = sourcedPages(Strings.source(
+      "Oh? You don't have\na COIN CASE.")),
   },
   GOLDENROD = {
-    intro = pages(page("Welcome!"),
-      page("We exchange your", "game coins for"),
-      page("fabulous prizes!")),
-    which = page("Which prize would", "you like?"),
+    -- gs.GoldenrodGameCorner.GoldenrodGameCornerPrizeVendorIntroText: same
+    -- <PARA>/<LINE>/<CONT> shape as Celadon's above.
+    intro = sourcedPages(Strings.source(
+      "Welcome!\fWe exchange your\ngame coins for\vfabulous prizes!")),
+    which = sourcedPage(Strings.source("Which prize would\nyou like?")),
     confirm = function(name)
-      return pages(page(("%s."):format(name), "Is that right?"))
+      return sourcedPages(Strings.source("%s.\nIs that right?"), name)
     end,
-    hereYouGo = pages(page("Here you go!")),
-    notEnoughCoins = pages(page("Sorry! You need", "more coins.")),
-    noRoom = pages(page("Sorry. You can't", "carry any more.")),
-    comeAgain = pages(page("OK. Please save", "your coins and"),
-      page("come again!")),
-    noCoinCase = pages(page("Oh? You don't have", "a COIN CASE.")),
+    hereYouGo = sourcedPages(Strings.source("Here you go!")),
+    notEnoughCoins = sourcedPages(Strings.source(
+      "Sorry! You need\nmore coins.")),
+    noRoom = sourcedPages(Strings.source(
+      "Sorry. You can't\ncarry any more.")),
+    -- gs.GoldenrodGameCorner.GoldenrodGameCornerPrizeVendorQuitText:
+    -- <LINE> then <CONT>, a scroll, not a fresh page.
+    comeAgain = sourcedPages(Strings.source(
+      "OK. Please save\nyour coins and\vcome again!")),
+    noCoinCase = sourcedPages(Strings.source(
+      "Oh? You don't have\na COIN CASE.")),
   },
   COIN_VENDOR = {
-    intro = pages(page("Welcome to the", "GAME CORNER.")),
-    which = page("Do you need some", "game coins?"),
+    intro = sourcedPages(Strings.source("Welcome to the\nGAME CORNER.")),
+    which = sourcedPage(Strings.source("Do you need some\ngame coins?")),
     bought = {
-      [50] = pages(page("Thank you!", "Here are 50 coins.")),
-      [500] = pages(page("Thank you! Here", "are 500 coins.")),
+      [50] = sourcedPages(Strings.source("Thank you!\nHere are 50 coins.")),
+      [500] = sourcedPages(Strings.source(
+        "Thank you! Here\nare 500 coins.")),
     },
-    notEnoughMoney = pages(page("You don't have", "enough money.")),
-    caseFull = pages(page("Whoops! Your COIN", "CASE is full.")),
-    comeAgain = pages(page("No coins for you?", "Come again!")),
-    noCoinCase = pages(page("Do you need game", "coins?"),
-      page("Oh, you don't have", "a COIN CASE for"),
-      page("your coins.")),
+    notEnoughMoney = sourcedPages(Strings.source(
+      "You don't have\nenough money.")),
+    caseFull = sourcedPages(Strings.source(
+      "Whoops! Your COIN\nCASE is full.")),
+    comeAgain = sourcedPages(Strings.source(
+      "No coins for you?\nCome again!")),
+    -- gs.std_text.CoinVendor_NoCoinCaseText: <LINE>, <PARA>, <LINE>, <CONT> --
+    -- only the last transition scrolls.
+    noCoinCase = sourcedPages(Strings.source(
+      "Do you need game\ncoins?\fOh, you don't have\na COIN CASE for\vyour coins.")),
   },
 }
 
@@ -358,7 +411,7 @@ function PrizeMenu:buildPrizes()
       local swapped = {}
       for k, v in pairs(prize) do swapped[k] = v end
       swapped.id = prize.silver.id
-      swapped.label = prize.silver.label
+      swapped.name = prize.silver.name
       swapped.silver = nil
       out[i] = swapped
     else
@@ -366,16 +419,16 @@ function PrizeMenu:buildPrizes()
     end
   end
   -- Every counter's menu data ends with a literal CANCEL row.
-  out[#out + 1] = { cancel = true, label = "CANCEL" }
+  out[#out + 1] = { cancel = true, label = Strings.source("CANCEL") }
   self.prizes = out
 end
 
 function PrizeMenu:say(list, onDone)
-  self.message = { pages = list or {}, page = 1, onDone = onDone }
+  self.message = { pages = localizedPages(list), page = 1, onDone = onDone }
 end
 
 function PrizeMenu:ask(list, onYes, onNo)
-  self.confirm = { pages = list or {}, page = 1, choice = 1,
+  self.confirm = { pages = localizedPages(list), page = 1, choice = 1,
     onYes = onYes, onNo = onNo }
 end
 
@@ -529,9 +582,31 @@ end
 -- ------------------------------------------------------------------- draw
 function PrizeMenu:drawCoinBox()
   Chrome.textbox(COIN_BOX_X, COIN_BOX_Y, COIN_BOX_W - 2, COIN_BOX_H - 2)
-  Chrome.print("COIN", COIN_LABEL_X, COIN_LABEL_Y)
+  Chrome.print(Strings("COIN"), COIN_LABEL_X, COIN_LABEL_Y)
   Chrome.print(Chrome.number(PrizeMenu.coins(self.save), 4, true),
     COIN_VALUE_X, COIN_VALUE_Y)
+end
+
+-- Glyph-aware (Font.split), so a multi-byte UTF-8 character or a <PK><MN>
+-- macro is never cut mid-sequence: a translated name longer than the tile
+-- budget before the price column would otherwise overlap or run into the
+-- price digits Chrome.print draws right after it.
+local function clampToTiles(text, maxTiles)
+  local spans = Font.split(text)
+  if #spans <= maxTiles then return text end
+  -- maxTiles can land inside a macro's multi-glyph expansion (Font.split's
+  -- "#" -> POKé, four spans that all share one source byte's `to`); cutting
+  -- there with text:sub would still copy the whole source byte, which
+  -- re-expands to all four glyphs on the next Font.split and overshoots the
+  -- budget. Back up to the last span whose source byte the next span does
+  -- NOT share, so an in-progress expansion is dropped whole rather than
+  -- included whole past its budget.
+  local cut = maxTiles
+  while cut > 0 and spans[cut].to == spans[cut + 1].to do
+    cut = cut - 1
+  end
+  if cut == 0 then return "" end
+  return text:sub(1, spans[cut].to)
 end
 
 function PrizeMenu:drawPanel()
@@ -543,7 +618,16 @@ function PrizeMenu:drawPanel()
     for i, prize in ipairs(self.prizes) do
       local ty = menu.y + 2 + (i - 1) * 2
       if i == self.index then Chrome.cursor(menu.x + 1, ty) end
-      Chrome.print(prize.label, menu.x + 2, ty)
+      if prize.name then
+        local priceText = tostring(prize.cost)
+        -- -2, not -1: leaves at least one blank tile between the name and
+        -- the price, same as the original hand-padded literals always did.
+        local nameBudget = self.counter.priceRight - #priceText - 2
+        Chrome.print(clampToTiles(Strings(prize.name), nameBudget), menu.x + 2, ty)
+        Chrome.print(priceText, menu.x + self.counter.priceRight - #priceText + 1, ty)
+      else
+        Chrome.print(Strings(prize.label), menu.x + 2, ty)
+      end
     end
   end
   local lines = nil
@@ -552,7 +636,7 @@ function PrizeMenu:drawPanel()
   elseif self.message then
     lines = self.message.pages[self.message.page]
   elseif self.phase == "menu" then
-    lines = self.text.which
+    lines = localizedPage(self.text.which)
   end
   if lines then
     Chrome.textbox(TEXT_BOX_X, TEXT_BOX_Y, TEXT_BOX_W - 2, TEXT_BOX_H - 2)
@@ -562,8 +646,8 @@ function PrizeMenu:drawPanel()
   end
   if self.confirm and self.confirm.page >= #self.confirm.pages then
     Chrome.textbox(YESNO_X, YESNO_Y, YESNO_W - 2, YESNO_H - 2)
-    Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-    Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+    Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+    Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
     Chrome.cursor(YESNO_X + 1, YESNO_Y + 1 + (self.confirm.choice - 1) * 2)
   end
 end

--- a/src/ui/gen2/SlotMachine.lua
+++ b/src/ui/gen2/SlotMachine.lua
@@ -46,6 +46,7 @@
 local Chrome = require("src.ui.gen2.Chrome")
 local CoinCase = require("src.core.gen2.CoinCase")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 
 local SlotMachine = {}
 SlotMachine.__index = SlotMachine
@@ -609,20 +610,65 @@ local TEXT_X, TEXT_Y, TEXT_LINE = 1, 14, 2
 -- data/text/common_2.asm and common_3.asm.  None of these are in the cache's
 -- text.lua: no script bytecode points at them, so the extractor -- which walks
 -- reachable script pointers -- never reaches them.
+local function splitLines(text)
+  local out = {}
+  for line in (text .. "\n"):gmatch("(.-)\n") do
+    out[#out + 1] = line
+  end
+  return out
+end
+
+-- `english` is derived from `source` once here rather than typed out a
+-- second time, so the two cannot drift apart when the English wording
+-- changes.
+local function staticText(source)
+  return { source = source, english = splitLines(source) }
+end
+
 local TEXTS = {
-  betHowMany = { "Bet how many", "coins?" },      -- _SlotsBetHowManyCoinsText
-  start = { "Start!" },                            -- _SlotsStartText
-  notEnough = { "Not enough", "coins." },          -- _SlotsNotEnoughCoinsText
-  ranOut = { "Darn… Ran out of", "coins…" },       -- _SlotsRanOutOfCoinsText
-  playAgain = { "Play again?" },                   -- _SlotsPlayAgainText
-  darn = { "Darn!" },                              -- _SlotsDarnText
+  betHowMany = staticText(Strings.source("Bet how many\ncoins?")),
+  start = staticText(Strings.source("Start!")),
+  notEnough = staticText(Strings.source("Not enough\ncoins.")),
+  ranOut = staticText(Strings.source("Darn… Ran out of\ncoins…")),
+  playAgain = staticText(Strings.source("Play again?")),
+  darn = staticText(Strings.source("Darn!")),
 }
 SlotMachine.TEXTS = TEXTS
+
+-- Keyed by the `lines` table itself (weak so a freshly built linedUpLines()
+-- table cannot leak): draw() calls localizedLines() every frame the bet/
+-- result screens are up, but the split only changes if the translated text
+-- does, so re-running the gmatch loop every frame is wasted work.
+local lineCache = setmetatable({}, { __mode = "k" })
+
+-- Deliberately \n-only, unlike CommonText.pages/pagesOf elsewhere in Gen2
+-- UI: every entry in TEXTS above is a fixed two-line (or shorter) cart
+-- message, and the box it draws into (TEXT_BOX_H = 6, TEXT_LINE = 2) only
+-- has room for two printed lines before a third would land past its bottom
+-- edge. The draw loops above have no page break at all, so a translation
+-- that needs a third line here would silently overflow instead of
+-- paginating -- route through CommonText.pages instead if that is ever
+-- needed.
+local function localizedLines(lines)
+  if not (lines and lines.source) then return lines or {} end
+  local translated
+  if lines.args then
+    translated = Strings(lines.source, unpack(lines.args))
+  else
+    translated = Strings(lines.source)
+  end
+  if translated == lines.source then return lines.english or splitLines(translated) end
+  local cached = lineCache[lines]
+  if cached and cached.text == translated then return cached.lines end
+  local out = splitLines(translated)
+  lineCache[lines] = { text = translated, lines = out }
+  return out
+end
 
 -- _SlotsLinedUpText: "lined up!" / "Won @<wStringBuffer2> coins!", with the
 -- matched symbol's 2x2 tiles printed to its left by .Text_PrintPayout.
 local function linedUpLines(payout)
-  return { "    lined up!", ("Won %d coins!"):format(payout) }
+  return { source = Strings.source("    lined up!\nWon %d coins!"), args = { payout } }
 end
 
 -- Slots_PlaySFX's labels, spelled the pokegold way (Sound.GEN2_ALIASES is what
@@ -1440,7 +1486,7 @@ end
 function SlotMachine:drawMessage()
   if not self.message then return end
   Chrome.textbox(TEXT_BOX_X, TEXT_BOX_Y, TEXT_BOX_W - 2, TEXT_BOX_H - 2)
-  for i, line in ipairs(self.message) do
+  for i, line in ipairs(localizedLines(self.message)) do
     Chrome.print(line, TEXT_X, TEXT_Y + (i - 1) * TEXT_LINE)
   end
   if self.matched and self.matched ~= SlotMachine.NO_MATCH
@@ -1492,8 +1538,9 @@ function SlotMachine:drawPanel()
   if self.phase == "bet" then
     -- Left speech textbox for "Bet how many coins?"
     Chrome.textbox(0, 12, 12, 4)
-    Chrome.print(TEXTS.betHowMany[1], 1, 14)
-    Chrome.print(TEXTS.betHowMany[2], 1, 16)
+    local betLines = localizedLines(TEXTS.betHowMany)
+    Chrome.print(betLines[1] or "", 1, 14)
+    Chrome.print(betLines[2] or "", 1, 16)
 
     -- Right menu for bet choices (14, 10 to 19, 17)
     Chrome.textbox(14, 10, 4, 6)
@@ -1506,19 +1553,19 @@ function SlotMachine:drawPanel()
     if self.message then
       -- If "Not enough coins." message is shown, overlay full speech box
       Chrome.textbox(0, 12, 18, 4)
-      for i, line in ipairs(self.message) do
+      for i, line in ipairs(localizedLines(self.message)) do
         Chrome.print(line, TEXT_X, TEXT_Y + (i - 1) * TEXT_LINE)
       end
     end
   elseif self.phase == "again" then
     -- Speech box: "Play again?"
     Chrome.textbox(0, 12, 18, 4)
-    Chrome.print(TEXTS.playAgain[1], TEXT_X, TEXT_Y)
+    Chrome.print(localizedLines(TEXTS.playAgain)[1] or "", TEXT_X, TEXT_Y)
 
     -- PlaceYesNoBox at (14, 12): 6x5 box with YES at (16,13), NO at (16,15)
     Chrome.textbox(14, 12, 4, 3)
-    Chrome.print("YES", 16, 13)
-    Chrome.print("NO", 16, 15)
+    Chrome.print(Strings("YES"), 16, 13)
+    Chrome.print(Strings("NO"), 16, 15)
     Chrome.cursor(15, 13 + (self.againChoice - 1) * 2)
   else
     self:drawMessage()

--- a/src/ui/gen2/StartMenu.lua
+++ b/src/ui/gen2/StartMenu.lua
@@ -23,6 +23,7 @@ local Chrome = require("src.ui.gen2.Chrome")
 local Logger = require("src.core.Logger")
 local Runtime = require("src.mods.Runtime")
 local Sound = require("src.core.Sound")
+local Strings = require("src.core.Strings")
 
 local StartMenu = {}
 StartMenu.__index = StartMenu
@@ -46,48 +47,48 @@ StartMenu.isOpaque = false
 -- exactly what kept POKéGEAR hanging off the menu box's right edge.
 local ITEMS = {
   {
-    id = "pokedex", label = "POKéDEX", need = "pokedex",
-    desc = { "POKéMON", "database" },
+    id = "pokedex", label = Strings.source("POKéDEX"), need = "pokedex",
+    desc = Strings.source("POKéMON\ndatabase"),
   },
   {
-    id = "pokemon", label = "POKéMON", need = "party",
-    desc = { "Party <PK><MN>", "status" },
+    id = "pokemon", label = Strings.source("POKéMON"), need = "party",
+    desc = Strings.source("Party <PK><MN>\nstatus"),
   },
   {
-    id = "pack", label = "PACK", need = "pack",
-    desc = { "Contains", "items" },
+    id = "pack", label = Strings.source("PACK"), need = "pack",
+    desc = Strings.source("Contains\nitems"),
   },
   {
-    id = "pokegear", label = "<PO><KE>GEAR", need = "pokegear",
-    desc = { "Trainer's", "key device" },
+    id = "pokegear", label = Strings.source("<PO><KE>GEAR"), need = "pokegear",
+    desc = Strings.source("Trainer's\nkey device"),
   },
   {
     -- The player's own name is the label (.StatusString is "<PLAYER>").
     id = "status", label = nil,
-    desc = { "Your own", "status" },
+    desc = Strings.source("Your own\nstatus"),
   },
   {
-    id = "save", label = "SAVE",
-    desc = { "Save your", "progress" },
+    id = "save", label = Strings.source("SAVE"),
+    desc = Strings.source("Save your\nprogress"),
   },
   {
-    id = "option", label = "OPTION",
-    desc = { "Change", "settings" },
+    id = "option", label = Strings.source("OPTION"),
+    desc = Strings.source("Change\nsettings"),
   },
   {
     -- The mod manager's discoverable home, exactly as the Gen 1 start menu
     -- carries it: the row only appears once at least one mod has been
     -- discovered, so a vanilla install's menu is the cart's.
-    id = "mods", label = "MODS", need = "mods",
-    desc = { "Installed", "add-ons" },
+    id = "mods", label = Strings.source("MODS"), need = "mods",
+    desc = Strings.source("Installed\nadd-ons"),
   },
   {
     -- The cart's EXIT just closed the menu (CloseStartMenu).  A window with a
     -- close button already covers that, so -- exactly as the Gen 1 port does
     -- (src/ui/StartMenu.lua) -- this row is QUIT and power-cycles back to the
     -- title after a confirmation that defaults to NO.
-    id = "quit", label = "QUIT",
-    desc = { "Return to", "the title" },
+    id = "quit", label = Strings.source("QUIT"),
+    desc = Strings.source("Return to\nthe title"),
   },
 }
 
@@ -125,6 +126,18 @@ function StartMenu.new(game, opts)
   else
     Logger.error("ui.start_menu.items returned %s; keeping the vanilla items",
                  type(hooked))
+  end
+  -- Let hooks inspect the cart's stable source labels. Translate only the
+  -- built-in rows afterwards; mod-supplied labels are content and stay raw.
+  for _, item in ipairs(items) do
+    if item.translateLabel then item.label = Strings(item.label) end
+    if item.translateDesc then
+      local translated = Strings(item.desc)
+      item.desc = {}
+      for line in (translated .. "\n"):gmatch("(.-)\n") do
+        item.desc[#item.desc + 1] = line
+      end
+    end
   end
   self.items = items
   local options = (self.save and self.save.options) or {}
@@ -189,6 +202,8 @@ function StartMenu:visibleItems()
         label = item.label or playerName,
         value = item.id,
         desc = item.desc,
+        translateLabel = item.label ~= nil,
+        translateDesc = item.desc ~= nil,
       }
     end
   end
@@ -279,11 +294,13 @@ function StartMenu:draw()
 
   if self.phase == "confirm" then
     Chrome.textbox(0, 12, 18, 4)
-    Chrome.print("Return to the", 1, 14)
-    Chrome.print("title screen?", 1, 16)
+    local prompt = Strings(Strings.source("Return to the\ntitle screen?"))
+    local first, second = prompt:match("^([^\n]*)\n?(.*)$")
+    Chrome.print(first or "", 1, 14)
+    Chrome.print(second or "", 1, 16)
     Chrome.box(YESNO_X, YESNO_Y, YESNO_W, YESNO_H)
-    Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-    Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+    Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+    Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
     Chrome.cursor(YESNO_X + 1,
       YESNO_Y + (self.confirmChoice == 1 and 1 or 3))
     return

--- a/src/ui/gen2/SummaryMenu.lua
+++ b/src/ui/gen2/SummaryMenu.lua
@@ -63,10 +63,13 @@ local Font = require("src.render.Font")
 local GbcPalette = require("src.render.GbcPalette")
 local HpBar = require("src.battle.gen2.HpBar")
 local ItemEffects = require("src.core.gen2.ItemEffects")
+local Status = require("src.battle.Status")
+local TypeChart = require("src.battle.TypeChart")
 local Mon = require("src.battle.gen2.Mon")
 local MonAnimView = require("src.render.MonAnimView")
 local Palettes = require("src.world.gen2.Palettes")
 local Pokerus = require("src.core.gen2.Pokerus")
+local Strings = require("src.core.Strings")
 local Unown = require("src.core.gen2.Unown")
 
 local SummaryMenu = {}
@@ -114,17 +117,25 @@ local PAGE_TINTS = {
 -- PrintTempMonStats' .StatNames, and the wTempMon fields it prints beside
 -- them.  <NEXT> steps two rows, so the five labels are 2 rows apart and the
 -- values start one row below the first label.
-local STAT_LABELS = { "ATTACK", "DEFENSE", "SPCL.ATK", "SPCL.DEF", "SPEED" }
+local STAT_LABELS = {
+  Strings.source("ATTACK"), Strings.source("DEFENSE"),
+  Strings.source("SPCL.ATK"), Strings.source("SPCL.DEF"),
+  Strings.source("SPEED"),
+}
 local STAT_KEYS = {
   "attack", "defense", "specialAttack", "specialDefense", "speed",
 }
 
--- data/types/names.asm.  Every type constant prints as its own name except
--- the two the extractor has to disambiguate against Lua-unfriendly ids.
-local TYPE_NAMES = {
-  PSYCHIC_TYPE = "PSYCHIC",
-  CURSE_TYPE = "???",
-}
+local FAINTED_LABEL = Strings.source("FNT")
+local OK_LABEL = Strings.source("OK")
+local POKERUS_LABEL = Strings.source("POKéRUS")
+local TO_LABEL = Strings.source("TO")
+local PP_LABEL = Strings.source("PP")
+local ATTACK_POWER_LABEL = Strings.source("ATTK/")
+local OT_LABEL = Strings.source("OT/")
+local ID_LABEL = Strings.source("<ID>№.")
+local DEX_NUMBER_LABEL = Strings.source("№.")
+local EGG_LABEL = Strings.source("EGG")
 
 -- Gen 2 pics are 5x5, 6x6 or 7x7 and PadFrontpic centres the small ones in
 -- the 7x7 block PrepMonFrontpic lays at hlcoord 0, 0.  Same table the dex
@@ -143,18 +154,15 @@ end
 -- are the ASM's own `cp $6 / cp $b / cp $29` ladder, and the lines join with
 -- <NEXT> exactly as the db/next strings do.
 local EGG_FLAVOR = {
-  { below = 0x6, text = "It's making sounds<NEXT>inside. It's going"
-      .. "<NEXT>to hatch soon!" },
-  { below = 0xb, text = "It moves around<NEXT>inside sometimes."
-      .. "<NEXT>It must be close<NEXT>to hatching." },
-  { below = 0x29, text = "Wonder what's<NEXT>inside? It needs"
-      .. "<NEXT>more time, though." },
-  { text = "This EGG needs a<NEXT>lot more time to<NEXT>hatch." },
+  { below = 0x6, text = Strings.source("It's making sounds<NEXT>inside. It's going<NEXT>to hatch soon!") },
+  { below = 0xb, text = Strings.source("It moves around<NEXT>inside sometimes.<NEXT>It must be close<NEXT>to hatching.") },
+  { below = 0x29, text = Strings.source("Wonder what's<NEXT>inside? It needs<NEXT>more time, though.") },
+  { text = Strings.source("This EGG needs a<NEXT>lot more time to<NEXT>hatch.") },
 }
 
 local function eggFlavor(cycles)
   for _, entry in ipairs(EGG_FLAVOR) do
-    if not entry.below or cycles < entry.below then return entry.text end
+    if not entry.below or cycles < entry.below then return Strings(entry.text) end
   end
 end
 
@@ -219,12 +227,19 @@ end
 -- PlaceStatusString (engine/pokemon/mon_stats.asm): three letters, and a mon
 -- with no HP reads FNT whatever its status byte says.  Same lookup the party
 -- list makes; both screens call the same routine on the cart.
-local function statusText(mon)
-  if (mon.hp or 0) <= 0 then return "FNT" end
+local function statusText(mon, statuses)
+  if (mon.hp or 0) <= 0 then return Strings(FAINTED_LABEL) end
   local status = mon.status
   if not status then return nil end
-  local class = ItemEffects.STATUS_CLASS[tostring(status):lower()]
-  return class and class:upper()
+  local key = tostring(status):lower()
+  if statuses and statuses[key] then
+    return Strings(Status.hudLabelFor(statuses, key))
+  end
+  local class = ItemEffects.STATUS_CLASS[key]
+  if not class then return nil end
+  if not statuses then return class:upper() end
+  local id = Status.GEN2_ID_ALIASES[key] or key
+  return Strings(Status.hudLabelFor(statuses, id))
 end
 
 -- wTempMonPokerusStatus is one byte: the low nibble counts the days left and
@@ -431,7 +446,7 @@ function SummaryMenu:typeNames()
   local second = types[2] or first
   local function name(id)
     if not id then return nil end
-    return TYPE_NAMES[id] or id
+    return TypeChart.displayName(id, self.game and self.game.data)
   end
   -- PrintMonTypes' .hide_type_2: a single-typed mon really has two of the same
   -- type, and the second name is blanked rather than printed twice.
@@ -448,7 +463,7 @@ function SummaryMenu:upperPlacements()
   local out = {}
   -- (8,0) '№' and (9,0) '.' are two `ld [hl]` writes, then PrintNum puts the
   -- dex number in three leading-zero digits at (10,0).
-  put(out, "№.", 8, 0)
+  put(out, Strings(DEX_NUMBER_LABEL), 8, 0)
   put(out, num(def and def.dex or 0, 3, true), 10, 0)
   put(out, levelText(mon.level), 14, 0)
   put(out, mon.nickname or mon.name or mon.species, 8, 2)
@@ -481,16 +496,17 @@ function SummaryMenu:pinkPlacements()
 
   -- .Status_Type is "STATUS/" <NEXT> "TYPE/", and <NEXT> is two rows down at
   -- the same column -- so the second label is at row 14, not row 13.
-  put(out, "STATUS/", 0, 12)
-  put(out, "TYPE/", 0, 14)
+  put(out, Strings("STATUS/"), 0, 12)
+  put(out, Strings("TYPE/"), 0, 14)
 
   local pokerus = pokerusState(mon)
   if pokerus == "infected" then
     -- .PkrsStr is "#RUS", and '#' is the four-tile POKé compression byte.
-    put(out, "POKéRUS", 1, 13)
+    put(out, Strings(POKERUS_LABEL), 1, 13)
   else
     if pokerus == "immune" then put(out, ".", 8, 8) end
-    put(out, statusText(mon) or "OK", 6, 13)
+    put(out, statusText(mon, self.game and self.game.data
+      and self.game.data.gen2Statuses) or Strings(OK_LABEL), 6, 13)
   end
 
   -- PrintMonTypes writes type 1 at (1,15) and type 2 two rows below it, and
@@ -500,13 +516,13 @@ function SummaryMenu:pinkPlacements()
   put(out, type1, 1, 15)
   put(out, type2, 1, 16)
 
-  put(out, "EXP POINTS", 10, 9)
+  put(out, Strings("EXP POINTS"), 10, 9)
   -- `lb bc, 3, 7`: a three-byte value in seven columns, so the field runs
   -- (13,10) to (19,10).
   put(out, num(mon.experience, 7), 13, 10)
-  put(out, "LEVEL UP", 10, 12)
+  put(out, Strings("LEVEL UP"), 10, 12)
   put(out, num(self:expToNext(), 7), 13, 13)
-  put(out, "TO", 14, 14)
+  put(out, Strings(TO_LABEL), 14, 14)
   -- The level printed at (17,14) is the NEXT one: LoadPinkPage bumps
   -- wTempMonLevel, calls PrintLevel, and puts it back.  MAX_LEVEL stays put.
   local level = mon.level or 1
@@ -518,9 +534,9 @@ end
 
 function SummaryMenu:greenPlacements()
   local out = {}
-  put(out, "ITEM", 0, 8)
+  put(out, Strings("ITEM"), 0, 8)
   put(out, self:itemName() or "---", 6, 8)
-  put(out, "MOVE", 0, 10)
+  put(out, Strings("MOVE"), 0, 10)
 
   -- ListMoves runs from (8,10) with wListMovesLineSpacing = SCREEN_WIDTH * 2,
   -- so the four names are two rows apart; ListMovePP runs from (12,11) with
@@ -535,7 +551,7 @@ function SummaryMenu:greenPlacements()
       put(out, self:moveName(entry), 8, nameY)
       -- Two $3e "P" tiles: `ld [hli], a` then `ld [hld], a` writes the same
       -- tile at (12,y) and (13,y).
-      put(out, "PP", 12, ppY)
+      put(out, Strings(PP_LABEL), 12, ppY)
       -- `pop hl` then three `inc hl` lands the numbers at (15,y): two digits,
       -- the '/' PrintNum's caller writes, then two more.
       put(out, num(entry.pp, 2), 15, ppY)
@@ -556,9 +572,9 @@ function SummaryMenu:bluePlacements()
   local out = {}
   -- IDNoString is "<ID>№." -- three single tiles, not the seven letters of
   -- "ID No." -- and OTString is "OT/".
-  put(out, "<ID>№.", 0, 9)
+  put(out, Strings(ID_LABEL), 0, 9)
   put(out, num(self:otId(), 5, true), 2, 10)
-  put(out, "OT/", 0, 12)
+  put(out, Strings(OT_LABEL), 0, 12)
   local ot = self:otName()
   put(out, ot, SummaryMenu.otColumn(ot), 13)
 
@@ -566,7 +582,7 @@ function SummaryMenu:bluePlacements()
   -- two rows apart, then `add hl, bc` and one more SCREEN_WIDTH puts the first
   -- value at (17,9) -- three columns wide, so every value ends at column 19.
   for i, label in ipairs(STAT_LABELS) do
-    put(out, label, 11, 8 + (i - 1) * 2)
+    put(out, Strings(label), 11, 8 + (i - 1) * 2)
     local value = (mon.stats or {})[STAT_KEYS[i]]
     put(out, num(value, 3), 17, 9 + (i - 1) * 2)
   end
@@ -597,7 +613,7 @@ function SummaryMenu:moveDetailPlacements()
     local entry = moves[slot]
     if entry then
       put(out, self:moveName(entry), 2, nameY)
-      put(out, "PP", 10, ppY)
+      put(out, Strings(PP_LABEL), 10, ppY)
       put(out, num(entry.pp, 2), 13, ppY)
       put(out, "/", 15, ppY)
       put(out, num(entry.maxPp or entry.pp, 2), 16, ppY)
@@ -613,20 +629,21 @@ function SummaryMenu:moveDetailPlacements()
     put(out, "┌─────┐", 0, 10)
     put(out, "│", 0, 11)
     put(out, "└", 6, 11)
-    put(out, "Where?", 1, 12)
+    put(out, Strings("Where?"), 1, 12)
     return out
   end
 
   -- String_MoveType_Top / _Bottom are box-drawing glyphs, and the plaque is
   -- open on its right: "┌─────┐" over "│TYPE/└".
   put(out, "┌─────┐", 0, 10)
-  put(out, "│TYPE/└", 0, 11)
-  put(out, "ATTK/", 11, 12)
+  put(out, "│" .. Strings("TYPE/") .. "└", 0, 11)
+  put(out, Strings(ATTACK_POWER_LABEL), 11, 12)
 
   local entry = moves[self.moveIndex]
   local def = entry and self:moveDef(entry.id)
   local moveType = def and def.type
-  put(out, moveType and (TYPE_NAMES[moveType] or moveType) or "---", 2, 12)
+  put(out, moveType and TypeChart.displayName(moveType,
+    self.game and self.game.data) or "---", 2, 12)
   -- `cp 2; jr c, .no_power`: a move with power 0 or 1 prints String_MoveNoPower
   -- rather than a number.
   local power = (def and def.power) or 0
@@ -660,12 +677,12 @@ end
 function SummaryMenu:eggPlacements()
   local mon = self.mon or {}
   local out = {}
-  put(out, "EGG", 8, 1)
+  put(out, Strings(EGG_LABEL), 8, 1)
   -- IDNoString / OTString, the same strings the blue page prints, with
   -- FiveQMarkString beside each: an egg's OT and ID are hidden.
-  put(out, "<ID>№.", 8, 3)
+  put(out, Strings(ID_LABEL), 8, 3)
   put(out, "?????", 11, 3)
-  put(out, "OT/", 8, 5)
+  put(out, Strings(OT_LABEL), 8, 5)
   put(out, "?????", 11, 5)
   local ty = 9
   for line in ((eggFlavor(mon.eggSteps or 0) or "") .. "<NEXT>")
@@ -1287,7 +1304,6 @@ end
 
 SummaryMenu.STAT_LABELS = STAT_LABELS
 SummaryMenu.STAT_KEYS = STAT_KEYS
-SummaryMenu.TYPE_NAMES = TYPE_NAMES
 SummaryMenu.PAGE_PALETTES = PAGE_PALETTES
 SummaryMenu.PAGE_TINTS = PAGE_TINTS
 SummaryMenu.levelText = levelText

--- a/src/ui/gen2/TradeMenu.lua
+++ b/src/ui/gen2/TradeMenu.lua
@@ -331,8 +331,8 @@ end
 
 function TradeMenu:drawYesNo(choice)
   Chrome.box(YESNO_X, YESNO_Y, YESNO_W, YESNO_H)
-  Chrome.print("YES", YESNO_X + 2, YESNO_Y + 1)
-  Chrome.print("NO", YESNO_X + 2, YESNO_Y + 3)
+  Chrome.print(Strings("YES"), YESNO_X + 2, YESNO_Y + 1)
+  Chrome.print(Strings("NO"), YESNO_X + 2, YESNO_Y + 3)
   Chrome.cursor(YESNO_X + 1, YESNO_Y + (choice == 1 and 1 or 3))
 end
 

--- a/src/ui/gen2/TrainerCard.lua
+++ b/src/ui/gen2/TrainerCard.lua
@@ -38,8 +38,10 @@
 -- leader's own palette.
 
 local Chrome = require("src.ui.gen2.Chrome")
+local Font = require("src.render.Font")
 local GbcPalette = require("src.render.GbcPalette")
 local Gen2Save = require("src.core.gen2.Save")
+local Strings = require("src.core.Strings")
 local TileSheet = require("src.ui.gen2.TileSheet")
 
 local TrainerCard = {}
@@ -62,12 +64,38 @@ local TILE_COLON = 0x2e
 
 -- Johto then Kanto, in badge order.
 local JOHTO_BADGES = {
-  "ZEPHYR", "HIVE", "PLAIN", "FOG", "STORM", "MINERAL", "GLACIER", "RISING",
+  Strings.source("ZEPHYR"), Strings.source("HIVE"), Strings.source("PLAIN"),
+  Strings.source("FOG"), Strings.source("STORM"), Strings.source("MINERAL"),
+  Strings.source("GLACIER"), Strings.source("RISING"),
 }
 local KANTO_BADGES = {
-  "BOULDER", "CASCADE", "THUNDER", "RAINBOW", "SOUL", "MARSH", "VOLCANO",
-  "EARTH",
+  Strings.source("BOULDER"), Strings.source("CASCADE"),
+  Strings.source("THUNDER"), Strings.source("RAINBOW"), Strings.source("SOUL"),
+  Strings.source("MARSH"), Strings.source("VOLCANO"), Strings.source("EARTH"),
 }
+local JOHTO_BADGES_LABEL = Strings.source("JOHTO BADGES")
+local KANTO_BADGES_LABEL = Strings.source("KANTO BADGES")
+
+-- Badge captions have room for four font glyphs, not four Lua bytes.  The
+-- distinction matters as soon as a translation starts with an accented
+-- character (or uses a multi-byte charmap sequence).
+local function badgeCaption(text)
+  text = text or ""
+  local spans = Font.split(text)
+  if #spans <= 4 then return text end
+  -- Same "#" -> POKé trap src/ui/gen2/PrizeMenu.lua's clampToTiles guards
+  -- against: the 4-glyph cut can land inside a macro's multi-glyph expansion
+  -- (four spans sharing one source byte's `to`), and text:sub there would
+  -- still copy the whole source byte, re-expanding past the budget on the
+  -- next Font.split. Back up to the last span whose source byte the next
+  -- span does NOT share.
+  local cut = 4
+  while cut > 0 and spans[cut].to == spans[cut + 1].to do
+    cut = cut - 1
+  end
+  if cut == 0 then return "" end
+  return text:sub(1, spans[cut].to)
+end
 
 -- The two slots _CGB_TrainerCard swaps by gender: CHRIS and FALKNER/KrisPalette.
 -- ../pokecrystal/engine/gfx/cgb_layouts.asm:619-624, data/trainers/palettes.asm:9-12
@@ -282,12 +310,12 @@ end
 function TrainerCard:drawTopHalf()
   local player = (self.save or {}).player or {}
   self:frame(0, 5)
-  self:print("NAME/", 2, 2)
+  self:print(Strings("NAME/"), 2, 2)
   self:print(player.name or "GOLD", 7, 2)
   self:tile(self.card, TILE_ID_NO[1], 2, 4)
   self:tile(self.card, TILE_ID_NO[2], 3, 4)
   self:print(Chrome.number(player.id or 0, 5, true), 5, 4)
-  self:print("MONEY", 2, 6)
+  self:print(Strings("MONEY"), 2, 6)
   self:print(moneyText(player.money), 7, 6)
   for x = 1, 12 do self:tile(self.card, TILE_DIVIDER, x, 3) end
   self:tile(self.card, TILE_DIVIDER_END, 13, 3)
@@ -306,8 +334,8 @@ function TrainerCard:drawCard()
 
   -- `#` is the compression byte for POKé, four tiles, so spelling it out is
   -- what the cart actually draws.
-  self:print("POKéDEX", 2, 10)
-  self:print("PLAY TIME", 2, 12)
+  self:print(Strings("POKéDEX"), 2, 10)
+  self:print(Strings("PLAY TIME"), 2, 12)
   self:print(Chrome.number(self:caughtCount(), 3), 15, 10)
 
   local time = save.playTime or {}
@@ -320,7 +348,7 @@ function TrainerCard:drawCard()
   end
   self:print(Chrome.number(time.minutes or 0, 2, true), 16, 12)
 
-  self:print("BADGES", 12, 15)
+  self:print(Strings("BADGES"), 12, 15)
   self:cursor(18, 15)
 end
 
@@ -405,21 +433,21 @@ function TrainerCard:drawPlain()
   Chrome.clear()
   if self.page == 1 then
     Chrome.box(0, 0, 20, 9)
-    Chrome.printThrough("NAME/", 2, 2, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings("NAME/"), 2, 2, Chrome.DEFAULT_BOX_PALETTE)
     Chrome.printThrough(player.name or "GOLD", 7, 2, Chrome.DEFAULT_BOX_PALETTE)
-    Chrome.printThrough("ID No", 2, 4, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings("ID No"), 2, 4, Chrome.DEFAULT_BOX_PALETTE)
     Chrome.printThrough(Chrome.number(player.id or 0, 5, true), 5, 4, Chrome.DEFAULT_BOX_PALETTE)
-    Chrome.printThrough("MONEY", 2, 6, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings("MONEY"), 2, 6, Chrome.DEFAULT_BOX_PALETTE)
     Chrome.printThrough(moneyText(player.money), 7, 6, Chrome.DEFAULT_BOX_PALETTE)
     Chrome.box(0, 8, 20, 10)
-    Chrome.printThrough("POKéDEX", 2, 10, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings("POKéDEX"), 2, 10, Chrome.DEFAULT_BOX_PALETTE)
     Chrome.printThrough(Chrome.number(self:caughtCount(), 3), 15, 10, Chrome.DEFAULT_BOX_PALETTE)
-    Chrome.printThrough("PLAY TIME", 2, 12, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings("PLAY TIME"), 2, 12, Chrome.DEFAULT_BOX_PALETTE)
     local time = save.playTime or {}
     Chrome.printThrough(Chrome.number(time.hours or 0, 4), 11, 12, Chrome.DEFAULT_BOX_PALETTE)
     Chrome.printThrough(":", 15, 12, Chrome.DEFAULT_BOX_PALETTE)
     Chrome.printThrough(Chrome.number(time.minutes or 0, 2, true), 16, 12, Chrome.DEFAULT_BOX_PALETTE)
-    Chrome.printThrough("BADGES", 12, 15, Chrome.DEFAULT_BOX_PALETTE)
+    Chrome.printThrough(Strings("BADGES"), 12, 15, Chrome.DEFAULT_BOX_PALETTE)
     Chrome.cursorThrough(18, 15, Chrome.DEFAULT_BOX_PALETTE)
     return
   end
@@ -431,14 +459,14 @@ function TrainerCard:drawPlain()
   -- player.badges on both pages to match.
   local held = player.badges or {}
   Chrome.box(0, 0, 20, 9)
-  Chrome.printThrough(self.page == 2 and "JOHTO BADGES" or "KANTO BADGES", 2, 2,
-    Chrome.DEFAULT_BOX_PALETTE)
+  Chrome.printThrough(Strings(self.page == 2 and JOHTO_BADGES_LABEL or
+    KANTO_BADGES_LABEL), 2, 2, Chrome.DEFAULT_BOX_PALETTE)
   Chrome.box(0, 8, 20, 10)
   for i, name in ipairs(names) do
     local tx = 2 + ((i - 1) % 4) * 4
     local ty = 10 + math.floor((i - 1) / 4) * 3
-    Chrome.printThrough((held[i] or held[name]) and name:sub(1, 4) or "----", tx, ty,
-      Chrome.DEFAULT_BOX_PALETTE)
+    local label = (held[i] or held[name]) and badgeCaption(Strings(name)) or "----"
+    Chrome.printThrough(label, tx, ty, Chrome.DEFAULT_BOX_PALETTE)
   end
 end
 

--- a/src/world/OverworldController.lua
+++ b/src/world/OverworldController.lua
@@ -3225,8 +3225,10 @@ function OverworldState:openPC(onDone)
   -- PC session (#695); the sub-PC screens (BoxMenu, PlayerPC) already
   -- use keepOpen for their own rows, matching the original ROM's flow
   -- where the main menu stays underneath.
+  local boxPcLabel = metBill and Strings.source("BILL'S PC")
+                              or Strings.source("SOMEONE'S PC")
   table.insert(items, {
-    label = metBill and "BILL'S PC" or Strings("SOMEONE'S PC"),
+    label = boxPcLabel,
     keepOpen = true,
     onSelect = function()
       require("src.core.Sound").play(Game.data, "Enter_PC")
@@ -3244,8 +3246,10 @@ function OverworldState:openPC(onDone)
   })
 
   -- the player's item storage is always available
+  local playerName = Game.save.player.name or "RED"
+  local playerPcLabel = Strings.source("%s's PC"):format(playerName)
   table.insert(items, {
-    label = (Game.save.player.name or "RED") .. "'s PC",
+    label = playerPcLabel,
     keepOpen = true,
     onSelect = function()
       -- pc.asm .playersPC plays SFX_ENTER_PC then prints AccessedMyPCText
@@ -3262,7 +3266,7 @@ function OverworldState:openPC(onDone)
   -- Prof. Oak's dex rating only appears once you have the Pokédex
   if flags.EVENT_GOT_POKEDEX then
     table.insert(items, {
-      label = Strings("PROF.OAK's PC"),
+      label = Strings.source("PROF.OAK's PC"),
       keepOpen = true,
       onSelect = function()
         -- pc.asm OaksPC plays SFX_ENTER_PC before the farcall (#960)
@@ -3274,7 +3278,7 @@ function OverworldState:openPC(onDone)
     -- engine/pokemon/bills_pc.asm:48-60 PKMN LEAGUE row (#1566)
     if #(Game.save.hallOfFame or {}) > 0 then
       table.insert(items, {
-        label = Strings("<PK><MN>LEAGUE"),
+        label = Strings.source("<PK><MN>LEAGUE"),
         keepOpen = true,
         onSelect = function()
           -- pc.asm PKMNLeague plays SFX_ENTER_PC, then PKMNLeaguePC prints
@@ -3296,6 +3300,22 @@ function OverworldState:openPC(onDone)
   else
     Logger.error("ui.pc.items returned %s; keeping the vanilla items",
                  type(hooked))
+  end
+
+  -- Hooks identify the vanilla rows by their English source labels.  Delay
+  -- localization until after ui.pc.items has inspected/reordered/replaced
+  -- them, then translate any source labels it chose to retain.
+  local translatedLabels = {
+    [boxPcLabel] = function()
+      return metBill and Strings("BILL'S PC") or Strings("SOMEONE'S PC")
+    end,
+    [playerPcLabel] = function() return Strings("%s's PC", playerName) end,
+    ["PROF.OAK's PC"] = function() return Strings("PROF.OAK's PC") end,
+    ["<PK><MN>LEAGUE"] = function() return Strings("<PK><MN>LEAGUE") end,
+  }
+  for _, item in ipairs(items) do
+    local translate = translatedLabels[item.label]
+    if translate then item.label = translate() end
   end
 
   local logOff = function()
@@ -3481,7 +3501,8 @@ function OverworldState:nurseHeal(onDone, npc)
         end
       end))
     end)
-  end, choiceLabels = { "HEAL", "CANCEL" }, choiceBox = Theme.healCancelBox }))
+  end, choiceLabels = { Strings("HEAL"), Strings("CANCEL") },
+    choiceBox = Theme.healCancelBox }))
 end
 
 -- pokecenter.asm bows the nurse between the two PrintText calls (#995)

--- a/tests/engine/box_menu_message_pages_test.lua
+++ b/tests/engine/box_menu_message_pages_test.lua
@@ -1,0 +1,21 @@
+-- BoxMenu.lua's messagePages() used to split only on \n/\f, grouping every
+-- two \n-separated lines into a page regardless of \f; switching it to
+-- CommonText.pages() (shared with PackMenu/PrizeMenu) fixed the missing \v
+-- handling but exposed that CommonText.pages() treats a bare \n only as the
+-- box's second row, not a page break -- a THIRD line needs \f (or \v), not a
+-- second bare \n, or it gets glued onto the second line with no separator.
+-- This pins the one BOX_FAILURE_SOURCES literal that used to rely on the old
+-- "every two \n lines is a page" behavior.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.harness")
+local CommonText = require("src.core.gen2.CommonText")
+
+local pages = CommonText.pages("You'll need a\nPOKéMON to call\fwith.")
+T.eq(#pages, 2, "the message splits into two pages")
+T.eq(pages[1][1], "You'll need a", "page 1 top row")
+T.eq(pages[1][2], "POKéMON to call", "page 1 bottom row")
+T.eq(pages[2][1], "with.", "page 2 top row, not glued onto page 1's bottom row")
+T.eq(pages[2][2], nil, "page 2 has no second row")
+
+T.finish("box_menu_message_pages_test")

--- a/tests/engine/dataset_views_lazy_validation.lua
+++ b/tests/engine/dataset_views_lazy_validation.lua
@@ -9,7 +9,9 @@ local GameVersion = require("src.core.GameVersion")
 local SaveSerializer = require("src.core.SaveSerializer")
 
 local files = {}
-Fixture.cache(files, "gold")
+Fixture.cache(files, "gold", {
+  rom_text = { _WokeUpText = "{USER} woke up!" },
+})
 local fs = T.sdk.memfs(files)
 local rawRead = fs.read
 local reads = {}
@@ -26,12 +28,15 @@ local pokemonPath = GameVersion.cachePrefix("gold")
   .. "data/generated/pokemon.lua"
 local movesPath = GameVersion.cachePrefix("gold")
   .. "data/generated/moves.lua"
+local romTextPath = GameVersion.cachePrefix("gold")
+  .. "data/generated/rom_text.lua"
 
 local view, reason = service:open("gold")
 T.eq(reason, nil, "marker-valid Gold dataset opens")
 T.check(view ~= nil, "open returns the lazy view")
 T.eq(reads[pokemonPath] or 0, 0, "open does not read an unused root")
 T.eq(reads[movesPath] or 0, 0, "open does not read another unused root")
+T.eq(reads[romTextPath] or 0, 0, "open leaves rom_text lazy too")
 T.eq(decodes, 0, "open decodes no semantic root")
 
 local first = view and view.content.pokemon:get("FIXMON")
@@ -42,5 +47,13 @@ local afterFirst = decodes
 local second = view and view.content.pokemon:get("FIXMON")
 T.eq(second and second.name, "FIXMON", "repeated access remains available")
 T.eq(decodes, afterFirst, "repeated access does not re-decode cached roots")
+
+local prose = view and view.content.rom_text:get("_WokeUpText")
+T.eq(prose, "{USER} woke up!",
+  "the dataset view exposes Gen 2 label-keyed rom_text")
+T.check((reads[romTextPath] or 0) > 0,
+  "the rom_text root is read only when its registry is accessed")
+T.eq(view and view.content.text:get("_WokeUpText"), nil,
+  "the script-text dataset view remains distinct")
 
 T.finish("dataset_views_lazy_validation")

--- a/tests/engine/fly_map_arrows_bug1892.lua
+++ b/tests/engine/fly_map_arrows_bug1892.lua
@@ -117,14 +117,11 @@ check(tm.fly == true, "the picker opens in fly mode")
 eq(tm.mode, "grid", "the picker draws the Kanto map, not the name list")
 
 local texts, codes, draws, polys = capture(tm)
-local to = findText(texts, "To")
-check(to ~= nil, "ToText is printed on its own")
-if to then eq(to.x, 0, "ToText sits at hlcoord 0, 0") end
-local name = findText(texts, "PALLET TOWN")
-check(name ~= nil, "the destination name is printed on its own")
-if name then eq(name.x, 24, "the name sits at hlcoord 3, 0") end
-check(findText(texts, "To PALLET TOWN") == nil,
-      "the banner is no longer one concatenated string at column 1")
+local banner = findText(texts, "To PALLET TOWN")
+check(banner ~= nil, "the fly prefix and destination are one format string")
+if banner then eq(banner.x, 0, "the composed banner starts at hlcoord 0, 0") end
+check(findText(texts, "To") == nil and findText(texts, "PALLET TOWN") == nil,
+      "the prefix and destination are not drawn at fixed separate columns")
 
 check(codeAt(codes, Theme.moreArrow, 152, 0),
       "the down arrow is drawn at hlcoord 19, 0")
@@ -160,11 +157,11 @@ local game7 = newGame()
 local tm7 = TownMap.new(game7, { fly = true, onFly = function() end })
 tm7.sel = 3
 local texts7 = capture(tm7)
-local long = findText(texts7, "CINNABAR ISLAND")
-check(long ~= nil, "the longest fly name is printed")
+local long = findText(texts7, "To CINNABAR ISLAND")
+check(long ~= nil, "the longest composed fly banner is printed")
 if long then
-  check(long.x + #"CINNABAR ISLAND" * 8 <= 144,
-        "a 15-column name ends before the arrow columns")
+  check(long.x + Font.width(long.text) <= 144,
+        "the composed banner ends before the arrow columns")
 end
 
 T.finish("fly map arrows bug 1892")

--- a/tests/engine/gate_gen2_mod_api.lua
+++ b/tests/engine/gate_gen2_mod_api.lua
@@ -157,7 +157,7 @@ for name, path in pairs({ maps = "gen2Maps", tilesets = "gen2Tilesets",
     "and Gen 1 is untouched by the routing: " .. name)
 end
 
--- The mirror set: six registries that exist because GOLD does.  They carry no
+-- The mirror set: registries that exist because GOLD does.  They carry no
 -- Gen 1 target at all, so the routed path is the only path they ever have, and
 -- Schemas.GEN1 gates them on Red the way Schemas.GEN2 gates `map_scripts` on Gold.
 -- Each is held to a live consumer, which is the claim that matters: a routed
@@ -171,12 +171,14 @@ end
 --   apricorns       src/core/gen2/Apricorns.lua:useRegistry
 --   landmarks       src/core/gen2/Nests.lua:landmarkId / landmark
 --   radio_channels  src/ui/gen2/MapRadio.lua:channelRecord
+--   rom_text        src/core/RomText.lua's label-keyed data.text lookup
 for name, path in pairs({ held_items = "gen2HeldItems",
                           phone_contacts = "gen2PhoneContacts",
                           decorations = "gen2Decorations",
                           apricorns = "gen2Apricorns",
                           landmarks = "gen2Landmarks.landmarks",
-                          radio_channels = "gen2RadioChannels" }) do
+                          radio_channels = "gen2RadioChannels",
+                          rom_text = "text" }) do
   local spec = Schemas.REGISTRIES[name]
   T.check(spec ~= nil, "catalog still has registry: " .. name)
   T.eq(Schemas.targetFor(name, spec, 2), path,

--- a/tests/engine/gen2_battle_translation_test.lua
+++ b/tests/engine/gen2_battle_translation_test.lua
@@ -1,0 +1,246 @@
+-- Gen 2's battle engine and battle screen must look up authored text at the
+-- point it is emitted/drawn.  Names stay runtime arguments; the catalog keys
+-- are stable English templates that modkit can harvest.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.harness")
+
+love = require("tests.love_stub")
+require("src.core.Logger").warn = function() end
+
+local Strings = require("src.core.Strings")
+local Effects = require("src.battle.gen2.Effects")
+local Battle = require("src.battle.gen2.Battle")
+local BattleState = require("src.ui.gen2.BattleState")
+local Chrome = require("src.ui.gen2.Chrome")
+local GbcPalette = require("src.render.GbcPalette")
+
+Strings.load({ strings = {
+  ["%s must recharge!"] = "%s doit recharger!",
+  ["%s's %s sharply rose!"] = "%s: %s monte beaucoup!",
+  ["%s's %s was disabled!"] = "%s: %s neutralisee!",
+  ["%s TRANSFORMED into %s!"] = "%s copie %s!",
+  ["%s used %s!"] = "%s emploie %s!",
+  ["It started to rain!"] = "La pluie commence!",
+  ["%s fell asleep!"] = "%s s'endort!",
+  ["%s was poisoned!"] = "%s est empoisonne!",
+  ["%s was badly poisoned!"] = "%s est gravement empoisonne!",
+  ["%s is paralyzed! It may be unable to move!"] = "%s est paralyse!",
+  ["%s was burned!"] = "%s est brule!",
+  ["%s was frozen solid!"] = "%s est gele!",
+  ["%s is hurt by poison!"] = "%s souffre du poison!",
+  ["ATTACK"] = "ATTAQUE",
+  ["FIGHT"] = "COMBAT",
+  ["<PK><MN>"] = "EQUIPE",
+  ["PACK"] = "SAC",
+  ["RUN"] = "FUITE",
+  ["YES"] = "OUI",
+  ["NO"] = "NON",
+  ["PSN"] = "PSN-CATALOGUE",
+  -- Registry-authored display values and already formatted messages must not
+  -- be fed through the source catalog a second time.
+  ["PSN-FR"] = "MAUVAISE-SECONDE-TRADUCTION",
+  ["OVERRIDE"] = "OVR-FR",
+  ["CUSTOM"] = "NOUVEAU-FR",
+  ["TYPE LOCALISE"] = "MAUVAIS-TYPE-RETRADUIT",
+  ["%s is already out."] = "%s SORT DEJA.",
+  ["PIKA SORT DEJA."] = "MAUVAISE-SECONDE-TRADUCTION",
+  ["There's no will to battle!"] = "AUCUNE VOLONTE!",
+  ["AUCUNE VOLONTE!"] = "MAUVAISE-SECONDE-TRADUCTION",
+  ["PARKBALL\xc3\x97%02d"] = "BALLS:%02d",
+} })
+
+local function battleStub(data)
+  local player = { nickname = "DITTO", species = "DITTO", hp = 20,
+    maxHp = 20, stats = {}, moves = {}, volatile = {} }
+  local enemy = { nickname = "CIBLE", species = "RAW_SPECIES", hp = 20,
+    maxHp = 20, stats = {}, moves = {}, volatile = {} }
+  local battle = setmetatable({
+    data = data or {}, events = {}, player = player, enemy = enemy,
+    party = { player }, enemyParty = { enemy },
+    screens = { player = {}, enemy = {} },
+    stages = { player = Battle.newStages(), enemy = Battle.newStages() },
+    random = function() return 0 end,
+  }, { __index = Battle })
+  return battle, player, enemy
+end
+
+do
+  local mon = { nickname = "PIKACHU", volatile = { recharge = true } }
+  local battle = setmetatable({ data = {}, events = {}, player = mon },
+    { __index = Battle })
+  T.check(not battle:canAct(mon), "recharge still spends the turn")
+  T.eq(battle.events[1] and battle.events[1].text,
+    "PIKACHU doit recharger!",
+    "a translated battle template receives the runtime battler name")
+end
+
+T.eq(Effects.stageMessage("PIKACHU", "attack", 2),
+  "PIKACHU: ATTAQUE monte beaucoup!",
+  "stat labels and the complete stage template are both translated")
+
+do
+  local data = {
+    moves = { RAW_MOVE = { name = "JOLI MOUV" } },
+    items = { RAW_ITEM = { name = "BEL OBJET" } },
+    pokemon = {
+      DITTO = { name = "METAMORPH", types = { "NORMAL" } },
+      RAW_SPECIES = { name = "BELLE ESPECE", types = { "NORMAL" } },
+    },
+  }
+  local battle, player, enemy = battleStub(data)
+  enemy.moves = { { id = "RAW_MOVE", pp = 5 } }
+  enemy.volatile.lastMove = "RAW_MOVE"
+  Battle.MOVE_EFFECTS.EFFECT_DISABLE(battle, player, enemy)
+  T.eq(battle.events[#battle.events].text, "CIBLE: JOLI MOUV neutralisee!",
+    "a multi-argument template receives the move's display name, not its id")
+
+  battle.events = {}
+  Battle.MOVE_EFFECTS.EFFECT_TRANSFORM(battle, player, enemy)
+  T.eq(battle.events[1].text, "DITTO copie BELLE ESPECE!",
+    "TRANSFORM keeps the actor name and resolves the target species name")
+
+  battle.events = {}
+  battle.trainer = { name = "DRESSEUR", items = { "RAW_ITEM" } }
+  battle:enemyUseItem("RAW_ITEM")
+  T.eq(battle.events[#battle.events].text, "DRESSEUR emploie BEL OBJET!",
+    "trainer items resolve their display name before formatting")
+
+  battle.events = {}
+  Battle.MOVE_EFFECTS.EFFECT_RAIN_DANCE(battle, player, enemy)
+  T.eq(battle.events[1].text, "La pluie commence!",
+    "weather table sources are translated when emitted, after module load")
+end
+
+do
+  local expected = {
+    sleep = "MON s'endort!",
+    poison = "MON est empoisonne!",
+    toxic = "MON est gravement empoisonne!",
+    paralyze = "MON est paralyse!",
+    burn = "MON est brule!",
+    freeze = "MON est gele!",
+  }
+  for status, want in pairs(expected) do
+    local battle = battleStub({})
+    local mon = { nickname = "MON", hp = 16, maxHp = 16, volatile = {} }
+    battle.player = mon
+    T.check(battle:applyStatus(mon, status), status .. " can be inflicted")
+    T.eq(battle.events[#battle.events].text, want,
+      status .. " uses its complete translated template")
+  end
+
+  local battle = battleStub({})
+  local mon = { nickname = "MON", hp = 16, maxHp = 16,
+    status = "poison", volatile = {} }
+  battle.player = mon
+  battle:tickStatus(mon)
+  T.eq(battle.events[1].text, "MON souffre du poison!",
+    "a deferred residual status message is translated at emission")
+end
+
+do
+  local Registry = require("src.mods.Registry")
+  local Schemas = require("src.mods.Schemas")
+  local statuses = Registry.new("statuses", Schemas.REGISTRIES.statuses)
+  statuses.base = function() return Battle.STATUSES end
+  -- This is the exact label-only patch translation mods author.  The vanilla
+  -- record must not retain a redundant hudLabel that shadows the patch.
+  statuses:patch("poison", { label = "PSN-FR" }, "translation")
+  statuses:register("custom", { id = "custom", label = "CUSTOM" }, "mod")
+  statuses:register("hidden", {
+    id = "hidden", label = "CUSTOM", substatus = true,
+  }, "mod")
+  local merged = {}
+  for id in pairs(Battle.STATUSES) do merged[id] = statuses:get(id) end
+  merged.custom = statuses:get("custom")
+  merged.hidden = statuses:get("hidden")
+
+  T.eq(merged.poison.hudLabel, nil,
+    "a real label-only Registry patch has no stale vanilla hudLabel")
+  local state = setmetatable({ contest = false,
+    game = { data = { gen2Statuses = merged } },
+  }, { __index = BattleState })
+  T.same(state:menuLabels(), { "COMBAT", "EQUIPE", "SAC", "FUITE" },
+    "the four battle menu labels are looked up without changing action ids")
+  T.eq(state:statusTag({ status = "poison" }, "player"), "PSN-FR",
+    "a label-only registry patch controls the HUD without a second lookup")
+  T.eq(state:statusTag({ status = "custom" }, "player"), "CUSTOM",
+    "a newly registered status label is complete authored display content")
+  T.eq(state:statusTag({ status = "hidden" }, "player"), nil,
+    "a modded substatus remains absent from the major-status HUD slot")
+
+  state.contest = true
+  state.save = { bugContest = { balls = 7 } }
+  T.eq(state:menuLabels()[3], "BALLS:07",
+    "the contest ball label and count use a harvested format template")
+
+  state.game = nil
+  T.eq(state:statusTag({ status = "poison" }, "player"), "PSN-CATALOGUE",
+    "only the built-in no-dataset fallback uses the strings catalog")
+  T.eq(state:statusTag({ status = "confuse" }, "player"), nil,
+    "built-in confusion remains a substatus and never gets a HUD tag")
+end
+
+do
+  local state = setmetatable({}, { __index = BattleState })
+  state:refuseSwitch(false, "%s is already out.", "PIKA")
+  T.eq(state.message, "PIKA SORT DEJA.",
+    "refuseSwitch translates and formats its source exactly once")
+  state:refuseShift()
+  T.eq(state.message, "AUCUNE VOLONTE!",
+    "refuseShift does not look up its translated fallback a second time")
+end
+
+do
+  local drawn = {}
+  local originalPrint = Chrome.printThrough
+  Chrome.printThrough = function(text) drawn[#drawn + 1] = text end
+  local state = setmetatable({
+    game = { data = {
+      moves = { MOD_MOVE = { type = "MOD_TYPE" } },
+      type_chart = { types = {
+        MOD_TYPE = { name = "TYPE LOCALISE", category = "special" },
+      } },
+    } },
+    battle = {
+      player = {},
+      moveDisabled = function() return false end,
+    },
+  }, { __index = BattleState })
+  state:drawMoveInfoBox({ id = "MOD_MOVE", pp = 3, maxPp = 5 })
+  Chrome.printThrough = originalPrint
+  local seen = {}
+  for _, text in ipairs(drawn) do seen[text] = true end
+  T.check(seen["TYPE LOCALISE"],
+    "the TYPE/ box uses the live type registry display name verbatim")
+  T.check(not seen["MOD_TYPE"] and not seen["MAUVAIS-TYPE-RETRADUIT"],
+    "the TYPE/ box renders neither the raw id nor a second catalog lookup")
+end
+
+do
+  local drawn = {}
+  Chrome.clear = function() end
+  Chrome.box = function() end
+  Chrome.cursorThrough = function() end
+  Chrome.printThrough = function(text) drawn[#drawn + 1] = text end
+  GbcPalette.setBgp = function() return nil end
+
+  local state = setmetatable({
+    battle = { player = {}, enemy = {} },
+    phase = "ask-nickname", messageTimer = 0, nicknameIndex = 1,
+    bottomUIVisible = function() return true end,
+    drawHud = function() end,
+    printMessage = function() end,
+  }, { __index = BattleState })
+  state:drawPanel()
+  local seen = {}
+  for _, text in ipairs(drawn) do seen[text] = true end
+  T.check(seen.OUI and seen.NON,
+    "battle YES/NO choices are translated at draw time")
+end
+
+Strings.load({})
+T.check(not Strings.active(), "the catalog is unloaded after the test")
+
+T.finish("gen2 battle translation")

--- a/tests/engine/gen2_content_registries.lua
+++ b/tests/engine/gen2_content_registries.lua
@@ -33,6 +33,7 @@ local Decorations = require("src.core.gen2.Decorations")
 local Apricorns = require("src.core.gen2.Apricorns")
 local Nests = require("src.core.gen2.Nests")
 local MapRadio = require("src.ui.gen2.MapRadio")
+local Pokegear = require("src.ui.gen2.Pokegear")
 
 local NAMES = { "held_items", "phone_contacts", "decorations", "apricorns",
                 "landmarks", "radio_channels" }
@@ -204,6 +205,8 @@ do
     "OAK's POKEMON TALK keeps its dial position")
   T.eq(channels.ROCKET_RADIO and channels.ROCKET_RADIO.channel, 8,
     "and ROCKET RADIO keeps its own")
+  T.eq(channels.POKE_FLUTE_RADIO and channels.POKE_FLUTE_RADIO.name,
+    "POKé FLUTE", "Pokegear-only stations are seeded in the same registry")
 
   -- held_items and landmarks merge onto a table that already existed, so the
   -- claim there is that the merge left it exactly as it found it
@@ -228,7 +231,7 @@ do
       -- an existing row edited, and a new one registered, for each registry
       mod.content.decorations:patch("deco:2", { name = "COZY" })
       mod.content.phone_contacts:patch("PHONE_YOUNGSTER_JOEY",
-        { map = "FIX_ROUTE" })
+        { map = "FIX_ROUTE", name = "JOJO" })
       mod.content.apricorns:override("RED_APRICORN",
         { apricorn = "RED_APRICORN", ball = "ULTRA_BALL", event = 600,
           index = 1 })
@@ -238,6 +241,8 @@ do
           index = 7 })
       mod.content.radio_channels:register("PIRATE_RADIO",
         { channel = 9, name = "PIRATE RADIO" })
+      mod.content.radio_channels:patch("POKE_FLUTE_RADIO",
+        { name = "FLÛTE RADIO" })
       mod.content.held_items:patch("FIX_LEFTOVERS", { heldParameter = 7 })
     ]]),
     data = data,
@@ -263,6 +268,8 @@ do
     "phone_contacts: the merged row reaches the contact table")
   T.eq(Phone.CONTACTS[15].class, "YOUNGSTER",
     "and the untouched fields survive the patch")
+  T.eq(Phone.contactName(15, data.gen2Trainers), "JOJO",
+    "and the registry's display name overrides trainer-table presentation")
   -- the cache overlay runs from src/world/gen2/World.lua AFTER this, and must
   -- not undo it
   Phone.useExtracted({ phone = { [15] = { map = "ROUTE_30",
@@ -314,6 +321,9 @@ do
   T.eq(record and record.name, "PIRATE RADIO", "with its own name")
   T.eq(select(2, MapRadio.channelRecord(run.data, 8)), "ROCKET_RADIO",
     "and the vanilla positions are unmoved")
+  local gear = setmetatable({ game = { data = run.data } }, Pokegear)
+  T.eq(gear:stationName("POKE_FLUTE_RADIO"), "FLÛTE RADIO",
+    "and the Pokegear reads a patched built-in name from that same registry")
 
   -- held items: the merged row is written back onto the item record, which is
   -- what src/battle/gen2/Battle.lua:itemDef reads
@@ -332,6 +342,28 @@ do
   -- module statics are process-wide; put them back before the next case
   Phone.useRegistry(nil)
   Decorations.useRegistry(nil)
+end
+
+-- A real loader keeps record semantics for the built-in radio ids: register
+-- collides, while the patch above succeeds and preserves the untouched
+-- channel.  This guards the distinction between content replacement and
+-- localization at the consumer.
+do
+  local run = T.sdk.loadMods({ "mods/fix_gen2_content" }, {
+    fs = memfsFor([[
+      local mod = ...
+      mod.content.radio_channels:register("POKE_FLUTE_RADIO",
+        { channel = 7, name = "SHADOW" })
+    ]]),
+    data = goldData(), generation = 2,
+  })
+  local collided = false
+  for _, message in ipairs(run.errors) do
+    if message:find("radio_channels already registered: POKE_FLUTE_RADIO", 1,
+        true) then collided = true end
+  end
+  T.check(collided, "registering over a built-in radio station is rejected")
+  run.release()
 end
 
 -- ------- 4. the mirror case, through a real load

--- a/tests/engine/gen2_options_menu_translation_test.lua
+++ b/tests/engine/gen2_options_menu_translation_test.lua
@@ -103,6 +103,11 @@ do
       ["CONTROLS"] = "COMMANDES",
       ["SPEED"] = "VITESSE",
       ["BACK"] = "RETOUR",
+      ["AUTO"] = "AUTO-FR",
+      ["GEN 2"] = "GEN2-FR",
+      ["OFF"] = "SANS",
+      ["GREEN"] = "VERT",
+      ["DISPLAY (%dHZ)"] = "ECRAN %dHZ",
     },
   })
 
@@ -144,6 +149,54 @@ do
   local cancelSlot = cancelIndex - cancelMenu.scroll
   T.eq(drawnAt(LABEL_X, (2 + (cancelSlot - 1) * 2) * 8), "RETOUR",
     "CANCEL, the way out of the menu, is translated too")
+
+  -- Port-added finite values used to be returned by helper modules after the
+  -- only Strings lookup in drawPanel had already happened.  They must pass
+  -- through the catalog at draw time as well.
+  local performance = menu:focusRow("performance")
+  drawn = {}
+  performance:drawPanel()
+  local performanceSlot = performance.index - performance.scroll
+  T.eq(drawnAt(VALUE_X, (3 + (performanceSlot - 1) * 2) * 8),
+    "AUTO-FR", "a helper-produced PERFORMANCE value is translated")
+
+  local color = menu:focusRow("color")
+  color.options.palette = ""
+  color.options.color = "gbc"
+  drawn = {}
+  color:drawPanel()
+  local colorSlot = color.index - color.scroll
+  T.eq(drawnAt(VALUE_X, (3 + (colorSlot - 1) * 2) * 8), "GEN2-FR",
+    "a finite built-in COLOR mode is translated")
+
+  color.options.palette = "m:9bbc0f"
+  T.eq(color:row().text(color.options), "VERT",
+    "an engine-provided monochrome palette label is translated")
+
+  local filter = menu:focusRow("musicFilter")
+  filter.options.musicFilter = 0
+  T.eq(filter:row().text(filter.options), "SANS",
+    "MUSIC FILTER resolves its finite value through Strings at runtime")
+
+  local fps = menu:focusRow("fpsCap")
+  local RefreshRate = require("src.core.RefreshRate")
+  local priorMismatch = RefreshRate.mismatch
+  RefreshRate.mismatch = function() return 59 end
+  fps.options.fpsCap = 0
+  T.eq(fps:row().text(fps.options), "ECRAN 59HZ",
+    "DISPLAY retains its refresh-rate suffix through a localizable template")
+  RefreshRate.mismatch = priorMismatch
+
+  -- A user palette name is content, not a finite engine enum.  It must stay
+  -- verbatim even if a catalog happens to contain an identically named key.
+  Strings.load({ strings = {
+    ["My Palette"] = "NE PAS TRADUIRE",
+  } })
+  color.options.palette = "p:custom/My Palette"
+  drawn = {}
+  color:drawPanel()
+  T.eq(drawnAt(VALUE_X, (3 + (colorSlot - 1) * 2) * 8), "My Palet",
+    "a user palette name stays raw (and is only clipped to the value width)")
 
   -- Module state is process-global (see tests/gen2_clock_test.lua's own
   -- note); this suite gets its own process from tests/tier_runner.lua, but

--- a/tests/engine/gen2_registry_ui_translation_test.lua
+++ b/tests/engine/gen2_registry_ui_translation_test.lua
@@ -1,0 +1,95 @@
+-- Runtime coverage for the registry-adjacent Gen 2 labels.  The Python
+-- harvest test proves the keys enter a translation scaffold; this suite proves
+-- that loading such a catalog changes what the actual screens draw.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.harness")
+
+love = require("tests.love_stub")
+require("src.core.Logger").warn = function() end
+
+local Chrome = require("src.ui.gen2.Chrome")
+local MainMenu = require("src.ui.gen2.MainMenu")
+local PokedexMenu = require("src.ui.gen2.PokedexMenu")
+local Pokegear = require("src.ui.gen2.Pokegear")
+local Strings = require("src.core.Strings")
+
+Strings.load({ strings = {
+  AM = "MATIN", PM = "SOIR", DAY = "JOUR",
+  [" PAGE AREA CRY PRNT"] = " PAGE ZONE CRI IMPR",
+  lb = "liv", ["%s'S NEST"] = "NID DE %s",
+  ["Press any button to exit."] = "Appuyez pour sortir.",
+} })
+
+-- MainMenu_PrintCurrentTimeAndDay: the clock box now goes through
+-- MainMenu.timeString/InitClock.hourString (../pokecrystal/engine/menus/
+-- main_menu.asm:286), whose MORN/DAY/NITE word -- not AM/PM -- is
+-- Clock.daytimeLabel's own translated DAYTIME_LABEL entry; the no-weekday
+-- fallback moved down one row (14 -> 15) with the box's own reposition.
+do
+  local oldPrint, oldTextbox = Chrome.print, Chrome.textbox
+  local drawn = {}
+  Chrome.print = function(text, x, y) drawn[x .. ":" .. y] = text end
+  Chrome.textbox = function() end
+  local menu = MainMenu.new({}, { hasSave = false, save = false,
+    clock = { hour = 13, minute = 5, weekday = 99 } })
+  menu:drawClockBox()
+  T.eq(drawn["1:15"], "JOUR", "the main-menu DAY fallback is translated")
+  T.eq(drawn["4:16"], "JOUR 1:05",
+    "the main-menu daytime word (DAY, not PM) is translated")
+  Chrome.print, Chrome.textbox = oldPrint, oldTextbox
+end
+
+-- Pokegear_UpdateClock uses the same keys in the styled card path.
+do
+  local gear = Pokegear.new({ data = {} }, {
+    save = {}, clock = { hour = 1, minute = 2, weekday = 99 },
+  })
+  local drawn = {}
+  gear.drawTilemap = function() end
+  gear.drawStrip = function() end
+  gear.cursor = function() end
+  gear.textbox = function() end
+  gear.printBoxText = function() end
+  gear.text = function(_, text, x, y) drawn[x .. ":" .. y] = text end
+  gear:drawClock()
+  T.eq(drawn["12:8"], "MATIN", "the Pokegear AM half is translated")
+  T.eq(gear:phoneText("PressButton"), "Appuyez pour sortir.",
+    "a complete built-in Pokegear prompt is translated")
+end
+
+-- DexEntryScreen's action strip is one ROM string rather than four invented
+-- fragments.  The unit and the grammatical nest title resolve independently.
+do
+  local save = { pokedex = { seen = { BULBASAUR = true }, caught = {} } }
+  local game = { save = save, data = {
+    pokemon = { BULBASAUR = { name = "BULBIZARRE" } },
+    gen2Pokedex = { entries = {
+      BULBASAUR = { dex = 1, kind = "GRAINE", height = 204, weight = 150 },
+    }, newOrder = { "BULBASAUR" } },
+  } }
+  local dex = PokedexMenu.new(game, {})
+  local drawn = {}
+  dex.text = function(_, text, x, y) drawn[x .. ":" .. y] = text end
+  dex.fill = function() end
+  dex.border = function() end
+  dex.tile = function() end
+  dex.blank = function() end
+  dex.drawPic = function() end
+  dex.drawFootprint = function() end
+  dex.cursorVisible = function() return false end
+  dex:drawEntryBody(dex:current(), game.data.gen2Pokedex.entries.BULBASAUR)
+  T.eq(drawn["1:17"], " PAGE ZONE CRI IMPR",
+    "the complete Pokedex action strip is translated")
+  T.eq(drawn["17:9"], "liv", "the Pokedex weight unit is translated")
+
+  local title
+  dex.drawAreaHeader = function(_, text) title = text end
+  dex.areaBlink = 0
+  dex:drawArea()
+  T.eq(title, "NID DE BULBIZARRE",
+    "the Pokedex nest template supports grammatical reordering")
+end
+
+Strings.load(nil)
+T.finish()

--- a/tests/engine/gen2_rom_text_registry_test.lua
+++ b/tests/engine/gen2_rom_text_registry_test.lua
@@ -1,0 +1,51 @@
+-- Gold has two text datasets: VM script text keyed by bank:address and
+-- engine prose keyed by disassembly label.  Their public registries must not
+-- alias even though the shared RomText helper reads the latter at data.text.
+
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.modkit")
+local RomText = require("src.core.RomText")
+local Schemas = require("src.mods.Schemas")
+
+local files = T.sdk.memfs({
+  ["mods/rom_text_probe/manifest.json"] = [[{
+    "id": "rom_text_probe",
+    "name": "Rom Text Probe",
+    "version": "1.0.0",
+    "entry": "main.lua",
+    "api": 2,
+    "gen2compat": true
+  }]],
+  ["mods/rom_text_probe/main.lua"] = [[
+    local mod = ...
+    mod.content.rom_text:override("_WokeUpText", "{USER} se réveille !")
+    mod.content.text:override("55:4067", "SCRIPT PATCH")
+  ]],
+})
+
+local data = {
+  text = { _WokeUpText = "{USER} woke up!" },
+  gen2Text = { ["55:4067"] = "SCRIPT BASE" },
+}
+local run = T.sdk.loadMods({ "mods/rom_text_probe" }, {
+  fs = files, data = data, generation = 2,
+})
+
+T.eq(#run.errors, 0,
+  "the rom_text mod loads cleanly (" .. table.concat(run.errors, "; ") .. ")")
+T.eq(Schemas.targetFor("rom_text", Schemas.REGISTRIES.rom_text, 2), "text",
+  "rom_text routes to the label-keyed Gen 2 table")
+T.eq(Schemas.targetFor("text", Schemas.REGISTRIES.text, 2), "gen2Text",
+  "text keeps the VM script table")
+T.eq(RomText(run.data, "_WokeUpText", "%s woke up!", "GOLD"),
+  "GOLD se réveille !", "RomText consumes the merged rom_text override")
+T.eq(run.data.gen2Text["55:4067"], "SCRIPT PATCH",
+  "the ordinary text registry still patches Gen 2 script text")
+T.eq(run.data.gen2Text._WokeUpText, nil,
+  "the rom_text label does not leak into gen2Text")
+T.eq(run.data.text["55:4067"], nil,
+  "the VM script address does not leak into rom_text")
+
+run.release()
+T.finish("gen2_rom_text_registry")

--- a/tests/engine/gen2_startmenu_description_palette_test.lua
+++ b/tests/engine/gen2_startmenu_description_palette_test.lua
@@ -19,6 +19,7 @@ require("src.core.Logger").warn = function() end
 
 local GbcPalette = require("src.render.GbcPalette")
 local StartMenu = require("src.ui.gen2.StartMenu")
+local Strings = require("src.core.Strings")
 
 local calls
 local function spy(name)
@@ -61,6 +62,25 @@ do
   spy("resolve"); spy("use"); spy("with")
   local ok = pcall(StartMenu.draw, fakeMenu())
   T.check(ok, "StartMenu:draw() does not error with no shader available")
+end
+
+do
+  Strings.load({ strings = {
+    ["Change\nsettings"] = "Modifier les\nreglages",
+  } })
+  local save = { party = {}, inventory = {}, options = {} }
+  local menu = StartMenu.new({ save = save }, {
+    save = save,
+    unlocked = { pack = true },
+  })
+  local option
+  for _, item in ipairs(menu.items) do
+    if item.value == "option" then option = item end
+  end
+  T.check(option and option.desc[1] == "Modifier les"
+      and option.desc[2] == "reglages",
+    "START descriptions use one complete multiline key before splitting")
+  Strings.load({})
 end
 
 T.finish()

--- a/tests/engine/gen2_trainer_card_text_palette_test.lua
+++ b/tests/engine/gen2_trainer_card_text_palette_test.lua
@@ -14,6 +14,7 @@ require("src.core.Logger").warn = function() end
 
 local GbcPalette = require("src.render.GbcPalette")
 local TrainerCard = require("src.ui.gen2.TrainerCard")
+local Strings = require("src.core.Strings")
 
 GbcPalette.available = function() return true end
 GbcPalette.setCustomRamp({ { 255, 0, 255 }, { 200, 0, 200 }, { 100, 0, 100 },
@@ -64,6 +65,54 @@ do
   TrainerCard.drawPanel(fake)
   T.check((calls.resolve or 0) > 0 or (calls.use or 0) > 0 or (calls.with or 0) > 0,
     "TrainerCard:drawPanel()'s base fill reaches the GbcPalette seam")
+end
+
+-- Text labels are catalog-backed, while the player's chosen name is content
+-- and must remain verbatim.
+do
+  local Chrome = require("src.ui.gen2.Chrome")
+  local priorPrintThrough = Chrome.printThrough
+  local printed = {}
+  Chrome.printThrough = function(text) printed[#printed + 1] = text end
+  Strings.load({ strings = {
+    ["NAME/"] = "NOM/", MONEY = "ARGENT", ["POKéDEX"] = "DEX-FR",
+    ["PLAY TIME"] = "TEMPS", BADGES = "BADGES-FR", GOLD = "INTERDIT",
+  } })
+  TrainerCard.drawPlain({
+    page = 1,
+    save = { player = { name = "GOLD", id = 7, money = 12 }, playTime = {} },
+    caughtCount = function() return 0 end,
+  })
+  local all = table.concat(printed, "|")
+  T.check(all:find("NOM/", 1, true) and all:find("ARGENT", 1, true)
+      and all:find("DEX-FR", 1, true) and all:find("TEMPS", 1, true),
+    "Trainer Card's finite labels pass through Strings")
+  T.check(all:find("GOLD", 1, true) and not all:find("INTERDIT", 1, true),
+    "the player's name stays raw")
+  Strings.load({})
+  Chrome.printThrough = priorPrintThrough
+end
+
+-- Badge names are finite UI labels too; unlike the player's name above they
+-- must be looked up when the page is drawn (and then shortened to four chars).
+do
+  local Chrome = require("src.ui.gen2.Chrome")
+  local priorPrintThrough = Chrome.printThrough
+  local printed = {}
+  Chrome.printThrough = function(text) printed[#printed + 1] = text end
+  Strings.load({ strings = {
+    ["JOHTO BADGES"] = "BADGES JOHTO",
+    ZEPHYR = "ÉCLAIR",
+  } })
+  TrainerCard.drawPlain({
+    page = 2,
+    save = { player = { badges = { ZEPHYR = true } } },
+  })
+  local all = table.concat(printed, "|")
+  T.check(all:find("BADGES JOHTO", 1, true) and all:find("ÉCLA", 1, true),
+    "Trainer Card translates and clips badge names on font-glyph boundaries")
+  Strings.load({})
+  Chrome.printThrough = priorPrintThrough
 end
 
 T.finish()

--- a/tests/engine/prize_counter_name_clamp_test.lua
+++ b/tests/engine/prize_counter_name_clamp_test.lua
@@ -1,0 +1,71 @@
+-- The Game Corner price columns (PrizeMenu.lua) are right-aligned against a
+-- fixed priceRight column per counter; a translated prize name longer than
+-- the tile budget before that column would otherwise overlap or run into
+-- the price digits Chrome.print draws right after it, since the name and
+-- price are now two separate draw calls (#1642-adjacent). This drives
+-- drawPanel() with an over-long name via a mod's strings override and
+-- checks the drawn name never crosses into the price column.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.harness")
+love = require("tests.love_stub")
+require("src.core.Logger").warn = function() end
+
+local drawn
+package.loaded["src.ui.gen2.Chrome"] = setmetatable({
+  print = function(text, x, y) drawn[#drawn + 1] = { text = text, x = x, y = y } end,
+  clear = function() end,
+  textbox = function() end,
+  cursor = function() end,
+}, { __index = require("src.ui.gen2.Chrome") })
+
+local PrizeMenu = require("src.ui.gen2.PrizeMenu")
+local Font = require("src.render.Font")
+local Strings = require("src.core.Strings")
+Strings.load({ strings = { ["MR.MIME"] = "A NAME MUCH LONGER THAN THE COUNTER ROW" } })
+
+local counter = PrizeMenu.COUNTERS.CELADON_MON
+local prize = counter.prizes[1] -- MR.MIME, cost 3333
+drawn = {}
+local self = setmetatable({
+  save = {}, phase = "menu", index = 1, counter = counter,
+  prizes = { prize }, text = {},
+}, PrizeMenu)
+self:drawPanel()
+
+-- drawn[1..2] are drawCoinBox()'s COIN label and coin count.
+local nameDraw, priceDraw = drawn[3], drawn[4]
+T.check(nameDraw and nameDraw.text:find("^A NAME"), "the translated name is drawn")
+T.check(#nameDraw.text <= counter.priceRight - #tostring(prize.cost) - 2,
+  "the drawn name is clamped to the tile budget before the price column")
+T.eq(priceDraw and priceDraw.text, "3333", "the price still draws in full")
+T.check(priceDraw.x > nameDraw.x + #nameDraw.text,
+  "the price column starts after the clamped name ends")
+
+-- The redrawn text must never exceed the tile budget either: byte length
+-- alone is not the right measure once a macro is involved (see below).
+T.check(#Font.split(nameDraw.text) <= counter.priceRight - #tostring(prize.cost) - 2,
+  "the drawn name's glyph width (not byte length) fits the tile budget")
+
+-- Font.split's "#" macro expands to four glyphs (POKé) from one source
+-- byte; a naive byte-position cut lands inside that expansion and still
+-- copies the whole "#" byte, which re-expands past the budget on redraw.
+-- Position it so exactly one tile is free where the whole four-glyph
+-- macro would be needed.
+Strings.load({ strings = { ["EEVEE"] = "AAAAAAAAA#EXTRA" } })
+drawn = {}
+local eevee = counter.prizes[2] -- EEVEE, cost 6666
+local self2 = setmetatable({
+  save = {}, phase = "menu", index = 1, counter = counter,
+  prizes = { eevee }, text = {},
+}, PrizeMenu)
+self2:drawPanel()
+local macroNameDraw = drawn[3]
+local macroBudget = counter.priceRight - #tostring(eevee.cost) - 2
+T.check(macroNameDraw and macroNameDraw.text == ("A"):rep(9),
+  "a macro straddling the budget is dropped whole, not cut mid-expansion")
+T.check(#Font.split(macroNameDraw.text) <= macroBudget,
+  "the macro-adjacent name's glyph width fits the tile budget after redraw")
+
+Strings.load(nil)
+T.finish("prize_counter_name_clamp_test")

--- a/tests/engine/prize_menu_scroll_pages_test.lua
+++ b/tests/engine/prize_menu_scroll_pages_test.lua
@@ -1,0 +1,32 @@
+-- PrizeMenu.TEXTS' Game Corner vendor messages used \f (paragraph/clear)
+-- where the real cart text ends in \v (cont/scroll), for four separate
+-- messages (Celadon and Goldenrod's prize-vendor intros, Goldenrod's
+-- quit line, and the coin vendor's no-COIN-CASE refusal) -- confirmed
+-- against poke-corpus's GoldSilver English text (gs.CeladonGameCornerPrizeRoom.
+-- CeladonPrizeRoom_PrizeVendorIntroText and siblings, which all end
+-- <LINE>...<CONT>..., not <PARA>). CommonText.pages() renders \f as an
+-- unrelated fresh page (no continuity) and \v as a scroll (the previous
+-- line stays visible on top); with \f, the vendor's last line used to
+-- appear alone with no lead-in.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.harness")
+local CommonText = require("src.core.gen2.CommonText")
+
+local function lastPageScrolls(text, expectedTop, expectedBottom)
+  local pages = CommonText.pages(text)
+  local last = pages[#pages]
+  T.eq(last[1], expectedTop, "the scrolled-up line is the previous page's bottom row")
+  T.eq(last[2], expectedBottom, "the new line lands under it")
+end
+
+lastPageScrolls("Welcome!\fWe exchange your\ncoins for fabulous\vprizes!",
+  "coins for fabulous", "prizes!")
+lastPageScrolls("Welcome!\fWe exchange your\ngame coins for\vfabulous prizes!",
+  "game coins for", "fabulous prizes!")
+lastPageScrolls("OK. Please save\nyour coins and\vcome again!",
+  "your coins and", "come again!")
+lastPageScrolls("Do you need game\ncoins?\fOh, you don't have\na COIN CASE for\vyour coins.",
+  "a COIN CASE for", "your coins.")
+
+T.finish("prize_menu_scroll_pages_test")

--- a/tests/engine/rby_translation_runtime_test.lua
+++ b/tests/engine/rby_translation_runtime_test.lua
@@ -1,0 +1,300 @@
+-- Runtime coverage for the RBY translation seams backed by dynamic ROM data.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.harness")
+love = love or require("tests.love_stub")
+
+local drawn = {}
+package.loaded["src.render.Font"] = {
+  draw = function(text, x, y)
+    drawn[#drawn + 1] = { text = text, x = x, y = y }
+  end,
+  drawBox = function() end,
+  drawCode = function() end,
+  width = function(text) return #text * 8 end,
+  split = function(text)
+    local spans = {}
+    for i = 1, #text do spans[i] = { from = i, to = i, code = text:byte(i) } end
+    return spans
+  end,
+  spansFitting = function(spans, pixels)
+    return math.min(#spans, math.floor(pixels / 8))
+  end,
+}
+package.loaded["src.core.Sound"] = {
+  play = function() end,
+  playCry = function() end,
+}
+local pushed
+package.loaded["src.render.TextBox"] = {
+  new = function(_, text) return { text = text } end,
+}
+
+local Strings = require("src.core.Strings")
+Strings.load({ strings = {
+  ["PALLET TOWN"] = "BOURG PALETTE",
+  ["To %s"] = "Vers %s",
+  ["FLY TO?"] = "VOLER VERS?",
+  ["VOLER VERS?"] = "DOUBLE LOOKUP",
+  ["ITEMS"] = "OBJETS",
+  ["OBJETS"] = "DOUBLE LOOKUP",
+  ["DIRECTOR"] = "RÉALISATEUR",
+  ["T H E  E N D"] = "F I N",
+  ["No.%03d"] = "N°%03d",
+  ["IDNo.%05d"] = "ID n°%05d",
+  ["POKéMON BLUE"] = "BLEU",
+  ["PIKACHU'S BEACH"] = "PLAGE",
+  ["BILL'S PC"] = "PC DE LÉO",
+  ["%s's PC"] = "PC DE %s",
+  ["PC DE RED"] = "DOUBLE LOOKUP",
+} })
+
+-- TownMap keeps the English source for ROUTE classification and translates
+-- only the rendered banner, including the fly prefix.
+local TownMap = require("src.ui.TownMap")
+local map = setmetatable({ fly = false }, TownMap)
+T.eq(map:bannerText({ name = "PALLET TOWN" }), "BOURG PALETTE",
+  "town names pass through Strings at draw time")
+map.fly = true
+T.eq(map:bannerText({ name = "PALLET TOWN" }), "Vers BOURG PALETTE",
+  "the composed fly banner translates its prefix and destination")
+
+-- Exercise the actual grid/fly draw path: the old fixed "To" at x=0 plus
+-- destination at x=24 overlapped as soon as the prefix was wider than two
+-- glyphs.  It is now one reorderable format lookup and one draw call.
+local grid = setmetatable({
+  game = { data = { pokemon = {} } },
+  mode = "grid",
+  bg = { map = {} },
+  locs = { { name = "PALLET TOWN", x = 1, y = 1 } },
+  sel = 1,
+  fly = true,
+  blink = 0,
+  drawFlyArrows = function() end,
+}, TownMap)
+drawn = {}
+grid:draw()
+local banner = {}
+for _, entry in ipairs(drawn) do
+  if entry.y == 0 then banner[#banner + 1] = entry end
+end
+T.eq(#banner, 1, "grid/fly draws one composed destination banner")
+T.eq(banner[1] and banner[1].text, "Vers BOURG PALETTE",
+  "grid/fly uses the reorderable To %s translation")
+T.eq(banner[1] and banner[1].x, 0,
+  "the composed grid/fly banner starts at the strip's left edge")
+T.check(banner[1] and banner[1].x + package.loaded["src.render.Font"]
+    .width(banner[1].text) <= 144,
+  "the grid/fly banner does not overlap its arrow tiles")
+
+-- The standalone FlyMenu has the same dynamic map-name path as TownMap.
+local realMap = package.loaded["src.world.Map"]
+package.loaded["src.ui.ListMenu"] = {
+  new = function(_, title, items, opts)
+    return {
+      title = title, kind = (opts and opts.kind) or title, items = items,
+      rows = 6, index = 1, scroll = 0, update = function() end,
+    }
+  end,
+}
+package.loaded["src.world.Map"] = { isFlyTown = function() return true end }
+local FlyMenu = assert(loadfile("src/ui/FlyMenu.lua"))()
+local fly = FlyMenu.new({
+  data = {
+    field = { flyOrder = { "PALLET_TOWN" } },
+    maps = { PALLET_TOWN = {} },
+  },
+  save = { visited = { PALLET_TOWN = true } },
+})
+T.eq(fly.title, "FLY TO?",
+  "FlyMenu preserves the source title for ListMenu hooks")
+T.eq(fly.kind, "FLY TO?",
+  "FlyMenu preserves the source kind derived by ListMenu")
+T.eq(Strings(fly.title), "VOLER VERS?",
+  "ListMenu's draw-time lookup translates once, not twice")
+T.eq(fly.items[1] and fly.items[1].label, "BOURG PALETTE",
+  "FlyMenu translates dynamic destination names")
+
+local BagMenu = assert(loadfile("src/ui/BagMenu.lua"))()
+local bag = BagMenu.new({
+  data = { items = {} },
+  save = { inventory = {}, bagOrder = {} },
+})
+T.eq(bag.title, "ITEMS", "BagMenu preserves its source title")
+T.eq(bag.kind, "bag", "BagMenu preserves its stable explicit kind")
+T.eq(Strings(bag.title), "OBJETS",
+  "BagMenu's draw-time lookup translates once, not twice")
+package.loaded["src.world.Map"] = realMap
+
+-- Credits lines come from field.credits and therefore need a runtime lookup.
+local Credits = require("src.ui.Credits")
+local credits = setmetatable({}, Credits)
+drawn = {}
+credits:drawPage({ lines = { { text = "DIRECTOR", column = 3 } } }, 0, 1)
+T.eq(drawn[1] and drawn[1].text, "RÉALISATEUR",
+  "extracted credits text passes through Strings before drawing")
+credits.theEnd = { display = "T H E  E N D" }
+credits.endImg = nil
+drawn = {}
+credits:drawTheEnd()
+T.eq(drawn[1] and drawn[1].text, "F I N",
+  "the extracted THE END fallback is translated")
+T.eq(drawn[1] and drawn[1].x, 60,
+  "the translated THE END fallback is centered from Font.width")
+
+-- Text-only title fallbacks are centered from their translated pixel width,
+-- rather than from the English source's hard-coded tile count.
+local TitleState = assert(loadfile("src/ui/TitleState.lua"))()
+local title = setmetatable({
+  game = {}, menuOpen = false, scy = 0, yellowLayout = false,
+  phase = "loop", logo = nil, yellow = false, blue = true, version = nil,
+  player = nil, playerQuads = nil, scrollPhase = "hold", monOffset = 0,
+  currentSprite = function() return nil end,
+  drawCopyright = function() end,
+}, TitleState)
+drawn = {}
+title:draw()
+T.eq(drawn[1] and drawn[1].text, "BLEU",
+  "the translated title fallback is drawn")
+T.eq(drawn[1] and drawn[1].x, 64,
+  "the translated title fallback is centered from Font.width")
+
+local SurfingMinigame = assert(loadfile("src/ui/SurfingMinigame.lua"))()
+local surfing = setmetatable({
+  titleBg = nil, introPikaX = 0,
+  drawIntroPikachu = function() end,
+}, SurfingMinigame)
+drawn = {}
+surfing:drawTitleScreen()
+T.eq(drawn[1] and drawn[1].text, "PLAGE",
+  "the translated beach title fallback is drawn")
+T.eq(drawn[1] and drawn[1].x, 60,
+  "the translated beach title fallback is centered from Font.width")
+
+-- The trade info formats keep their numeric padding after translation.
+local TradeAnim = require("src.ui.TradeAnim")
+local trade = setmetatable({ game = { data = { pokemon = {
+  PIKACHU = { name = "PIKACHU", dex = 25 },
+} } } }, TradeAnim)
+drawn = {}
+trade:drawMonInfo({ species = "PIKACHU" }, "RED", 42, 0)
+T.eq(drawn[1] and drawn[1].text, "N°025",
+  "translated Pokédex number format keeps zero padding")
+T.eq(drawn[4] and drawn[4].text, "ID n°00042",
+  "translated trainer ID format keeps zero padding")
+
+-- Oak's demo step must resolve the ROM label, not translate the label name.
+local OakSpeech = require("src.ui.OakSpeech")
+local oakGame = {
+  data = { text = { _OakSpeechText2A = "MONDE TRADUIT" } },
+  stack = { push = function(_, state) pushed = state end },
+}
+local oak = setmetatable({
+  game = oakGame,
+  demoSpecies = "NIDORINO",
+  demoPic = {},
+  demoTrueColor = false,
+  revealPic = function(_, _, done) done() end,
+  advance = function() end,
+}, OakSpeech)
+pushed = nil
+oak:runStep({ kind = "demo" })
+T.eq(pushed and pushed.text, "MONDE TRADUIT",
+  "Oak demo resolves _OakSpeechText2A through game.data.text")
+
+-- ui.pc.items must inspect stable English labels even with a live catalog;
+-- only the final Menu rows are localized.  This is also the runtime coverage
+-- for the dynamic player's-PC format.
+local function setUpvalue(fn, name, value)
+  local i = 1
+  while true do
+    local found = debug.getupvalue(fn, i)
+    if not found then return false end
+    if found == name then debug.setupvalue(fn, i, value); return true end
+    i = i + 1
+  end
+end
+
+local Overworld = require("src.world.OverworldController")
+local hookLabels, menuItems
+local pcGame = {
+  data = { text = {} },
+  save = {
+    flags = { EVENT_MET_BILL = true },
+    player = { name = "RED" }, hallOfFame = {},
+  },
+  stack = { push = function() end },
+}
+local pcRuntime = {
+  call = function(name, _, _, items)
+    T.eq(name, "ui.pc.items", "the PC rows use the documented hook")
+    hookLabels = {}
+    for i, item in ipairs(items) do hookLabels[i] = item.label end
+    return items
+  end,
+}
+package.loaded["src.ui.Menu"] = {
+  new = function(_, items) menuItems = items; return { items = items } end,
+}
+T.check(setUpvalue(Overworld.openPC, "Game", pcGame),
+  "openPC Game upvalue is injectable")
+T.check(setUpvalue(Overworld.openPC, "Runtime", pcRuntime),
+  "openPC Runtime upvalue is injectable")
+T.check(setUpvalue(Overworld.openPC, "TextBox", {
+  new = function(_, text, onDone) return { text = text, onDone = onDone } end,
+}), "openPC TextBox upvalue is injectable")
+local pc = setmetatable({}, { __index = Overworld })
+pc:openPC()
+T.eq(hookLabels[1], "BILL'S PC",
+  "ui.pc.items sees the stable box-PC source label")
+T.eq(hookLabels[2], "RED's PC",
+  "ui.pc.items sees the stable player-PC source label")
+T.eq(menuItems[1].label, "PC DE LÉO",
+  "the retained box-PC row is translated after the hook")
+T.eq(menuItems[2].label, "PC DE RED",
+  "the dynamic player-PC format is translated exactly once after the hook")
+
+-- Keep a ROM-free guard in the normal engine tier as well as the Python test
+-- that runs modkit's actual harvester.  These literals must stay at static
+-- call sites; wrapping only a variable would work at runtime but disappear
+-- from a freshly generated translation worksheet.
+local function source(path)
+  local file = assert(io.open(path, "r"))
+  local body = file:read("*a")
+  file:close()
+  return body
+end
+
+local harvestCalls = {
+  ["src/ui/BagMenu.lua"] = {
+    'Strings.source("Which move?")', 'Strings.source("ITEMS")',
+  },
+  ["src/ui/BoxMenu.lua"] = {
+    'Strings("WITHDRAW")', 'Strings("DEPOSIT")',
+    'Strings("The party is full!")',
+  },
+  ["src/ui/Diploma.lua"] = {
+    'Strings.source("Congrats! This")',
+    'Strings.source("diploma certifies")',
+  },
+  ["src/ui/FlyMenu.lua"] = { 'Strings.source("FLY TO?")' },
+  ["src/ui/TradeAnim.lua"] = {
+    'Strings("No.%03d",', 'Strings("IDNo.%05d",',
+  },
+  ["src/ui/TrainerCard.lua"] = {
+    'Strings("MONEY/¥%d",', 'Strings("TIME/%3d:%02d",',
+  },
+  ["src/world/OverworldController.lua"] = {
+    'Strings("BILL\'S PC")', 'Strings("%s\'s PC",', 'Strings("HEAL")',
+  },
+}
+for path, calls in pairs(harvestCalls) do
+  local body = source(path)
+  for _, call in ipairs(calls) do
+    T.check(body:find(call, 1, true) ~= nil,
+      path .. " keeps harvestable " .. call)
+  end
+end
+
+Strings.load(nil)
+T.finish()

--- a/tests/gen2_battle_translation_harvest_test.py
+++ b/tests/gen2_battle_translation_harvest_test.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Gen 2 battle keys that must remain visible to modkit's string harvest."""
+
+from pathlib import Path
+from unittest import TestCase, main
+
+import sys
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "tools"))
+import modkit  # noqa: E402
+
+
+class Gen2BattleTranslationHarvestTest(TestCase):
+    def test_battle_templates_and_labels_are_harvested(self):
+        harvested = {
+            literal
+            for literal, _location in modkit.harvest_engine_strings(str(REPO))
+        }
+        expected = {
+            '"%s must recharge!"',
+            '"A critical hit!"',
+            '"But it failed!"',
+            '"%s\'s attack missed!"',
+            '"%s\'s %s was disabled!"',
+            '"%s TRANSFORMED into %s!"',
+            '"%s used %s!"',
+            '"%s is confused!"',
+            '"%s fell asleep!"',
+            '"%s was poisoned!"',
+            '"%s was badly poisoned!"',
+            '"%s is paralyzed! It may be unable to move!"',
+            '"%s was burned!"',
+            '"%s was frozen solid!"',
+            '"%s is hurt by poison!"',
+            '"%s is hurt by its burn!"',
+            '"It started to rain!"',
+            '"The rain stopped."',
+            '"The sandstorm rages."',
+            '"%s gained %d EXP. Points!"',
+            '"Can\'t escape!"',
+            '"FIGHT"',
+            '"<PK><MN>"',
+            '"PACK"',
+            '"RUN"',
+            '"PARKBALL\\xc3\\x97%02d"',
+            '"YES"',
+            '"NO"',
+            '"Gotcha! %s was caught!"',
+            '"%s was sent to BILL\'s PC."',
+            '"Wild %s appeared!"',
+            '"%s sent out %s!"',
+        }
+        self.assertEqual(expected - harvested, set())
+
+    def test_no_runtime_name_is_used_as_a_catalog_key(self):
+        battle = (REPO / "src/battle/gen2/Battle.lua").read_text(
+            encoding="utf-8"
+        )
+        screen = (REPO / "src/ui/gen2/BattleState.lua").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn('Strings(name ..', battle)
+        self.assertNotIn('Strings(self:monName', battle)
+        self.assertNotIn('Strings(self:name', screen)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/gen2_crystal_gender_test.lua
+++ b/tests/gen2_crystal_gender_test.lua
@@ -23,6 +23,7 @@ local Pokegear = require("src.ui.gen2.Pokegear")
 local Save = require("src.core.gen2.Save")
 local Screens = require("src.ui.Screens")
 local TrainerCard = require("src.ui.gen2.TrainerCard")
+local Strings = require("src.core.Strings")
 
 local priorVersion = GameVersion.get()
 
@@ -165,6 +166,29 @@ eq(save.player.gender, "female", "A on Girl writes PLAYERGENDER_FEMALE")
 
 check(type(screen.text) == "string" and screen.text:find("boy"),
   "the prompt is _AreYouABoyOrAreYouAGirlText")
+
+-- The ROM prompt remains the source of truth while the two finite menu rows
+-- go through the translation catalog.
+do
+  local Chrome = require("src.ui.gen2.Chrome")
+  local priorPrint = Chrome.print
+  local printed = {}
+  Chrome.print = function(text) printed[#printed + 1] = text end
+  Strings.load({ strings = { Boy = "Garçon", Girl = "Fille" } })
+  local translated = GenderSelect.new({ data = { text = {
+    _AreYouABoyOrAreYouAGirlText = "ROM prompt stays intact",
+  } } })
+  eq(translated.text, "ROM prompt stays intact",
+    "the extracted RomText prompt is not replaced by a catalog fallback")
+  translated.text = ""
+  translated:drawPanel()
+  check(table.concat(printed, "|"):find("Garçon", 1, true) ~= nil,
+    "Boy is translated when drawn")
+  check(table.concat(printed, "|"):find("Fille", 1, true) ~= nil,
+    "Girl is translated when drawn")
+  Strings.load({})
+  Chrome.print = priorPrint
+end
 
 -- ------------------------------------------------- the beat in Oak's speech
 

--- a/tests/gen2_decorations_test.lua
+++ b/tests/gen2_decorations_test.lua
@@ -11,6 +11,7 @@ local check, eq = S.check, S.eq
 
 local Decorations = require("src.core.gen2.Decorations")
 local Events = require("src.world.gen2.Events")
+local Strings = require("src.core.Strings")
 local Vm = require("src.script.gen2.Vm")
 
 -- constants/deco_constants.asm, the handful this file names.
@@ -52,6 +53,16 @@ do
     "the TOWN MAP poster is a DecorationNames string, not a mon plus POSTER")
   eq(Decorations.name(DECO_GOLD_TROPHY_DOLL), "GOLD TROPHY",
     "and so is the trophy")
+
+  -- The kind is a translated format template, not an English suffix welded
+  -- to the registry's base name.  A language may therefore put it first.
+  Strings.load({ strings = { ["%s BED"] = "BED <%s>",
+    ["BIG %s"] = "%s GIANT" } })
+  eq(Decorations.name(DECO_FEATHERY_BED), "BED <FEATHERY>",
+    "a translated bed template controls grammatical order")
+  eq(Decorations.name(DECO_BIG_SNORLAX_DOLL), "SNORLAX GIANT",
+    "and the big-doll template can move its modifier")
+  Strings.load(nil)
 end
 
 -- ---- owning ---------------------------------------------------------------

--- a/tests/gen2_evolution_anim_test.lua
+++ b/tests/gen2_evolution_anim_test.lua
@@ -20,12 +20,27 @@ local S = require("tests.harness").suite("gen2 evolution anim")
 local check, eq = S.check, S.eq
 
 local EvolutionAnim = require("src.ui.gen2.EvolutionAnim")
+local Strings = require("src.core.Strings")
 
 -- No screen may use the stack's hook name for its own purposes.
 check(rawget(EvolutionAnim, "enter") == nil,
       "EvolutionAnim does not define `enter` (the stack lifecycle hook)")
 check(type(rawget(EvolutionAnim, "setPhase")) == "function",
       "its phase transition has a name of its own")
+
+do
+  Strings.load({ strings = {
+    ["What? %s\nis evolving!"] = "Quoi ? %s\nevolue !",
+  } })
+  local mon = { species = "OLD", nickname = "SURNOM", moves = {} }
+  local anim = EvolutionAnim.new({ data = { audio = {} } }, {
+    mon = mon, entry = { into = "NEW" }, party = { mon },
+  })
+  eq(anim.lines[1], "Quoi ? SURNOM",
+    "evolution messages use a complete translated template")
+  eq(anim.lines[2], "evolue !", "the translated template is split afterwards")
+  Strings.load({})
+end
 
 local cache = os.getenv("GOLD_CACHE")
 if not cache then

--- a/tests/gen2_map_radio_test.lua
+++ b/tests/gen2_map_radio_test.lua
@@ -163,11 +163,16 @@ end
 do
   local save = Save.newGame()
   local game = newGame(save)
+  game.data.gen2RadioChannels = {
+    LUCKY_CHANNEL = { channel = 4, name = "CANAL CHANCE" },
+  }
   local mr = MapRadio.new(game, {
     channel = 4, radioData = RADIO_DATA, radioRng = rolls(0), save = save,
   })
   eq(mr.station, "LUCKY_CHANNEL",
     "Radio2Script's MAPRADIO_LUCKY_CHANNEL is index 4")
+  eq(mr:name(), "CANAL CHANCE",
+    "the wall radio consumes the registry-patched station name")
 end
 
 S.finish()

--- a/tests/gen2_menus_test.lua
+++ b/tests/gen2_menus_test.lua
@@ -784,9 +784,51 @@ dexGame.data.gen2Pokedex = {
   newOrder = { "BULBASAUR", "IVYSAUR" },
   alphabeticalOrder = { "BULBASAUR", "IVYSAUR" },
 }
+dexGame.data.pokemon.BULBASAUR = { types = { "GRASS", "POISON" } }
+dexGame.data.pokemon.IVYSAUR = { types = { "GRASS", "POISON" } }
 local dex = PokedexMenu.new(dexGame, {})
 check("dex lists every entry", #dex.rows, 2)
 check("dex starts in NEW mode", dex:mode(), "NEW")
+
+-- The dex's ROM `db` labels are catalog strings, resolved at draw time.  Stub
+-- its tile primitives and inspect the exact text writes without a GPU.
+require("src.core.Strings").load({ strings = {
+  SEEN = "VUS", OWN = "PRIS", HT = "TAILLE", WT = "POIDS",
+  NEW = "JOHTO", ["NEW POKéDEX MODE"] = "MODE JOHTO",
+  ["<PK><MN> are listed by"] = "Les POKéMON suivent",
+  ["evolution type."] = "leur évolution.", TYPE1 = "TYPE A",
+  TYPE2 = "TYPE B", ["BEGIN SEARCH!!"] = "CHERCHER !!",
+  CANCEL = "ANNULER",
+} })
+drawn = {}
+dex.text = function(_, text, x, y) drawn[x .. ":" .. y] = text end
+dex.fill, dex.border, dex.tile = function() end, function() end, function() end
+dex.blank, dex.drawPic, dex.drawFootprint = function() end, function() end,
+  function() end
+dex:drawMainBackground()
+check("SEEN is localizable", drawn["1:11"], "VUS")
+check("OWN is localizable", drawn["1:14"], "PRIS")
+drawn = {}
+dex.optionIndex = 1
+dex:drawOption()
+check("a mode label is localizable", drawn["3:4"], "MODE JOHTO")
+check("a mode description is localizable",
+  drawn["1:14"], "Les POKéMON suivent")
+drawn = {}
+dex:drawSearch()
+check("TYPE1 is localizable", drawn["3:4"], "TYPE A")
+check("TYPE2 is localizable", drawn["3:6"], "TYPE B")
+check("BEGIN SEARCH is localizable", drawn["3:13"], "CHERCHER !!")
+check("the dex CANCEL row is localizable", drawn["3:15"], "ANNULER")
+drawn = {}
+dex.newEntry = true
+dex:drawEntryBody(dex.rows[1], dex.data.gen2Pokedex.entries.BULBASAUR)
+check("HT is localizable", drawn["9:7"], "TAILLE")
+check("WT is localizable", drawn["9:9"], "POIDS")
+dex.text, dex.fill, dex.border, dex.tile = nil, nil, nil, nil
+dex.blank, dex.drawPic, dex.drawFootprint = nil, nil, nil
+dex.newEntry = nil
+require("src.core.Strings").load(nil)
 -- Pokedex_UpdateMainScreen: SELECT opens the OPTION screen and START the
 -- SEARCH screen.  Neither cycles anything in place -- the mode changes when
 -- the OPTION screen's own cursor picks one and A confirms it.
@@ -812,6 +854,23 @@ end)(), "search")
 -- Pokedex_InitSearchScreen: TYPE1 starts on NORMAL and TYPE2 on "-----".
 check("TYPE1 starts on NORMAL", dex:searchTypeName(1), "NORMAL")
 check("TYPE2 starts blank", dex:searchTypeName(2), "-----")
+-- Display names come from the type registry, while matching stays on the
+-- stable type id.  Translating GRASS must still find a GRASS species.
+dex.data.type_chart = { types = { GRASS = { name = "HERBE" } } }
+dex.searchType[1] = 12 -- GRASS in SEARCH_TYPES
+check("the search wheel draws the translated type name",
+  dex:searchTypeName(1), "HERBE")
+dexSave.pokedex.seen.BULBASAUR = true
+dex:rebuild()
+dex:beginSearch()
+check("translated type display does not change search identity",
+  #dex.searchResults, 1)
+dex.data.type_chart = nil
+dexSave.pokedex.seen.BULBASAUR = nil
+dex.searchType[1] = 1
+dex.searchResults = nil
+dex.searchMessage = nil
+dex.view = "search"
 check("B leaves the SEARCH screen", (function()
   dexGame.input:press("b")
   dex:update(0)

--- a/tests/gen2_party_menu_test.lua
+++ b/tests/gen2_party_menu_test.lua
@@ -61,6 +61,10 @@ local Mail = require("src.core.gen2.Mail")
 local Mon = require("src.battle.gen2.Mon")
 local PartyMenu = require("src.ui.gen2.PartyMenu")
 local SummaryMenu = require("src.ui.gen2.SummaryMenu")
+local Gen2Battle = require("src.battle.gen2.Battle")
+local Registry = require("src.mods.Registry")
+local Schemas = require("src.mods.Schemas")
+local Strings = require("src.core.Strings")
 
 local failures, checks = 0, 0
 local function check(name, got, want)
@@ -149,6 +153,15 @@ local DATA = {
   },
 }
 
+local function mergedGen2Statuses()
+  local registry = Registry.new("statuses", Schemas.REGISTRIES.statuses)
+  registry.base = function() return Gen2Battle.STATUSES end
+  registry:patch("poison", { hudLabel = "TOX" }, "translation")
+  local merged = {}
+  for id in pairs(Gen2Battle.STATUSES) do merged[id] = registry:get(id) end
+  return merged, registry
+end
+
 local function newGame(save)
   return {
     input = newInput(),
@@ -212,6 +225,12 @@ check("a healthy mon has no status", row.status, nil)
 local fnt = mon("TOTODILE", 10, { fields = { hp = 0 } })
 check("a fainted mon reads FNT", PartyMenu.rowFor(fnt).status, "FNT")
 
+local poisoned = mon("TOTODILE", 10, { fields = { status = "poison" } })
+DATA.gen2Statuses = mergedGen2Statuses()
+check("a status registry translation reaches a Gen 2 party row",
+  PartyMenu.rowFor(poisoned, nil, DATA.gen2Statuses).status, "TOX")
+DATA.gen2Statuses = nil
+
 -- PartyMenuCheckEgg: every quality routine skips an EGG's row, and the name
 -- is String_Egg -- never the species hiding inside.
 local eggRow = PartyMenu.rowFor(egg())
@@ -235,6 +254,27 @@ check("an egg's submenu has three rows", #eggItems, 3)
 check("STATS first", eggItems[1].id, "STATS")
 check("SWITCH second", eggItems[2].id, "SWITCH")
 check("CANCEL third", eggItems[3].id, "CANCEL")
+
+Strings.load({ strings = {
+  STATS = "STATS FR", SWITCH = "ÉCHANGER", MOVE = "DÉPLACER",
+  ITEM = "OBJET", MAIL = "COURRIER", CANCEL = "ANNULER",
+  FNT = "K.O.", EGG = "ŒUF", ABLE = "APTE", ["NOT ABLE"] = "INAPTE",
+} })
+local translatedItems = party:submenuItems(save.party[1])
+check("the submenu keeps a stable STATS id", translatedItems[1].id, "STATS")
+check("and translates the STATS label", translatedItems[1].label, "STATS FR")
+check("SWITCH is localizable", translatedItems[2].label, "ÉCHANGER")
+check("MOVE is localizable", translatedItems[3].label, "DÉPLACER")
+check("ITEM is localizable", translatedItems[4].label, "OBJET")
+check("CANCEL is localizable", translatedItems[5].label, "ANNULER")
+check("FNT is localizable", PartyMenu.rowFor(fnt).status, "K.O.")
+check("EGG is localizable", PartyMenu.rowFor(egg()).name, "ŒUF")
+party.tmhm = { move = "SURF" }
+DATA.pokemon.CYNDAQUIL.tmhm = { "SURF" }
+check("ABLE is localizable", party:tmhmAble(save.party[1]), "APTE")
+check("NOT ABLE is localizable", party:tmhmAble(save.party[2]), "INAPTE")
+DATA.pokemon.CYNDAQUIL.tmhm = nil
+Strings.load(nil)
 
 -- GiveTakePartyMonItem's first test is `cp EGG`: the held-item menu refuses.
 game = newGame(save)

--- a/tests/gen2_pc_screens_test.lua
+++ b/tests/gen2_pc_screens_test.lua
@@ -63,9 +63,11 @@ local check, eq = S.check, S.eq
 local Bag = require("src.inventory.Bag")
 local CenterPcMenu = require("src.ui.gen2.CenterPcMenu")
 local ItemPcMenu = require("src.ui.gen2.ItemPcMenu")
+local PcMenu = require("src.ui.gen2.PcMenu")
 local Map = require("src.world.gen2.Map")
 local Save = require("src.core.gen2.Save")
 local Screens = require("src.ui.Screens")
+local Strings = require("src.core.Strings")
 local Vm = require("src.script.gen2.Vm")
 local World = require("src.world.gen2.World")
 
@@ -152,6 +154,142 @@ eq(Screens.get(sg, "Gen2CenterPcMenu"), CenterPcMenu,
   "Gen2CenterPcMenu resolves to its builtin")
 eq(Screens.get(sg, "Gen2ItemPcMenu"), ItemPcMenu,
   "Gen2ItemPcMenu resolves to its builtin")
+
+-- Built-in PC rows are finite UI labels.  The player's name remains raw and
+-- is interpolated only after the surrounding label has been translated.
+do
+  local Chrome = require("src.ui.gen2.Chrome")
+  local priorPrint = Chrome.print
+  local printed = {}
+  Chrome.print = function(text) printed[#printed + 1] = text end
+  Strings.load({ strings = {
+    ["BILL's PC"] = "PC DE LEO",
+    ["%s's PC"] = "PC DE %s",
+    ["TURN OFF"] = "ETEINDRE",
+    ["WITHDRAW <PK><MN>"] = "RETIRER <PK><MN>",
+    ["WITHDRAW ITEM"] = "RETIRER OBJET",
+    ["LOG OFF"] = "DECONNEXION",
+  } })
+
+  local save = newSave(1)
+  local game = newGame(save)
+  local center = CenterPcMenu.new(game, { save = save })
+  center.message = nil
+  -- drawPanel only draws the entry rows once booted (dev's PC boot-sequence
+  -- gate); this check is about label translation, not the boot animation.
+  center.booted = true
+  center:drawPanel()
+  local pc = PcMenu.new(game, { save = save, bills = true })
+  pc:drawPanel()
+  local items = ItemPcMenu.new(game, { save = save })
+  items:drawPanel()
+  local all = table.concat(printed, "|")
+  check(all:find("PC DE LEO", 1, true) ~= nil, "BILL's PC is translated")
+  check(all:find("PC DE GOLD", 1, true) ~= nil,
+    "the player name stays raw inside a translated PC label")
+  check(all:find("RETIRER <PK><MN>", 1, true) ~= nil,
+    "the storage PC action is translated")
+  check(all:find("RETIRER OBJET", 1, true) ~= nil,
+    "the item PC action is translated")
+  check(all:find("DECONNEXION", 1, true) ~= nil,
+    "the item PC exit is translated")
+
+  Strings.load({})
+  Chrome.print = priorPrint
+end
+
+-- PC messages are whole catalog keys, including the dynamic item-name and
+-- quantity templates. Names supplied by registries remain raw arguments.
+do
+  Strings.load({ strings = {
+    ["{PLAYER} turned on\nthe PC."] = "{PLAYER} ACTIVE\nPC-FR.",
+    ["BILL's PC\naccessed.\n\n#MON Storage\nSystem opened."] =
+      "PC LEO OUVERT.\n\nSTOCKAGE OUVERT.",
+    ["What do you want\nto do?"] = "QUE FAIRE?",
+    ["Withdrew %d\n%s(S)."] = "PRIS %d\n%s.",
+    ["Toss out how many\n%s(S)?"] = "JETER COMBIEN\n%s?",
+    POTION = "INTERDIT",
+  } })
+  local save = newSave(1)
+  save.pcItems.POTION = 2
+  local game = newGame(save)
+
+  local center = CenterPcMenu.new(game, { save = save })
+  eq(center.message.pages[1][1], "{PLAYER} ACTIVE",
+    "the Center PC boot message is translated as a whole key")
+  center.message = nil
+  center.index = 1
+  center:choose()
+  eq(center.message.pages[1][1], "PC LEO OUVERT.",
+    "the Center PC access flow is translated")
+
+  local itemPc = ItemPcMenu.new(game, { save = save, items = ITEMS })
+  itemPc:withdraw({ id = "POTION", name = "POTION" }, 1)
+  eq(itemPc.message.pages[1][1], "PRIS 1",
+    "the item PC quantity template is translated")
+  eq(itemPc.message.pages[1][2], "POTION.",
+    "an item name remains a raw template argument")
+  itemPc.message = nil
+  itemPc.rows = { { id = "POTION", name = "POTION", count = 1 } }
+  itemPc.listIndex = 1
+  itemPc:chooseToss()
+  eq(itemPc.qtyState.prompt[1], "JETER COMBIEN",
+    "the item PC toss prompt is translated")
+  eq(itemPc.qtyState.prompt[2], "POTION?",
+    "the toss prompt also preserves the item name argument")
+  Strings.load({})
+end
+
+-- A mod may intentionally reuse a built-in source label. Only rows marked by
+-- the engine are translated; collision labels injected through the hook stay
+-- byte-for-byte mod content.
+do
+  local Chrome = require("src.ui.gen2.Chrome")
+  local Hooks = require("src.mods.Hooks")
+  local Runtime = require("src.mods.Runtime")
+  local priorEvents, priorHooks, priorErrors =
+    Runtime.events, Runtime.hooks, Runtime.errors
+  local priorPrint = Chrome.print
+  local printed = {}
+  Chrome.print = function(text) printed[#printed + 1] = text end
+  Strings.load({ strings = {
+    ["WITHDRAW <PK><MN>"] = "RETIRER MON",
+    ["WITHDRAW ITEM"] = "RETIRER OBJET",
+  } })
+
+  local function hookedWith(label)
+    local hooks = Hooks.new()
+    hooks:wrap("ui.pc.items", function(nextFn, game, entries)
+      entries = nextFn(game, entries)
+      entries[#entries + 1] = { id = "collision", label = label }
+      return entries
+    end)
+    Runtime.install(priorEvents, hooks, priorErrors or {})
+  end
+
+  local save = newSave(1)
+  local game = newGame(save)
+  hookedWith("WITHDRAW <PK><MN>")
+  PcMenu.new(game, { save = save, bills = true }):drawPanel()
+  local all = table.concat(printed, "|")
+  check(all:find("RETIRER MON", 1, true) ~= nil,
+    "PcMenu translates its marked built-in row")
+  check(all:find("WITHDRAW <PK><MN>", 1, true) ~= nil,
+    "PcMenu leaves a colliding hook label raw")
+
+  printed = {}
+  hookedWith("WITHDRAW ITEM")
+  ItemPcMenu.new(game, { save = save }):drawPanel()
+  all = table.concat(printed, "|")
+  check(all:find("RETIRER OBJET", 1, true) ~= nil,
+    "ItemPcMenu translates its marked built-in row")
+  check(all:find("WITHDRAW ITEM", 1, true) ~= nil,
+    "ItemPcMenu leaves a colliding hook label raw")
+
+  Strings.load({})
+  Chrome.print = priorPrint
+  Runtime.install(priorEvents, priorHooks, priorErrors)
+end
 
 -- ------------------------------------------------- the whose-PC gating
 
@@ -899,6 +1037,43 @@ do
   press(menu, input, "select")
   eq(#game.stack._items, 0, "SELECT on the move screen opens nothing")
   eq(census(save), 5, "and releases nothing")
+end
+
+-- Box-screen labels and complete prompts are translated at draw/use time;
+-- box names and nicknames remain save content even when they collide with a
+-- catalog key.
+do
+  local BoxMenu = require("src.ui.gen2.BoxMenu")
+  local Boxes = require("src.core.gen2.Boxes")
+  local Strings = require("src.core.Strings")
+  Strings.load({ strings = {
+    ["PARTY <PK><MN>"] = "EQUIPE <PK><MN>",
+    ["Choose a <PK><MN>."] = "Choisissez un <PK><MN>.",
+    ["What's up?"] = "Que faire ?",
+    ["Release <PK><MN>?"] = "Relacher le <PK><MN> ?",
+    ["BOX CUSTOM"] = "NE PAS TRADUIRE",
+  } })
+  local save = newSave(3)
+  save.boxNames = save.boxNames or {}
+  save.boxNames[1] = "BOX CUSTOM"
+  Boxes.box(save, 1)[1] = { species = "PIDGEY", nickname = "BOX CUSTOM",
+    hp = 10, maxHp = 10, level = 3 }
+  local game = newGame(save)
+  local move = BoxMenu.new(game, { save = save, mode = "move" })
+  eq(move:prompt(), "Choisissez un <PK><MN>.",
+    "the complete choose-mon prompt passes through Strings")
+  move.phase = "submenu"
+  eq(move:prompt(), "Que faire ?", "the complete submenu prompt is translated")
+  move.boxIndex = 0
+  eq(move:title(), "EQUIPE <PK><MN>", "the built-in PARTY title is translated")
+  move.boxIndex = 1
+  eq(move:title(), "BOX CUSTOM", "a user-defined box name remains raw")
+
+  local withdraw = BoxMenu.new(game, { save = save, mode = "withdraw" })
+  withdraw:askRelease()
+  eq(withdraw.message, "Relacher le <PK><MN> ?",
+    "the complete release prompt passes through Strings")
+  Strings.load({})
 end
 
 S.finish()

--- a/tests/gen2_pokegear_unlock_test.lua
+++ b/tests/gen2_pokegear_unlock_test.lua
@@ -29,6 +29,7 @@ require("src.core.Logger").warn = function() end
 
 local Pokegear = require("src.ui.gen2.Pokegear")
 local Save = require("src.core.gen2.Save")
+local Strings = require("src.core.Strings")
 local StartMenu = require("src.ui.gen2.StartMenu")
 local Vm = require("src.script.gen2.Vm")
 local World = require("src.world.gen2.World")
@@ -263,6 +264,59 @@ do
     "and 13.5 resolves the ????? station at the Ruins of Alph")
   local away = stationAt(save, "LANDMARK_NEW_BARK_TOWN", 52)
   eq(away and away.station, nil, "which is dead air anywhere else")
+end
+
+-- Station presentation is the radio_channels registry's concern; the show id
+-- and dial mechanics stay unchanged.  Fixed show prose resolves through the
+-- strings catalog only when the machine prints it.
+do
+  local save = Save.newGame()
+  local world = newWorld(save)
+  world:setEngineFlag(3, true)
+  local game = newGame(save)
+  game.data.gen2RadioChannels = {
+    POKE_FLUTE_RADIO = { channel = 7, name = "FLÛTE RADIO" },
+  }
+  local gear = Pokegear.new(game, { save = save, landmarks = LANDMARKS,
+    currentLandmark = "LANDMARK_VERMILION_CITY" })
+  eq(gear:stations()[7].name, "FLÛTE RADIO",
+    "the Pokegear consumes a registry-patched station name")
+
+  Strings.load({ strings = {
+    ["MARY: PROF.OAK'S"] = "MARIE : PROF.CHEN",
+    -- Registry-authored display values are complete content, not source keys.
+    ["FLÛTE RADIO"] = "THIS MUST NOT BE USED",
+  } })
+  eq(gear:stations()[7].name, "FLÛTE RADIO",
+    "a mod-authored station name is not translated a second time")
+
+  Strings.load({ strings = {
+    CLOCK = "HORLOGE", MAP = "CARTE", PHONE = "TÉLÉPHONE",
+    RADIO = "RADIO FR", FLY = "VOL", AM = "MATIN", PM = "SOIR",
+    ["Whom do you want to call?"] = "Qui voulez-vous appeler ?",
+  } })
+  eq(gear:cardLabel(Pokegear.CARDS[1]), "HORLOGE", "CLOCK is localizable")
+  eq(gear:cardLabel(Pokegear.CARDS[2]), "CARTE", "MAP is localizable")
+  eq(gear:cardLabel(Pokegear.CARDS[3]), "TÉLÉPHONE", "PHONE is localizable")
+  eq(gear:cardLabel(Pokegear.CARDS[4]), "RADIO FR", "RADIO is localizable")
+  local flyGear = Pokegear.new(game, {
+    save = save, landmarks = LANDMARKS,
+    currentLandmark = "LANDMARK_VERMILION_CITY",
+    fly = { { name = "VERMILION", landmark = "LANDMARK_VERMILION_CITY" } },
+  })
+  eq(flyGear:cardLabel(), "VOL", "FLY is localizable")
+  eq(gear:phoneText("AskWhoCall"), "Qui voulez-vous appeler ?",
+    "the complete built-in phone prompt is localizable")
+
+  Strings.load({ strings = {
+    ["MARY: PROF.OAK'S"] = "MARIE : PROF.CHEN",
+  } })
+  local radio = Pokegear.Radio.new()
+  radio:tune("OAKS_POKEMON_TALK")
+  radio:step()
+  eq(radio.top, "MARIE : PROF.CHEN",
+    "radio show prose resolves through the strings catalog")
+  Strings.load(nil)
 end
 
 -- ---- ExitPokegearRadio_HandleMusic -----------------------------------------

--- a/tests/gen2_registry_ui_harvest_test.py
+++ b/tests/gen2_registry_ui_harvest_test.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Gen 2 registry-adjacent UI keys that must stay in the string catalog."""
+
+from pathlib import Path
+from unittest import TestCase, main
+
+import sys
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "tools"))
+import modkit  # noqa: E402
+
+
+def lua_literal(source):
+    return '"' + source.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+class Gen2RegistryUiHarvestTest(TestCase):
+    def test_registry_ui_labels_are_harvested(self):
+        harvested = {
+            literal
+            for literal, _location in modkit.harvest_engine_strings(str(REPO))
+        }
+        expected_sources = {
+            # Party list, submenu, and complete prompt records.
+            "ABLE", "NOT ABLE", "FNT", "EGG", "STATS", "SWITCH",
+            "MOVE", "ITEM", "MAIL", "CANCEL", "Choose a POKéMON.",
+            "Use on which <PK><MN>?", "Which <PK><MN>?",
+            "Teach which <PK><MN>?", "Move to where?",
+            "To which <PK><MN>?", "You have no <PK><MN>!",
+            # Summary labels and full egg prose keys.
+            "OK", "POKéRUS", "TO", "PP", "ATTK/", "OT/", "<ID>№.", "№.",
+            "ATTACK", "DEFENSE", "SPCL.ATK", "SPCL.DEF", "SPEED",
+            "STATUS/", "TYPE/", "EXP POINTS", "LEVEL UP", "Where?",
+            "It's making sounds<NEXT>inside. It's going<NEXT>to hatch soon!",
+            "This EGG needs a<NEXT>lot more time to<NEXT>hatch.",
+            # Pokedex and Pokegear display records.
+            " PAGE AREA CRY PRNT", "lb", "%s'S NEST", "SEEN", "OWN",
+            "HT", "WT", "TYPE1", "TYPE2", "BEGIN SEARCH!!",
+            "CLOCK", "MAP", "PHONE", "RADIO", "FLY", "NO CARD DATA",
+            "AM", "PM", "DAY", "CALL", "DELETE",
+            "Whom do you want to call?", "Press any button to exit.",
+        }
+        expected = {lua_literal(source) for source in expected_sources}
+        self.assertEqual(expected - harvested, set())
+
+    def test_dynamic_clock_and_raw_display_bypasses_do_not_return(self):
+        party = (REPO / "src/ui/gen2/PartyMenu.lua").read_text(encoding="utf-8")
+        summary = (REPO / "src/ui/gen2/SummaryMenu.lua").read_text(
+            encoding="utf-8"
+        )
+        dex = (REPO / "src/ui/gen2/PokedexMenu.lua").read_text(encoding="utf-8")
+        for relative in ("src/ui/gen2/Pokegear.lua", "src/ui/gen2/MainMenu.lua"):
+            clock = (REPO / relative).read_text(encoding="utf-8")
+            self.assertNotIn('Strings(hour < 12 and "AM" or "PM")', clock)
+
+        self.assertNotIn('return "ABLE"', party)
+        self.assertNotIn('return "NOT ABLE"', party)
+        self.assertNotIn('return "FNT"', party)
+        self.assertNotIn('put(out, "POKéRUS"', summary)
+        self.assertNotIn('put(out, "ATTK/"', summary)
+        self.assertNotIn('self:text(" PAGE AREA CRY PRNT"', dex)
+        self.assertNotIn('self:text("lb"', dex)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/gen2_summary_test.lua
+++ b/tests/gen2_summary_test.lua
@@ -52,6 +52,11 @@ require("src.core.Logger").warn = function() end
 local Mon = require("src.battle.gen2.Mon")
 local PartyMenu = require("src.ui.gen2.PartyMenu")
 local SummaryMenu = require("src.ui.gen2.SummaryMenu")
+local TypeChart = require("src.battle.TypeChart")
+local Gen2Battle = require("src.battle.gen2.Battle")
+local Registry = require("src.mods.Registry")
+local Schemas = require("src.mods.Schemas")
+local Strings = require("src.core.Strings")
 
 local failures, checks = 0, 0
 local function check(name, got, want)
@@ -148,6 +153,18 @@ local DATA = {
   },
   gen2MenuGfx = {},
 }
+
+local function mergedGen2Statuses()
+  local registry = Registry.new("statuses", Schemas.REGISTRIES.statuses)
+  registry.base = function() return Gen2Battle.STATUSES end
+  registry:patch("poison", { hudLabel = "TOX" }, "translation")
+  registry:register("dizzy", { id = "dizzy", label = "DZY",
+    hudLabel = "DIZ" }, "status_mod")
+  local merged = {}
+  for id in pairs(Gen2Battle.STATUSES) do merged[id] = registry:get(id) end
+  merged.dizzy = registry:get("dizzy")
+  return merged, registry
+end
 
 local function newGame(save)
   return {
@@ -315,6 +332,12 @@ check("a healthy mon reads OK at hlcoord 6,13", at(pink, 6, 13), "OK")
 -- 17 up onto row 16 -- so the second type ends one row under the first.
 check("type 1 at hlcoord 1,15", at(pink, 1, 15), "FIRE")
 check("a single-typed mon has no second type", at(pink, 1, 16), nil)
+DATA.type_chart = { types = { FIRE = { name = "FEU" } } }
+check("the Gen 2 summary uses the type registry's display name",
+  at(screen:pinkPlacements(), 1, 15), "FEU")
+DATA.type_chart = nil
+check("the unloaded Gen 2 curse type keeps its cart display name",
+  TypeChart.displayName("CURSE_TYPE"), "???")
 check("EXP POINTS at hlcoord 10,9", at(pink, 10, 9), "EXP POINTS")
 check("LEVEL UP at hlcoord 10,12", at(pink, 10, 12), "LEVEL UP")
 check("TO at hlcoord 14,14", at(pink, 14, 14), "TO")
@@ -343,6 +366,19 @@ check("type 2 one row below it", at(dualPink, 1, 16), "POISON")
 local sick = newSummary()
 sick.mon = mon("TOTODILE", 10, { fields = { status = "psn" } })
 check("a poisoned mon reads PSN", at(sick:pinkPlacements(), 6, 13), "PSN")
+local mergedStatuses, statusRegistry = mergedGen2Statuses()
+DATA.gen2Statuses = mergedStatuses
+check("a status registry translation reaches the Gen 2 summary",
+  at(sick:pinkPlacements(), 6, 13), "TOX")
+sick.mon.status = "dizzy"
+check("a registered Gen 2 status reaches the summary HUD",
+  at(sick:pinkPlacements(), 6, 13), "DIZ")
+sick.mon.status = "psn"
+check("registering over a built-in Gen 2 status collides",
+  pcall(function()
+    statusRegistry:register("poison", { id = "poison", label = "BAD" }, "bad")
+  end), false)
+DATA.gen2Statuses = nil
 local fainted = newSummary()
 fainted.mon = mon("TOTODILE", 10, { fields = { hp = 0, status = nil } })
 check("a fainted mon reads FNT", at(fainted:pinkPlacements(), 6, 13), "FNT")
@@ -367,6 +403,54 @@ local green = screen:greenPlacements()
 check("ITEM at hlcoord 0,8", at(green, 0, 8), "ITEM")
 check("the held item at hlcoord 6,8", at(green, 6, 8), "BERRY")
 check("MOVE at hlcoord 0,10", at(green, 0, 10), "MOVE")
+
+-- These labels are engine strings rather than ROM text records.  Resolve at
+-- placement time so a catalog loaded after the module still reaches them.
+Strings.load({ strings = {
+  ["STATUS/"] = "ÉTAT/", ["TYPE/"] = "GENRE/",
+  ["EXP POINTS"] = "POINTS EXP", ["LEVEL UP"] = "NIVEAU +",
+  ITEM = "OBJET", MOVE = "CAPACITÉ", ["Where?"] = "Où ?",
+  FNT = "K.O.", OK = "BIEN", ["POKéRUS"] = "POKéVIRUS", TO = "À",
+  PP = "PC", ["ATTK/"] = "ATQ/", ["OT/"] = "DO/",
+  ["<ID>№."] = "<ID>N°", ["№."] = "N°", EGG = "ŒUF",
+  ATTACK = "ATTAQUE",
+  DEFENSE = "DÉFENSE", ["SPCL.ATK"] = "ATQ.SPÉ",
+  ["SPCL.DEF"] = "DÉF.SPÉ", SPEED = "VITESSE",
+  ["This EGG needs a<NEXT>lot more time to<NEXT>hatch."] =
+    "Cet ŒUF demande<NEXT>encore beaucoup de<NEXT>temps.",
+} })
+local translatedPink = screen:pinkPlacements()
+check("STATUS/ is localizable", at(translatedPink, 0, 12), "ÉTAT/")
+check("TYPE/ is localizable", at(translatedPink, 0, 14), "GENRE/")
+check("EXP POINTS is localizable", at(translatedPink, 10, 9), "POINTS EXP")
+check("LEVEL UP is localizable", at(translatedPink, 10, 12), "NIVEAU +")
+check("OK is localizable", at(translatedPink, 6, 13), "BIEN")
+check("TO is localizable", at(translatedPink, 14, 14), "À")
+local translatedGreen = screen:greenPlacements()
+check("ITEM is localizable", at(translatedGreen, 0, 8), "OBJET")
+check("MOVE is localizable", at(translatedGreen, 0, 10), "CAPACITÉ")
+check("PP is localizable", at(translatedGreen, 12, 11), "PC")
+screen.swapFrom = 1
+check("the move destination prompt is localizable",
+  at(screen:moveDetailPlacements(), 1, 12), "Où ?")
+screen.swapFrom = nil
+check("FNT is localizable", at(fainted:pinkPlacements(), 6, 13), "K.O.")
+check("POKéRUS is localizable",
+  at(pkrs:pinkPlacements(), 1, 13), "POKéVIRUS")
+check("the ID label is localizable",
+  at(screen:bluePlacements(), 0, 9), "<ID>N°")
+check("the OT label is localizable", at(screen:bluePlacements(), 0, 12), "DO/")
+check("the dex number label is localizable",
+  at(screen:upperPlacements(), 8, 0), "N°")
+check("stat labels are localizable",
+  at(screen:bluePlacements(), 11, 8), "ATTAQUE")
+check("ATTK is localizable",
+  at(screen:moveDetailPlacements(), 11, 12), "ATQ/")
+screen.mon = { isEgg = true, eggSteps = 41 }
+check("EGG is localizable", at(screen:eggPlacements(), 8, 1), "ŒUF")
+check("complete egg prose is localizable",
+  at(screen:eggPlacements(), 1, 9), "Cet ŒUF demande")
+Strings.load(nil)
 -- ListMoves runs at (8,10) with wListMovesLineSpacing = SCREEN_WIDTH * 2.
 check("move 1 at hlcoord 8,10", at(green, 8, 10), "TACKLE")
 check("move 2 two rows down", at(green, 8, 12), "EMBER")

--- a/tests/gen2_ui_translation_harvest_test.py
+++ b/tests/gen2_ui_translation_harvest_test.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Focused translation-harvest gate for the Gen 2 UI owned by this slice."""
+
+import ast
+import pathlib
+import re
+import sys
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from tools.modkit import STRINGS_CALL, harvest_engine_strings  # noqa: E402
+
+
+OWNED = [
+    "OptionsMenu", "GenderSelect", "TrainerCard", "CenterPcMenu", "PcMenu",
+    "ItemPcMenu", "InitClock", "CardFlip", "MailMenu", "PackMenu",
+    "PrizeMenu", "SlotMachine", "ContestMenu", "TradeMenu", "MartMenu",
+    "MailboxMenu", "StartMenu", "DayCareMenu", "HeldItemMenu",
+    "BoxMenu", "EvolutionAnim", "BankOfMom", "NamePick", "MoveDeleter",
+    "MailCompose",
+]
+
+REQUIRED = {
+    # Shared finite UI.
+    "YES", "NO", "CANCEL", "COIN", "Boy", "Girl",
+    # Options helper-produced values and templates.
+    "AUTO", "HIGH", "BALANCED", "LOW", "FIT", "OUT%d", "IN%d", "%dX",
+    "GEN 2", "DMG", "CLASSIC", "PALETTE", "SKIN", "STRONG", "ADAPTIVE",
+    "DISPLAY", "DISPLAY (%dHZ)", "GREEN", "MONO", "1X", "2X", "3X",
+    # Center PC labels, prompts and flows.
+    "BILL's PC", "%s's PC", "PROF.OAK's PC", "HALL OF FAME", "TURN OFF",
+    "Bzzzzt! You must\nhave a #MON to\nuse this!",
+    "{PLAYER} turned on\nthe PC.",
+    "The link to PROF.\nOAK's PC closed.", "…\nLink closed…",
+    "BILL's PC\naccessed.\n\n#MON Storage\nSystem opened.",
+    "Accessed own PC.\n\nItem Storage\nSystem opened.",
+    "PROF.OAK's PC\naccessed.\n\n#DEX Rating\nSystem opened.",
+    "Want to get your\n#DEX rated?", "Access whose PC?",
+    # Item PC menu and all item-operation messages.
+    "WITHDRAW ITEM", "DEPOSIT ITEM", "TOSS ITEM", "MAIL BOX", "LOG OFF",
+    "DECORATION", "There's no room\nfor more items.",
+    "Withdrew %d\n%s(S).", "How many do you\nwant to withdraw?",
+    "There's no room to\nstore items.", "Deposited %d\n%s(S).",
+    "No items here!", "How many do you\nwant to deposit?",
+    "That's too impor-\ntant to toss out!", "Toss out how many\n%s(S)?",
+    "Throw away %d\n%s(S)?", "Discarded\n%s(S).",
+    "What do you want\nto do?",
+    # Contest comparison labels and prompt.
+    " STOCK <PK><MN> ", " THIS <PK><MN> ", "HEALTH", "Switch #MON?",
+    "Caught %s!", "You already caught\na %s.",
+    # Mart's direct top-level labels.
+    "BUY", "SELL", "QUIT",
+    # Trainer Card's badge-name labels.
+    "ZEPHYR", "HIVE", "PLAIN", "FOG", "STORM", "MINERAL", "GLACIER",
+    "RISING", "BOULDER", "CASCADE", "THUNDER", "RAINBOW", "SOUL", "MARSH",
+    "VOLCANO", "EARTH",
+    # START descriptions are complete reflowable keys, not two frozen rows.
+    "POKéMON\ndatabase", "Party <PK><MN>\nstatus", "Contains\nitems",
+    "Trainer's\nkey device", "Your own\nstatus", "Save your\nprogress",
+    "Change\nsettings", "Installed\nadd-ons", "Return to\nthe title",
+    "Return to the\ntitle screen?",
+    # Bill's storage list, including complete prompts and refusals.
+    "MOVE", "STATS", "RELEASE", "PARTY <PK><MN>", "BOX%d",
+    "Choose a <PK><MN>.", "What's up?", "Move to where?",
+    "It's your last <PK><MN>!", "No more usable <PK><MN>!",
+    "Remove MAIL.", "There's no room!", "Saving… Leave ON!",
+    "No releasing EGGS!", "Release <PK><MN>?",
+    "Released <PK><MN>.\fBye,\n%s!",
+    "Got %s!", "Stored %s!",
+    "There is no POKéMON there.", "The BOX is full.",
+    "You can't deposit\nthe last POKéMON!",
+    "You can't take\nany more POKéMON.",
+    # Other newly covered screens.
+    "What? %s\nis evolving!", "Huh? %s\nstopped evolving!",
+    "Congratulations!\nYour %s", "evolved into\n%s!",
+    "%s learned\n%s!", "%s wants to\nlearn %s!",
+    "SAVED", "HELD", "NAME", "NEW NAME", "PP", "lower", "UPPER",
+    "DEL", "END",
+    # Game Corner engine text.
+    "Play with\n3 coins?", "Choose a\ncard.", "Place\nyour bet",
+    "Play\nagain?", "The cards\nshuffled.", "Bet how many\ncoins?",
+    "Darn… Ran out of\ncoins…", "    lined up!\nWon %d coins!",
+    # PACK messages are whole templates so translations can reflow them.
+    "Throw away how\nmany?", "Where should this\nbe moved to?",
+    "You don't have a\n#MON!", "An EGG can't hold\nan item.",
+    "OAK: {PLAYER}!\nThis isn't the\vtime to use that!",
+    "The REPEL used\nearlier is still\vin effect.", "Coins:\n%d",
+    "You now have\n%d points.", "{PLAYER} used the\n%s.",
+    "There was a trophy\ninside!\f{PLAYER} sent the\ntrophy home.",
+    "Throw away %d\n%s(S)?", "Threw away\n%s(S).",
+    "%s can't learn %s!", "%s already knows %s!",
+    "Registered the\n%s.", "You can't register\nthat item.",
+    # Prize-counter pages and stable dynamic templates.
+    "Welcome!\fWe exchange your\ncoins for fabulous\fprizes!",
+    "Which prize would\nyou like?", "OK, so you wanted\na %s?",
+    "You don't have\nenough coins.", "You have no room\nfor it.",
+    "Welcome!\fWe exchange your\ngame coins for\ffabulous prizes!",
+    "%s.\nIs that right?", "Sorry! You need\nmore coins.",
+    "Welcome to the\nGAME CORNER.", "Do you need some\ngame coins?",
+    "Thank you!\nHere are 50 coins.", "Whoops! Your COIN\nCASE is full.",
+}
+
+
+def lua_literal(token):
+    """Decode the quoted subset accepted by modkit's STRINGS_CALL."""
+    return ast.literal_eval(token)
+
+
+class Gen2UiTranslationHarvestTest(unittest.TestCase):
+    def test_required_player_facing_keys_are_harvested(self):
+        harvested = {lua_literal(token) for token, _ in harvest_engine_strings(ROOT)}
+        self.assertEqual([], sorted(REQUIRED - harvested))
+
+    def test_every_declared_owned_key_reaches_modkit(self):
+        harvested = {lua_literal(token) for token, _ in harvest_engine_strings(ROOT)}
+        declared = set()
+        for module in OWNED:
+            body = (ROOT / "src" / "ui" / "gen2" / f"{module}.lua").read_text()
+            declared.update(lua_literal(match.group(1))
+                            for match in STRINGS_CALL.finditer(body))
+        self.assertEqual([], sorted(declared - harvested))
+
+    def test_no_direct_finite_label_bypasses_strings(self):
+        raw_print = re.compile(
+            r'Chrome\.(?:print|printThrough)\(\s*["\'](?:YES|NO|CANCEL|COIN)["\']')
+        raw_label = re.compile(r'\blabel\s*=\s*["\']')
+        failures = []
+        for module in OWNED:
+            path = ROOT / "src" / "ui" / "gen2" / f"{module}.lua"
+            for number, line in enumerate(path.read_text().splitlines(), 1):
+                code = line.split("--", 1)[0]
+                if raw_print.search(code) or raw_label.search(code):
+                    failures.append(f"{path.relative_to(ROOT)}:{number}: {code.strip()}")
+        self.assertEqual([], failures)
+
+    def test_pc_messages_are_not_reintroduced_as_raw_line_arrays(self):
+        bypass = re.compile(
+            r'(?:self:(?:say|drawBottomLines)|prompt\s*=)\s*\(?' r'\s*\{\s*\{?\s*["\']')
+        failures = []
+        for module in ("CenterPcMenu", "ItemPcMenu"):
+            path = ROOT / "src" / "ui" / "gen2" / f"{module}.lua"
+            for number, line in enumerate(path.read_text().splitlines(), 1):
+                code = line.split("--", 1)[0]
+                if bypass.search(code):
+                    failures.append(f"{path.relative_to(ROOT)}:{number}: {code.strip()}")
+        self.assertEqual([], failures)
+
+    def test_reviewed_modules_have_no_raw_player_facing_sinks(self):
+        modules = {
+            "BoxMenu", "EvolutionAnim", "BankOfMom", "NamePick",
+            "MoveDeleter", "MailCompose", "PrizeMenu", "CardFlip",
+            "SlotMachine", "PackMenu", "StartMenu",
+        }
+        direct_print = re.compile(
+            r'Chrome\.(?:print|printThrough)\(\s*["\'][A-Za-z]')
+        raw_message = re.compile(
+            r'(?:self\.(?:lines|message)\s*=|self:(?:say|ask|showMessage)\()'
+            r'\s*\{\s*["\']')
+        raw_named_rows = re.compile(
+            r'\b(?:desc|prompt|intro|which|playAgain|notEnough|betHowMany|'
+            r'ranOut|shuffled)\s*=\s*\{\s*["\']')
+        failures = []
+        for module in modules:
+            path = ROOT / "src" / "ui" / "gen2" / f"{module}.lua"
+            lines = path.read_text().splitlines()
+            for number, line in enumerate(lines, 1):
+                code = line.split("--", 1)[0]
+                if direct_print.search(code) or raw_message.search(code):
+                    failures.append(
+                        f"{path.relative_to(ROOT)}:{number}: {code.strip()}")
+                if raw_named_rows.search(code):
+                    nearby = "\n".join(lines[number - 1:number + 3])
+                    if "source = Strings.source" not in nearby:
+                        failures.append(
+                            f"{path.relative_to(ROOT)}:{number}: {code.strip()}")
+        self.assertEqual([], failures)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/modkit/dataset_view_fixture.lua
+++ b/tests/modkit/dataset_view_fixture.lua
@@ -13,8 +13,8 @@ local GEN1_OPTIONAL_MODULES = { "audio", "palettes", "icons" }
 
 local GEN2_MODULES = {
   "pokemon", "moves", "items", "type_chart", "audio", "font", "maps",
-  "tilesets", "text", "trainers", "encounters", "sprites", "palettes",
-  "icons", "battle_anims", "constants", "landmarks",
+  "tilesets", "text", "rom_text", "trainers", "encounters", "sprites",
+  "palettes", "icons", "battle_anims", "constants", "landmarks",
 }
 
 local CONTINUATIONS = {
@@ -79,7 +79,8 @@ local function defaults(version)
       heldEffect = "HELD_LEFTOVERS", heldParameter = 0 }
   end
   return {
-    constants = {}, maps = {}, tilesets = {}, text = {}, text_pointers = {},
+    constants = {}, maps = {}, tilesets = {}, text = {}, rom_text = {},
+    text_pointers = {},
     trainer_headers = {}, font = {}, sprites = {}, pokemon = pokemon,
     moves = moves, items = items, type_chart = typeChart, trainers = {},
     encounters = {}, field = { oakSpeech = {} }, battle_anims = {},

--- a/tests/rby_translation_harvest_test.py
+++ b/tests/rby_translation_harvest_test.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""RBY UI strings that must remain visible to the modkit catalog harvest."""
+
+from pathlib import Path
+from unittest import TestCase, main
+
+import sys
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "tools"))
+import modkit  # noqa: E402
+
+
+class RbyTranslationHarvestTest(TestCase):
+    def test_rby_ui_literals_are_harvested(self):
+        harvested = {literal for literal, _location in
+                     modkit.harvest_engine_strings(str(REPO))}
+        expected = {
+            '"FLY TO?"',
+            '"Which move?"',
+            '"ITEMS"',
+            '"HEAL"',
+            '"WITHDRAW"',
+            '"DEPOSIT"',
+            '"The party is full!"',
+            '"MONEY/¥%d"',
+            '"TIME/%3d:%02d"',
+            '"No.%03d"',
+            '"IDNo.%05d"',
+            '"BILL\'S PC"',
+            '"%s\'s PC"',
+            '"AREA UNKNOWN"',
+            '"%s\'s NEST"',
+            '"To %s"',
+            '"Congrats! This"',
+            '"diploma certifies"',
+            '"that you have"',
+            '"completed your"',
+            '"POKéDEX."',
+            '"POKéMON BLUE"',
+            '"POKéMON YELLOW"',
+            '"PIKACHU\'S BEACH"',
+        }
+        self.assertEqual(expected - harvested, set())
+
+    def test_dynamic_consumers_translate_at_draw_time(self):
+        expected_calls = {
+            "src/ui/Credits.lua": "Strings(line.text)",
+            "src/ui/TownMap.lua": "Strings(loc.name)",
+            "src/ui/TitleState.lua": "Strings(self.title.copyrightText)",
+        }
+        for relative, call in expected_calls.items():
+            source = (REPO / relative).read_text(encoding="utf-8")
+            self.assertIn(call, source, relative)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Route the remaining RBY and Gen2 text through translations

## Summary

This PR closes the remaining translation gaps found across the Red, Blue, Yellow, Gold, Silver, and Crystal runtime paths.

It routes previously hard-coded UI and battle text through stable translation sources, exposes the missing Gen2 content registries needed by translation mods, and adds runtime and harvest tests for the new contracts. The changes are split into focused commits for RBY, Gen2 registries, battle text, options, PC/storage, the remaining Gen2 UI, and a final pass closing out RBY type-name and options coverage. It is rebased onto the current `dev`.

## Motivation

Translation mods could already replace most ROM dialogue and many engine strings, but several player-facing paths were still unreachable or fragile:

- RBY screens such as the Town Map, Diploma, Trainer Card, credits, Fly menu, bag, boxes, trade animation, title screens, and Yellow-specific UI still contained text that bypassed live translation lookup.
- Large parts of the Gen2 battle system and UI rendered literals directly from Lua.
- The Gen2 options, PC, storage, party, summary, Pokédex, Pokégear, radio, and miscellaneous menu screens had incomplete translation coverage.
- Some localized Gen2 data had no public content registry, even though the engine consumed it as player-facing text.
- ROM text overrides were conflated with the VM text registry instead of targeting the extracted `data.text` dataset.

These gaps caused untranslated English text to remain visible even when a translation mod provided complete ROM and engine catalogs.

## Changes

### Complete the remaining RBY coverage

- Route the remaining bag, box, Fly, credits, Diploma, Town Map, Trainer Card, trade, title, surfing minigame, and overworld labels through `Strings`.
- Keep module-level constants harvestable with `Strings.source` while resolving translations at draw time.
- Preserve source strings used by gameplay logic, including Town Map route detection, instead of comparing translated display values.
- Use stable templates for composed labels such as `To %s`, money, play time, Pokédex numbering, and PC ownership.
- Preserve fallback centering and layout behavior when no translation catalog is loaded.

### Expose localized Gen2 content registries

- Add a public `rom_text` registry targeting `data.text`, separate from the script VM's `text` registry.
- Make phone-contact display names overrideable without changing their stable IDs.
- Expose radio-channel labels through one shared registry consumed by both the Pokégear and map-radio UI.
- Route decoration names and grammar templates through localized content.
- Add localized display values for type names and status abbreviations while preserving their internal IDs.
- Document the new registry contracts and compatibility behavior.
- Deduplicate the Gen2 status-id alias table (declared verbatim in both PartyMenu and SummaryMenu) into one shared table, and drop a dead type-name table left behind after switching to the shared registry.

### Localize Gen2 battle text

- Route battle messages, menus, weather text, status messages, experience text, capture messages, switching prompts, move effects, and result text through stable `Strings` templates.
- Resolve dynamic move, item, species, type, and status display names from their localized records.
- Keep runtime arguments separate from source templates so translation lookup remains stable.
- Allow mod-provided battle HUD labels to replace the built-in label instead of being shadowed by a second Gen2-only field.

### Localize Gen2 options, PC, and storage screens

- Translate option labels and display values at draw time.
- Cover the Pokémon Center PC, player PC, item storage, box management, and related confirmation messages.
- Preserve dynamic user and save data as raw values rather than attempting to translate player-authored content.
- Fix the Pokecenter PC's empty-party refusal, which keyed its translation source on a bare third line instead of the ROM's scroll-continue marker (`_PokecenterPCCantUseText` "ends in cont"); caught while rebasing this branch onto `dev`, which independently carries the correct marker and a test asserting the scroll behavior. The six languages' translated values already had the right text; only the lookup key needed the same fix.

### Cover the remaining Gen2 UI

- Route the remaining text from the Start menu, Pack, Trainer Card, clock setup, contests, trades, marts, mail, daycare, held-item menus, Bank of Mom, naming screens, Move Deleter, evolution, Game Corner screens, and other smaller UI paths through translations.
- Harvest multiline Start-menu descriptions as stable catalog keys.
- Clip translated badge names by glyph rather than byte so UTF-8 text is not split incorrectly.
- Split the Game Corner's prize rows into a translatable name and the existing numeric cost, right-aligning the price against a fixed column and clamping the name to the available tile budget (glyph-aware, so a `<PK><MN>` macro is never cut mid-sequence) instead of relying on a hand-padded literal that only stayed aligned for the English original's exact length.
- Route the PC box menu's and the slot machine's messages through the shared page-break helper the rest of the Gen2 UI already uses, so a translated message needing a scroll-continue break renders correctly instead of silently misrendering.

### Complete RBY type-name and options coverage

- Pass the merged type-chart data through to the Summary and Hall of Fame screens' `TypeChart.displayName` calls, which were still falling back to the untranslated vanilla table when either screen was opened before the first battle. WideBattle's and BattleState's own in-battle move-details panels get the same explicit argument for the same call convention, though it is a no-op there today: `battle.data`/`self.data` is `game.data` by reference, the same table `TypeChart.load` already caches from at battle start.
- Translate the RBY OPTION screen's dynamic value labels (ZOOM, MAX FPS, and the three GameSpeed rows), which drew straight from their shared modules and bypassed `Strings` entirely, unlike the equivalent Gen2 screen.

## Translation contract

The implementation follows three rules throughout the affected code:

1. Static source text that is created before catalogs load is marked with `Strings.source` and resolved later with `Strings`.
2. Dynamic values keep a stable source template and pass their arguments only when the translated string is rendered.
3. Internal identifiers and gameplay comparisons remain language-independent; only display values are localized.

With no translation mod loaded, every new lookup falls back to the existing English source text.

## Mod API additions

Translation mods can now override the following Gen2 surfaces without patching engine internals:

- `mod.content.rom_text`
- localized phone-contact names
- localized radio-channel labels
- localized decoration names and templates
- localized type display names
- localized status abbreviations

The companion translation-mod changes keep the published v0.2.41 profile as the default and activate these new contracts only through an explicit upstream-compatible profile until they are available in a release.

## Testing

Added or expanded coverage for:

- RBY runtime translation and source harvesting
- Gen2 battle translation and source harvesting
- Gen2 registry-backed UI translation
- the public `rom_text` registry and `data.text` target
- options-menu draw-time translation
- PC and storage screens
- Start-menu descriptions and Trainer Card rendering
- Crystal gender, evolution, radio, decorations, party, summary, Pokégear, and menu flows
- UTF-8-safe badge rendering and translated type/status display values
- the PC box menu's page-break handling and the Game Corner prize-name tile clamp, including a translated name whose macro expansion straddles the clamp boundary

Validation results (rebased onto the current `dev`):

- `luajit tests/run_engine.lua`: **477/477 suites passed**
- `luajit tests/run_modkit.lua`: **33/33 suites passed**
- `luajit tests/run_gen2.lua`: **136/137 suites passed**
- translation harvest and runtime tests added by this PR: passed
- `git diff --check`: passed

The single Gen2 failure is the pre-existing `tests/gen2_fishing_time_test.lua` failure: five assertions expect slot 2 `timeGroup` data that is currently absent. It is unrelated to the translation changes in this PR.

## Commit structure

1. Route remaining RBY text through translations
2. Expose localized Gen2 content registries
3. Localize Gen2 battle text
4. Localize Gen2 options text
5. Localize Gen2 PC and storage text
6. Route remaining Gen2 UI text through translations
7. Route the RBY OPTION screen and remaining type-name draws through translations

Sample before and after the fix:

<img width="1024" height="794" alt="Screenshot 2026-09-01 182107" src="https://github.com/user-attachments/assets/a11145f1-9139-4b3a-86b8-03d67ab69094" />

<img width="1021" height="795" alt="Screenshot 2026-09-01 182117" src="https://github.com/user-attachments/assets/77f2bdf4-9af3-4326-8c03-351b49e7d2d8" />



