### PR TITLE
Fix Windows LuaJIT directory-detection fallback in FsIo.isDir

### DIFF
--- a/tests/fs_io.lua
+++ b/tests/fs_io.lua
@@ -78,8 +78,24 @@ function FsIo.globPrefix(prefix)
   return matches
 end
 
--- existence probe that never shells out on Windows: directories do not
--- open() there at all, and rename-self succeeds for anything that exists
+-- Windows existence probe: `if exist "path\*"` is true only for a real
+-- directory (a file never matches its own "\*" glob, and a missing path
+-- matches neither). Shells out like listDir's Windows branch above --
+-- os.rename(path, path) was tried first as a shell-free rename-self probe,
+-- but it returns nil for real, existing directories on at least one
+-- Windows/LuaJIT (lovec.exe) build, which made every mod directory look
+-- absent to FsIo.isDir and silently zeroed out mod discovery.
+local function winIsDir(path)
+  local p = tostring(path):gsub("[/\\]+$", "")
+  local pipe = io.popen('if exist "' .. p .. '\\*" (echo dir_yes)')
+  if not pipe then return false end
+  local out = pipe:read("*a")
+  pipe:close()
+  return out:find("dir_yes", 1, true) ~= nil
+end
+
+-- existence probe: directories do not open() at all on Windows, so a nil
+-- handle there falls through to the shell probe above
 function FsIo.isDir(path)
   local handle = io.open(path, "rb")
   if handle then
@@ -88,7 +104,7 @@ function FsIo.isDir(path)
     if probe ~= nil then return false end
     if FsIo.isWindows then return false end -- opened but empty: a file
   elseif FsIo.isWindows then
-    return os.rename(path, path) == true
+    return winIsDir(path)
   end
   local ok = os.execute("test -d " .. quote(path))
   return ok == true or ok == 0


### PR DESCRIPTION
## Summary
- `FsIo.isDir`'s Windows fallback (`os.rename(path, path) == true`) returns `nil` instead of `true` for a real, existing directory under Windows LuaJIT (reproduced with `lovec.exe`), so every directory looks absent
- Practical effect: `Loader:_discover` silently finds zero mods on a Windows LuaJIT host, since it gates on `getInfo` returning a directory type — and nothing lands in `loader.errors` to explain why, since the `if info and (...)` guard in `_discover` just never fires
- Replaces the self-rename probe with a shell-out (`if exist "path\*"`) matching the pattern `FsIo.listDir`'s own Windows branch already uses (`dir /b`) — a file never matches its own `\*` glob and a missing path matches neither, so this is true only for a real directory

## Repro
```lua
local p = "mods/some_real_mod_dir"
print(io.open(p, "rb"))         --> nil, as expected
print(os.rename(p, p))          --> nil, NOT true, on Windows LuaJIT