### PR TITLE
Fix white battle panel when menus are mirrored to another display

### DIFF
--- a/src/core/Game2.lua
+++ b/src/core/Game2.lua
@@ -1779,6 +1779,17 @@ function Game2:paintBattleSurround(w, h)
   G.setColor(1, 1, 1, 1)
 end
 
+-- Mirrored menus stay on the input stack. They must not trigger another
+-- panel pass over a completed widescreen scene when none is visible.
+local function hasVisibleOverlay(stack, base)
+  for i = #stack.states, 1, -1 do
+    local screen = stack.states[i]
+    if screen == base then return false end
+    if stack:renderVisible(screen) then return true end
+  end
+  return false
+end
+
 function Game2:drawScene(w, h)
   local G = love.graphics
   -- render.compose reads this after the scene is drawn; the plain overworld
@@ -1858,7 +1869,7 @@ function Game2:drawScene(w, h)
       self:paintBattleSurround(w, h)
       Chrome.worldSurround = false
       self:letterbox(w, h, false)
-      if wide ~= top then
+      if wide ~= top and hasVisibleOverlay(self.stack, wide) then
         local scale, ox, oy = panelBlit(self.stack, w, h)
         G.push()
         G.translate(ox, oy)

--- a/tests/modkit/cases/screen_render_visible.lua
+++ b/tests/modkit/cases/screen_render_visible.lua
@@ -130,6 +130,58 @@ do
     T.eq(world.draws, boot and 0 or 1,
       "Gold reveals its external world (boot=" .. tostring(boot) .. ")")
   end
+  -- A mirrored menu leaves the complete widescreen battle visible. Drawing
+  -- its ordinary panel again can cover a mod-provided scene with opaque paper.
+  local stack = setmetatable({}, { __index = StateStack })
+  stack:init()
+  local wide = {
+    isOpaque = true, draws = 0, wideDraws = 0,
+    drawsWidescreen = function() return true end,
+    drawWidescreen = function(self) self.wideDraws = self.wideDraws + 1 end,
+    draw = function(self) self.draws = self.draws + 1 end,
+  }
+  local hidden = {
+    screenId = "BagMenu", isOpaque = true, updates = 0,
+    update = function(self) self.updates = self.updates + 1 end,
+    draw = function() error("hidden menu drawn") end,
+  }
+  local overlay = { draws = 0,
+    draw = function(self) self.draws = self.draws + 1 end }
+  game = setmetatable({
+    stack = stack, world = { map = {} }, save = { options = {} },
+    inFillBoot = function() return false end,
+    letterbox = function() end, paintBattleSurround = function() end,
+  }, { __index = Game2 })
+  local function draw(states)
+    stack.states = states
+    wide.draws, wide.wideDraws, overlay.draws = 0, 0, 0
+    game:drawScene(1280, 720)
+    T.eq(wide.wideDraws, 1, "the widescreen base is composed once")
+  end
+  draw({ wide })
+  T.eq(wide.draws, 0, "an unobscured widescreen scene needs no panel pass")
+  draw({ wide, hidden })
+  T.eq(wide.draws, 0, "a hidden menu must not repaint the widescreen base")
+  T.eq(stack:top(), hidden, "rendering does not change native menu ownership")
+  stack:update(1 / 60)
+  T.eq(hidden.updates, 1, "the hidden menu still receives input updates")
+  local hiddenChild = { screenId = "BagMenu", isOpaque = true,
+    draw = function() error("hidden child drawn") end }
+  draw({ wide, hidden, hiddenChild })
+  T.eq(wide.draws, 0, "multiple hidden menus must not trigger a panel pass")
+  draw({ wide, overlay })
+  T.eq(wide.draws, 1, "a visible overlay retains the existing panel pass")
+  T.eq(overlay.draws, 1, "visible text is still drawn above the base")
+  draw({ wide, hidden, overlay })
+  T.eq(overlay.draws, 1, "visible text above a mirrored menu remains visible")
+  draw({ wide, overlay, hidden })
+  T.eq(overlay.draws, 1, "a hidden top must not suppress a visible lower overlay")
+  overlay.isOpaque = true
+  stack.states = { wide, overlay }
+  wide.draws, wide.wideDraws, overlay.draws = 0, 0, 0
+  game:drawScene(1280, 720)
+  T.eq(wide.wideDraws, 0, "an opaque visible menu still replaces the battle")
+  T.eq(overlay.draws, 1, "the opaque visible menu is drawn")
   run.release()
 end
 


### PR DESCRIPTION
In Crystal, using Kanto Gear together with Battle Art Voxel Gen2 can produce a large white rectangle over the 3D battle scene when opening the Bag or choosing a Pokémon. Move selection and the rest of the fight can look fine. This change keeps the battle scene visible while those menus are being used on Gear's display.

The mirrored menus remain on the game's state stack so they can still handle input, but their main-screen rendering is hidden through `screen.render_visible`. The Gen 2 renderer currently sees that a menu is on top and draws an additional panel pass, even when every screen above the already-composed battle is hidden. That pass redraws the ordinary battle background over the 3D scene.

Only run that additional pass when a visible screen actually exists above the widescreen base. Visible text and menus keep their existing drawing behavior, and hidden menus retain their input/update ownership. The fix uses the existing visibility hook and has no dependency on either mod.

Validation:

- Windows A/B test with official Recomp 0.2.59, Kanto Gear 3.2.9-test.4 and Battle Art Voxel Gen2 2.1.1. Both variants used the same prepared Crystal save, settings and mods; their game-code difference was this `Game2.lua` change. The tester confirmed the fix in B.
- The added regression cases fail on the original renderer when one or multiple hidden menus cause the base to be redrawn. All 33 screen-visibility checks pass with the fix, including visible overlays above/below hidden menus and native update ownership.
- On the current `dev` base: Gen 2 render-output tests (9/9), widescreen clipping tests (39/39), and render-viewport tests pass.
