### PR TITLE
linux arm64 builder: bullseye apt sources from snapshot.debian.org

### DIFF
--- a/scripts/linux-arm64/Dockerfile
+++ b/scripts/linux-arm64/Dockerfile
@@ -29,7 +29,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 # runtime linkage: SDL detects each backend at compile time and then dlopens
 # it, so these headers decide which backends exist at all while adding no
 # DT_NEEDED entry to the shipped library.
-RUN apt-get update -qq \
+RUN printf 'deb http://snapshot.debian.org/archive/debian/20260831T000000Z bullseye main\ndeb http://snapshot.debian.org/archive/debian-security/20260831T000000Z bullseye-security main\n' > /etc/apt/sources.list \
+ && apt-get -o Acquire::Check-Valid-Until=false update -qq \
  && apt-get install -y --no-install-recommends \
       build-essential pkg-config autoconf automake libtool cmake \
       ca-certificates curl file xz-utils bzip2 zip unzip squashfs-tools \


### PR DESCRIPTION
bullseye hit EOL on 2026-08-31; deb.debian.org now serves an expired bullseye-security InRelease and its pool already 404s, while archive.debian.org has only the main suite (whose libc6 is older than the one baked into the debian:bullseye image). Pin both suites to the 2026-08-31 snapshot so the image builds again and stays reproducible.