### PR TITLE
Gen 2: the day-of-week wheel is an overlay, so it must not clip

### DIFF
--- a/src/ui/gen2/Chrome.lua
+++ b/src/ui/gen2/Chrome.lua
@@ -137,6 +137,15 @@ function Chrome.withPanel(winW, winH, r, g, b, drawFn, scale)
   G.pop()
 end
 
+-- Clip to the GB field, for a screen that OWNS the frame.
+--
+-- The rectangle is WINDOW pixels -- a LOVE scissor ignores the transform in
+-- force, which is why withPanel above computes ox/oy/scale and clips before it
+-- translates.  So this is only correct where the panel really is at (0,0) at
+-- scale 1, or where a correct scissor is already in force and this one merely
+-- intersects it.  An OVERLAY drawn through `stack:draw()` -- inside Game2's
+-- own translate/scale -- must NOT use it: the scissor lands in the corner of
+-- the window and the whole screen is clipped away.  See InitClock:draw.
 function Chrome.withClip(drawFn)
   local G = love.graphics
   G.push("all")

--- a/src/ui/gen2/InitClock.lua
+++ b/src/ui/gen2/InitClock.lua
@@ -446,6 +446,32 @@ function InitClock:drawBody()
 end
 
 function InitClock:draw()
+  -- The day wheel is an OVERLAY and must not clip.
+  --
+  -- `Chrome.withClip` clips to (0, 0, 160, 144), and a LOVE scissor is in
+  -- WINDOW pixels: it ignores the transform in force.  That is why
+  -- `Chrome.withPanel` computes ox/oy/scale and clips BEFORE it translates.
+  --
+  -- Every other screen that calls withClip -- OakSpeech, Credits,
+  -- GenderSelect, BattleState, HallOfFame, and this file in "clock" mode -- is
+  -- opaque AND answers true to `drawsWidescreen`, so Game2:drawScene paints it
+  -- through `drawWidescreen` -> `Chrome.withPanel`, which sets the right
+  -- scissor.  Their `draw()` pass is the redundant second one the stack makes
+  -- on top, and the wrong scissor quietly threw it away -- which is why this
+  -- has never shown.
+  --
+  -- Day mode is the one screen here that answers FALSE (timeset.asm:385 --
+  -- SetDayOfWeek stands over the living room, it does not replace it), so
+  -- `stack:draw()` is its ONLY paint, inside Game2's own translate/scale.  The
+  -- window-space scissor then sat in the top-left 160x144 of the window while
+  -- the wheel drew into a panel scaled six times that: every box outside its
+  -- own clip.  Alive, taking A and B, and invisible -- reported as "nothing
+  -- pops up for me to answer mom, but if I spam a it continues".
+  --
+  -- It needs no clip of its own: every box it draws is inside the 160x144
+  -- field already, and every other overlay on Gold -- the START menu, the text
+  -- box, the caller strip -- draws with none.
+  if self.mode == "day" then return self:drawBody() end
   Chrome.withClip(function() self:drawBody() end)
 end
 

--- a/tests/gen2_clock_test.lua
+++ b/tests/gen2_clock_test.lua
@@ -215,6 +215,48 @@ do
   eq(Clock.weekday(save), 6, "and the save reads it")
 end
 
+-- ------------------------------------------- the wheel is an OVERLAY, unclipped
+--
+-- SetDayOfWeek stands OVER the living room (timeset.asm:385), so day mode is
+-- the one screen in this file that answers false to `drawsWidescreen` -- which
+-- means Game2:drawScene never paints it through `drawWidescreen` /
+-- `Chrome.withPanel`, and `stack:draw()` is its ONLY paint, inside Game2's own
+-- translate/scale.
+--
+-- `Chrome.withClip` clips to (0, 0, 160, 144) and a LOVE scissor is in WINDOW
+-- pixels, ignoring that transform.  So clipping here put the wheel in the
+-- top-left corner of the window while it drew into a panel scaled several
+-- times that: alive, taking A and B, and invisible.  Reported as "nothing pops
+-- up for me to answer mom, but if I spam a it continues".
+--
+-- Clock mode keeps its clip: it owns the frame, and its own `drawWidescreen`
+-- has already set a correct scissor that this one only intersects.
+do
+  local scissors = {}
+  local realIntersect = love.graphics.intersectScissor
+  local realSet = love.graphics.setScissor
+  love.graphics.intersectScissor = function(x, y, w, h)
+    scissors[#scissors + 1] = { x, y, w, h }
+  end
+  love.graphics.setScissor = love.graphics.intersectScissor
+
+  local day = InitClock.new({}, { mode = "day", save = {} })
+  day:draw()
+  eq(#scissors, 0, "the day wheel sets no scissor of its own")
+
+  local clock = InitClock.new({}, { mode = "clock", save = {} })
+  clock:draw()
+  eq(#scissors, 1, "clock mode still clips to the field it owns")
+  if scissors[1] then
+    eq(("%d,%d,%d,%d"):format(scissors[1][1], scissors[1][2],
+                              scissors[1][3], scissors[1][4]),
+       "0,0,160,144", "at the GB field's own rectangle")
+  end
+
+  love.graphics.intersectScissor = realIntersect
+  love.graphics.setScissor = realSet
+end
+
 -- The driven path: a screen this new must not stall a scripted run, so it
 -- walks itself to the end on its defaults.
 do


### PR DESCRIPTION
Mom asks what day it is and nothing appears.  The wheel is pushed, it is updating and it takes A and B -- pressing A twice walks it to the DST question -- but nothing is drawn.  Reported as "nothing pops up for me to answer mom, but if I spam a it continues to the daylight savings question".

Chrome.withClip clips to (0, 0, 160, 144), and a LOVE scissor is in WINDOW pixels: it ignores the transform in force.  That is exactly why Chrome.withPanel computes ox/oy/scale and clips BEFORE it translates.

Every screen that calls withClip -- OakSpeech, Credits, GenderSelect, BattleState, HallOfFame, and InitClock in "clock" mode -- is opaque AND answers true to drawsWidescreen, so Game2:drawScene paints it through drawWidescreen -> Chrome.withPanel, which sets the right scissor.  Their draw() pass is the redundant second one stack:draw() makes on top, and the wrong scissor quietly threw it away.  That is why this has never shown.

InitClock in "day" mode is the single exception: SetDayOfWeek stands over the living room rather than replacing it (timeset.asm:385), so it answers FALSE, drawWidescreen is never called, and stack:draw() is its only paint -- inside Game2's own translate/scale.  The window-space scissor then sat in the top-left 160x144 of the window while the wheel drew into a panel scaled six times that at a 6x window.  Every box it draws landed outside its own clip.

Measured rather than reasoned: at 960x864 the panel is at (0,0) scale 6, the scissor is (0,0,160,144), and the twelve rectangles the wheel draws are all outside it.

Day mode now draws unclipped, which is what every other overlay on Gold does -- the START menu, the text box, the caller strip -- and it needs no clip of its own: every box it draws is inside the 160x144 field already. Clock mode is untouched, and withClip is left alone so the five opaque screens' second pass keeps being discarded rather than double-painting their alpha fades.

Chrome.withClip now says in its own header that it is screen-space and what that means for an overlay, so the next caller does not walk into it.

tests/gen2_clock_test.lua asserts the day wheel sets no scissor and clock mode still sets exactly one, at the field's own rectangle.  Both fail on the unpatched screen.