### PR TITLE
Widen Gen 2 move_effects registration to the movedex's own effect ids

### DIFF
--- a/src/battle/gen2/Battle.lua
+++ b/src/battle/gen2/Battle.lua
@@ -2974,9 +2974,53 @@ end
 
 -- vanilla registrations, engine-owned (Schemas.ENGINE), so a mod's register of
 -- one of these ids collides the way it does on Red and has to say override
-function Battle.registerMoveEffectsInto(registry, _, owner)
+--
+-- MOVE_EFFECT_RECORDS only carries the effects that have a standalone
+-- handler above -- by design, the "full" effects (a move's own damage-only
+-- EFFECT_NORMAL_HIT, the multi-hit/recoil/drain families...) have none and
+-- fall through to the generic damage path. But src/mods/Schemas.lua's
+-- `moves.effect = f.id("move_effects")` cross-check treats move_effects as
+-- the complete id space regardless, so every "full" effect the real movedex
+-- uses reads as a dangling reference the moment a mod touches `moves`.
+-- Registering a bare kind="full" marker for every effect id `data.moves`
+-- actually uses gives the validator that complete id space while staying a
+-- no-op at both of moveEffectRecordFor's call sites, which already treat a
+-- record with no run/status as a miss. kind="full", not "primary", to match
+-- both Schemas.lua's own R.move_effects enum and Gen 1's parallel
+-- src/battle/MoveEffects.lua, which label this same category the same way.
+--
+-- Two invariants keep this correct and safe to call from a DatasetViews lazy
+-- view: it must run synchronously, here, before Loader.lua's merge loop
+-- writes mod-patched values into `data.moves` in place (else a mod's own
+-- typo gets absorbed as if it were ROM data) and before that loop's
+-- `pairs(registry.ops)` traversal (inserting into move_effects any later
+-- than this is a Lua pairs()-mutation hazard); and it must read `data.moves`
+-- with `rawget`, not a plain index, so an unread DatasetViews root stays
+-- unread (tests/engine/dataset_views_lazy_validation.lua's "pokemon access
+-- leaves moves unused").
+function Battle.registerMoveEffectsInto(registry, data, owner)
   for id, record in pairs(Battle.MOVE_EFFECT_RECORDS) do
     registry:register(id, record, owner)
+  end
+  local moves = data and rawget(data, "moves")
+  if moves then
+    -- RomExtractorGen2:extractMoves seeds `out` with `generation`/`source`
+    -- alongside the move records themselves (src/import/RomExtractorGen2.lua),
+    -- so a bare `pairs(moves)` walks those two non-record entries too --
+    -- confirmed live: `generation` is the number 2, and indexing it as a
+    -- move crashed the whole mod boot the first time this ran for real.
+    -- Same extractor, same line: `effect = effects[row[2] + 1] or row[2]`
+    -- falls back to the raw effect BYTE (a number) when the ROM's own value
+    -- has no name in the manifest's moveEffectOrder, so `effect` itself can
+    -- be a non-string even once `move` is confirmed a real record --
+    -- registry:register asserts its id is a string, and an assert here
+    -- would take the same whole-boot fall the earlier `move`-shaped bug did.
+    for _, move in pairs(moves) do
+      local effect = type(move) == "table" and move.effect
+      if type(effect) == "string" and effect ~= "" and registry:get(effect) == nil then
+        registry:register(effect, { kind = "full" }, owner)
+      end
+    end
   end
 end
 

--- a/tests/engine/gate_gen2_mod_api.lua
+++ b/tests/engine/gate_gen2_mod_api.lua
@@ -1001,6 +1001,87 @@ do
   T.eq(table.concat(order, ","), "c,b,a", "clear unwinds top-first")
 end
 
+-- ------- 7. move_effects: a "full" effect (no standalone handler) is a
+-- valid id, not a dangling reference
+--
+-- src/battle/gen2/Battle.lua's MOVE_EFFECT_RECORDS only carries the effects
+-- that have a standalone handler, by design -- a move whose effect is just
+-- "deal damage" (EFFECT_NORMAL_HIT and friends) falls through to the generic
+-- damage path and has no entry there.  registerMoveEffectsInto has to widen
+-- the id space it registers to match, or every "full" effect the real
+-- movedex uses reads as unresolved the moment any mod's `moves` patch (even
+-- one that only touches `name`) triggers the cross-reference scan.
+do
+  local data = gen2Fixtures()
+  data.moves.FIX_TACKLE.effect = "EFFECT_NORMAL_HIT"
+  -- RomExtractorGen2:extractMoves seeds `data.moves` with `generation`/
+  -- `source` alongside the move records (src/import/RomExtractorGen2.lua),
+  -- so `generation` is the NUMBER 2, not a move -- a real fixture for this
+  -- scan, or it never catches a bare pairs(moves) indexing it as one.
+  data.moves.generation = 2
+  data.moves.source = "ROM:Moves + MoveNames"
+  local run = T.sdk.loadMods({ "mods/fix_refs" }, {
+    fs = T.sdk.memfs(refsFixture([[
+      local mod = ...
+      mod.content.moves:patch("FIX_TACKLE", { name = "SLAP" })
+    ]])),
+    data = data,
+    generation = 2,
+  })
+  local dangling = danglingRefs(run)
+  T.eq(#dangling, 0,
+    "Gen 2: a handler-less effect id (EFFECT_NORMAL_HIT) resolves ("
+      .. table.concat(dangling, "; ") .. ")")
+  T.eq(run.data.moves.FIX_TACKLE.name, "SLAP", "Gen 2: the patch still landed")
+  run.release()
+end
+
+do
+  -- the base ROM data is never wrong here, so the realistic typo is a MOD's
+  -- own patch introducing an effect id nothing seeded -- registerMoveEffectsInto
+  -- only widens the space from data.moves as it stood before the merge, so
+  -- this still has to miss.
+  local data = gen2Fixtures()
+  data.moves.FIX_TACKLE.effect = "EFFECT_NORMAL_HIT"
+  local run = T.sdk.loadMods({ "mods/fix_refs" }, {
+    fs = T.sdk.memfs(refsFixture([[
+      local mod = ...
+      mod.content.moves:patch("FIX_TACKLE", { effect = "EFFECT_NOT_A_REAL_ID" })
+    ]])),
+    data = data,
+    generation = 2,
+  })
+  local dangling = danglingRefs(run)
+  T.eq(#dangling, 1,
+    "Gen 2: widening the id space does not stop catching a mod's real typo")
+  T.check(dangling[1] and dangling[1]:match("move_effects"),
+    "Gen 2: and the report still names move_effects")
+  run.release()
+end
+
+do
+  -- RomExtractorGen2:extractMoves' `effect = effects[row[2] + 1] or row[2]`
+  -- falls back to the raw effect BYTE (a number) when the ROM's value has no
+  -- name in the manifest's moveEffectOrder -- so `move` being a real record
+  -- table does not guarantee `move.effect` is a string. registry:register
+  -- asserts its id is a non-empty string; passing it a number would take the
+  -- whole boot down the same way the `generation`/`source` case above did.
+  local data = gen2Fixtures()
+  data.moves.FIX_TACKLE.effect = 27
+  local ok = pcall(function()
+    local run = T.sdk.loadMods({ "mods/fix_refs" }, {
+      fs = T.sdk.memfs(refsFixture([[
+        local mod = ...
+        mod.content.moves:patch("FIX_TACKLE", { name = "SLAP" })
+      ]])),
+      data = data,
+      generation = 2,
+    })
+    run.release()
+  end)
+  T.check(ok, "Gen 2: a numeric effect byte with no manifest name does not crash the boot")
+end
+
 -- Without this the file printed its FAILs and exited 0, so the runner marked
 -- the gate "ok" while it was red -- a gate that cannot fail is not a gate.
 T.finish("gate_gen2_mod_api")


### PR DESCRIPTION
# Widen Gen 2 move_effects registration to the movedex's own effect ids

## Bug

Any mod that patches the `moves` registry on a Gen 2 game (even a translation mod whose patch only touches `name`, never `effect`) triggers a flood of spurious `[error]` log lines during the merge: `moves.X.effect: unresolved reference to move_effects "EFFECT_..."`, one per move in the movedex — roughly 130 of them for Gold/Silver's full move list.

The cause is in `src/battle/gen2/Battle.lua`. `Battle.MOVE_EFFECT_RECORDS` only lists effects that have a standalone handler function — by design, a move whose effect is just "deal damage" (`EFFECT_NORMAL_HIT` and the multi-hit/recoil/drain families) has none and falls through to the generic damage path. But `src/mods/Schemas.lua`'s schema for `moves` declares `effect = f.id("move_effects")`, treating `move_effects` as the *complete* id space — so every "full" effect the real movedex uses reads as a dangling reference the instant cross-validation runs.

Found building the Gold/Silver translation mod (`fix/complete-translation-coverage-v0241`): its `move_names` patch (name only) was enough to trip the scan on essentially the whole movedex. Unrelated to translation — present on plain `dev` too — just latent until a mod exercises a real, ROM-derived `moves` dataset, which the ROM-free test fixtures don't.

The errors don't corrupt anything — `data.moves[X].effect` keeps its correct value, battle behavior is unaffected — but they're real `[error]`-level noise on every Gen 2 boot with almost any mod installed, crowding out genuine validation problems in the same log stream.

## Fix

`Battle.registerMoveEffectsInto` now also registers a bare `{ kind = "full" }` marker (matching `Schemas.lua`'s own `move_effects` enum and Gen 1's parallel `MoveEffects.lua`, which label this same handler-less category the same way) for every effect id `data.moves` actually uses that `MOVE_EFFECT_RECORDS` doesn't already cover. Both call sites of `Battle.moveEffectRecordFor` already nil-check `.run`/`.status`, so a handler-less marker is a no-op — validation-only change, no battle behavior difference. Because the widened set comes from `data.moves` as it stood *before* the merge, a mod that patches a move's `effect` to a genuinely bogus id is still caught as a dangling reference.

Two guards on the scan, both hit live rather than in the ROM-free fixtures: `data.moves` isn't a pure id-keyed table (`RomExtractorGen2:extractMoves` seeds it with `generation`/`source` fields too), so the loop skips anything that isn't a table before reading `.effect`; and a ROM effect byte with no name in the manifest's `moveEffectOrder` falls back to a raw number (or, in principle, an empty string), either of which would trip `registry:register`'s string-id assert and take the whole boot down — so the loop also requires `type(effect) == "string" and effect ~= ""`.

The scan has to run synchronously, right inside `registerMoveEffectsInto`, reading `data.moves` with `rawget` rather than a plain index. Two deferred designs were tried first and rejected: wrapping the registry's `.base` to scan lazily on first lookup ended up inserting new keys into `registry.ops` from inside `Loader.lua`'s own `pairs(registry.ops)` merge loop — undefined behavior in Lua, confirmed non-deterministic by an independent code review, with a real risk of making `Fingerprint.lua`'s Gen 2 compat digest vary between identical boots and breaking multiplayer `checkCompat`. Overriding `registry:get` to scan lazily without touching `registry.ops` avoided that, but ran too late in a different way: `Loader.lua`'s merge loop writes mod-patched values into `data.moves` in place before `crossValidate` runs, so the deferred scan absorbed a mod's own typo as if it were real ROM data. Scanning eagerly, before mod discovery and before the merge loop, avoids both problems; `rawget` instead of a plain index keeps it from forcing open an unread root on a `src/mods/DatasetViews.lua` lazy view (`tests/engine/dataset_views_lazy_validation.lua`'s "pokemon access leaves moves unused").

## Testing

Three cases added to `tests/engine/gate_gen2_mod_api.lua`: a mod patching only a move's `name` now reports zero dangling references against a fixture that also carries the extractor's `generation`/`source` fields; a mod patching `effect` to a genuinely bogus id still reports exactly one dangling reference, proving typo detection survives the widening; a numeric `effect` doesn't crash the boot. 969/969 checks pass on that gate.

Also green: `gen2_move_effects_test.lua` (100/100), `gen2_battle_test.lua` (806 checks, 0 failures), `gen2_battle_lockin_test.lua` (54/54), `engine/gate_registries.lua` (1051/1051), `engine/dataset_views_lazy_validation.lua` (10/10). A full local `./scripts/test.sh` run leaves only the four pre-existing, environment-specific failures (missing local Pillow for the T0 ROM-tooling suites, and `gen2_fishing_time_test.lua`, which fails identically on plain `dev`).

Verified live earlier in the branch's life too: a Windows exe built from it, run against a real Gold ROM import with `translation-fr-gen2` and other installed mods active — the error flood is gone and mods load cleanly.

Screenshot before the fix:
<img width="1115" height="822" alt="Screenshot 2026-09-02 102419" src="https://github.com/user-attachments/assets/b9f81535-52db-4c71-96d3-2b549febed00" />
